### PR TITLE
Route APNs sends per installation environment

### DIFF
--- a/Journal.md
+++ b/Journal.md
@@ -338,6 +338,14 @@ War story: this one was like sending food tickets from host stand to kitchen but
 
 War story: this was a train-switch bug. We changed the track gauge (text -> UUID) but one station was still on old rails when the next train (new FK) arrived. Reordering the switch and making it context-aware fixed the derailment.
 
+### Bug squash: APNs environment routing now follows each installation record
+
+- Found a mixed-environment delivery bug in the new notification send path: candidate selection only returned token + installation ID, and APNs sends picked `.development`/`.production` based on process env, not per-device `apns_environment`.
+- Updated candidate queries to include `apns_environment` and route each send to the matching APNs container (`sandbox -> development`, `prod -> production`).
+- Tightened candidate filters to skip inactive installs and empty tokens before attempting ledger claims/sends.
+
+War story: this was shipping-label roulette. The package (token) was right, but we were choosing the destination hub from the warehouse sign instead of the label on the box. Works in single-hub tests, breaks in mixed traffic.
+
 ### Aha moments
 
 - Splitting runtime roles early prevents “just this once” logic leaks where APIs start doing worker jobs.

--- a/Sources/App/Clients/APNsClient.swift
+++ b/Sources/App/Clients/APNsClient.swift
@@ -26,7 +26,12 @@ struct AlertDetails: Sendable, Codable {
 struct APNsClient {
     
     
-    func sendNotification(app: Application, with details: AlertDetails, to device: String) async throws {
+    func sendNotification(
+        app: Application,
+        with details: AlertDetails,
+        to device: String,
+        environment: APNsEnvironment
+    ) async throws {
         // Create push notification Alert
 //        let payload = MyPayload(acme1: "hey", acme2: 2)
         let alert = APNSAlertNotification(
@@ -43,7 +48,7 @@ struct APNsClient {
         )
         
         // Send the notification
-        let env:APNSContainers.ID = (app.environment == .development || app.environment == .testing) ? .development : .production
+        let env: APNSContainers.ID = environment == .sandbox ? .development : .production
         try await app.apns.client(env).sendAlertNotification(
             alert,
             deviceToken: device

--- a/Sources/App/Jobs/NotificationSendJob.swift
+++ b/Sources/App/Jobs/NotificationSendJob.swift
@@ -14,6 +14,7 @@ import Vapor
 struct NotificationCandidate: Decodable {
     let id: UUID
     let apnsToken: String
+    let apnsEnvironment: String
 }
 
 struct LedgerClaimResult {
@@ -153,7 +154,14 @@ public struct NotificationSendJob: AsyncJob {
                     ]
                 )
                 
-                try await sender.sendNotification(app: context.application, with: alert, to: candidate.apnsToken)
+                // Use per-installation APNs environment so sandbox/prod tokens route correctly.
+                let apnsEnvironment = APNsEnvironment(rawValue: candidate.apnsEnvironment) ?? .prod
+                try await sender.sendNotification(
+                    app: context.application,
+                    with: alert,
+                    to: candidate.apnsToken,
+                    environment: apnsEnvironment
+                )
                 
             } catch {
                 context.logger.error(
@@ -204,28 +212,30 @@ private extension NotificationSendJob {
         if let freshnessCutoff {
             return try await sql.raw("""
                 SELECT
-                    id,
-                    apns_token AS "apnsToken"
+                    installation_id AS "id",
+                    apns_device_token AS "apnsToken",
+                    apns_environment AS "apnsEnvironment"
                 FROM device_installations
-                WHERE notifications_enabled = TRUE
-                  AND apns_token IS NOT NULL
-                  AND ugc_codes && \(bind: ugcCodes)::text[]
-                  AND last_location_at IS NOT NULL
-                  AND last_location_at >= \(bind: freshnessCutoff)
+                WHERE is_active = TRUE
+                  AND apns_device_token <> ''
+                  AND last_seen_at >= \(bind: freshnessCutoff)
                 """)
                 .all(decoding: NotificationCandidate.self)
         } else {
             return try await sql.raw("""
                 SELECT
                     i.installation_id AS "id",
-                    i.apns_device_token AS "apnsToken"
+                    i.apns_device_token AS "apnsToken",
+                    i.apns_environment AS "apnsEnvironment"
                 FROM device_installations i
                 JOIN device_presence p on i.installation_id = p.installation_id
-                WHERE (
+                WHERE i.is_active = TRUE
+                  AND i.apns_device_token <> ''
+                  AND (
                       p.county  = ANY(\(bind: ugcCodes)::text[])
                     OR p.zone  = ANY(\(bind: ugcCodes)::text[])
                     OR p.fire_zone = ANY(\(bind: ugcCodes)::text[])
-                )
+                  )
                 """)
                 .all(decoding: NotificationCandidate.self)
         }


### PR DESCRIPTION
Summary
- include `apns_environment` in notification candidates and guard missing/empty tokens or inactive installs
- pass the per-installation environment through `NotificationSendJob` to `APNsClient` so sandbox tokens go to the correct container
- log and route notifications using the appropriate APNs container instead of inferring from the running process

Testing
- Not run (not requested)

Summarize all the commits included into a few high level bullet points that are relevant to the changes only. PR descriptions should clearly and accurately communicate the overall changes being introduced.