### PR TITLE
Persist CAP alert parameters and capture notification debug snapshots

### DIFF
--- a/Sources/App/Infrastructure/Notifications/NotificationEngine.swift
+++ b/Sources/App/Infrastructure/Notifications/NotificationEngine.swift
@@ -72,12 +72,26 @@ struct NotificationEngine: Sendable {
         with payload: NotificationSendJobPayload,
         on device: NotificationCandidate
     ) -> AlertDetails {
+        buildAlertDetails(for: series, with: payload, on: device)
+    }
+
+    func buildPreviewNotification(
+        for series: ArcusSeriesModel,
+        with payload: NotificationSendJobPayload
+    ) -> AlertDetails {
+        buildAlertDetails(for: series, with: payload, on: nil)
+    }
+
+    private func buildAlertDetails(
+        for series: ArcusSeriesModel,
+        with payload: NotificationSendJobPayload,
+        on device: NotificationCandidate?
+    ) -> AlertDetails {
         let eventName = deriveEventName(for: series)
         let tone = deriveTone(for: series)
         let eventKind = NotificationEventKind(eventName: eventName)
         let severeTags = deriveSevereTags(for: series, of: eventKind)
 
-        
         let title = deriveTitle(for: eventName, reason: payload.reason)
         let subTitle = deriveSubtitle(with: payload, on: device)
         let body = deriveBody(
@@ -195,7 +209,7 @@ struct NotificationEngine: Sendable {
         case .new:
             return eventName
         case .update:
-            return "\(eventName) Update"
+            return "\(eventName) - Update"
         case .endedAllClear:
             return "\(eventName) Ended"
         case .cancelInError:
@@ -205,8 +219,10 @@ struct NotificationEngine: Sendable {
 
     private func deriveSubtitle(
         with payload: NotificationSendJobPayload,
-        on device: NotificationCandidate
+        on device: NotificationCandidate?
     ) -> String {
+        _ = device
+
         switch payload.reason {
         case .new:
             return payload.mode == .h3 ? "Includes your location" : "For your area"
@@ -299,7 +315,7 @@ struct NotificationEngine: Sendable {
         case .fireWeatherWatch:
             return "Fire weather risk continues for your area."
         case .extremeFireDanger:
-            return "Extreme fire danger continues in your area."
+            return "Extreme fire danger continues for your area."
         case .genericWarning:
             return "Weather alert updated for your area."
         case .genericWatch:

--- a/Sources/App/Infrastructure/Notifications/NotificationEngine.swift
+++ b/Sources/App/Infrastructure/Notifications/NotificationEngine.swift
@@ -75,12 +75,80 @@ struct NotificationEngine: Sendable {
         let eventName = deriveEventName(for: series)
         let tone = deriveTone(for: series)
         let eventKind = NotificationEventKind(eventName: eventName)
+        let severeTags = deriveSevereTags(for: series, of: eventKind)
 
-        return .init(
-            title: deriveTitle(for: eventName, reason: payload.reason),
-            subTitle: deriveSubtitle(with: payload, on: device),
-            body: deriveBody(for: eventKind, tone: tone, reason: payload.reason)
+        
+        let title = deriveTitle(for: eventName, reason: payload.reason)
+        let subTitle = deriveSubtitle(with: payload, on: device)
+        let body = deriveBody(
+            for: eventKind,
+            tone: tone,
+            reason: payload.reason,
+            severeTags: severeTags
         )
+        
+        return .init(
+            title: title,
+            subTitle: subTitle,
+            body: body
+        )
+    }
+    
+    private func deriveSevereTags(
+        for series: ArcusSeriesModel,
+        of kind: NotificationEventKind
+    ) -> [String] {
+        var tags: [String] = []
+
+        switch kind {
+        case .severeThunderstormWarning:
+            if normalizedCategory(series.tornadoDetection) == "possible" {
+                tags.append("Tornado possible")
+            }
+
+            if let damageThreat = severeThunderstormDamageThreatTag(series.thunderstormDamageThreat) {
+                tags.append(damageThreat)
+            }
+
+            if let windGust = windGustTag(series.maxWindGust) {
+                tags.append(windGust)
+            }
+
+            if let hailSize = hailSizeTag(series.maxHailSize) {
+                tags.append(hailSize)
+            }
+
+            if let hailThreat = hazardThreatTag(series.hailThreat, noun: "severe hail") {
+                tags.append(hailThreat)
+            }
+
+            if let windThreat = hazardThreatTag(series.windThreat, noun: "severe winds") {
+                tags.append(windThreat)
+            }
+
+        case .tornadoWarning:
+            if let detection = tornadoDetectionTag(series.tornadoDetection) {
+                tags.append(detection)
+            }
+
+            if let damageThreat = tornadoDamageThreatTag(series.tornadoDamageThreat) {
+                tags.append(damageThreat)
+            }
+
+        case .flashFloodWarning:
+            if let detection = floodDetectionTag(series.flashFloodDetection) {
+                tags.append(detection)
+            }
+
+            if let damageThreat = flashFloodDamageThreatTag(series.flashFloodDamageThreat) {
+                tags.append(damageThreat)
+            }
+
+        default:
+            break
+        }
+
+        return tags
     }
 
     private func deriveTone(for series: ArcusSeriesModel) -> NotificationTone {
@@ -139,148 +207,315 @@ struct NotificationEngine: Sendable {
         with payload: NotificationSendJobPayload,
         on device: NotificationCandidate
     ) -> String {
-        let location = locationTarget(for: payload.mode, on: device)
-
         switch payload.reason {
         case .new:
-            if payload.mode == .h3 {
-                return "At \(location)"
-            }
-
-            return "For \(location)"
+            return payload.mode == .h3 ? "Includes your location" : "For your area"
         case .update:
-            return "Updated for \(location)"
+            return "Updated for your area"
         case .endedAllClear:
-            return "No longer affecting \(location)"
+            return "No longer affecting your area"
         case .cancelInError:
-            return "Cancelled for \(location)"
+            return "Cancelled for your area"
         }
     }
 
     private func deriveBody(
         for eventKind: NotificationEventKind,
         tone: NotificationTone,
-        reason: NotificationReason
+        reason: NotificationReason,
+        severeTags: [String]
     ) -> String {
-        let action: String
-
         switch reason {
         case .new:
-            action = newAction(for: eventKind, tone: tone)
+            return newAction(for: eventKind, tone: tone, severeTags: severeTags)
         case .update:
-            action = updateAction(for: eventKind, tone: tone)
+            return updateAction(for: eventKind, tone: tone, severeTags: severeTags)
         case .endedAllClear:
-            action = "This alert is no longer active."
+            return endedAction(for: eventKind)
         case .cancelInError:
-            action = "This alert was cancelled by the issuer."
-        }
-
-        return "\(action) Tap for details."
-    }
-
-    private func locationTarget(
-        for mode: NotificationTargetMode,
-        on device: NotificationCandidate
-    ) -> String {
-        switch mode {
-        case .h3:
-            return "your location"
-        case .ugc:
-            if let countyLabel = trimmedNonEmpty(device.countyLabel) {
-                return countyLabel
-            }
-            if let fireZoneLabel = trimmedNonEmpty(device.fireZoneLabel) {
-                return fireZoneLabel
-            }
-            return "your area"
+            return cancelledAction(for: eventKind)
         }
     }
+
+    // locationTarget(for:on:) function removed
 
     private func newAction(
         for eventKind: NotificationEventKind,
-        tone: NotificationTone
+        tone: NotificationTone,
+        severeTags: [String]
     ) -> String {
         switch eventKind {
         case .tornadoWarning:
-            return "Take shelter now."
+            return tornadoWarningBody(reason: .new, severeTags: severeTags)
         case .tornadoWatch:
-            return "Conditions are favorable for tornadoes. Stay ready to act."
+            return "Conditions are favorable for tornadoes in your area."
         case .severeThunderstormWarning:
-            return "Move indoors and protect yourself from dangerous weather."
+            return severeThunderstormWarningBody(reason: .new, severeTags: severeTags)
         case .severeThunderstormWatch:
-            return "Conditions are favorable for severe storms. Stay ready to act."
+            return "Conditions are favorable for severe storms in your area."
         case .flashFloodWarning:
-            return "Move to higher ground and avoid flooded roads."
+            return flashFloodWarningBody(reason: .new, severeTags: severeTags)
         case .blizzardWarning:
-            return "Travel may become dangerous very quickly."
+            return "Blizzard conditions expected in your area."
         case .winterStormWarning:
-            return "Travel conditions may deteriorate quickly."
-        case .fireWarning:
-            return "Be ready to act quickly if fire conditions worsen."
+            return "Dangerous winter weather expected in your area."
+        case .fireWarning, .redFlagWarning:
+            return "Critical fire weather conditions in your area."
         case .fireWeatherWatch:
-            return "Fire conditions may develop. Avoid anything that can start a fire."
-        case .extremeFireDanger, .redFlagWarning:
-            return "Fire danger is high. Avoid anything that can start a fire."
+            return "Critical fire weather conditions may develop in your area."
+        case .extremeFireDanger:
+            return "Extreme fire danger in your area today."
         case .genericWarning:
-            return warningAction(for: tone)
+            return genericWarningBody(for: tone)
         case .genericWatch:
-            return "Conditions are favorable. Stay ready."
+            return "Weather conditions may become hazardous in your area."
         case .generic:
-            return genericAction(for: tone)
+            return genericInformationalBody(for: tone)
         }
     }
 
     private func updateAction(
         for eventKind: NotificationEventKind,
-        tone: NotificationTone
+        tone: NotificationTone,
+        severeTags: [String]
     ) -> String {
         switch eventKind {
         case .tornadoWarning:
-            return "Take shelter now if threatened."
-        case .tornadoWatch, .severeThunderstormWatch:
-            return "Stay ready to act quickly."
+            return tornadoWarningBody(reason: .update, severeTags: severeTags)
+        case .tornadoWatch:
+            return "Tornado risk continues for your area."
         case .severeThunderstormWarning:
-            return "Stay indoors and protect yourself from dangerous weather."
+            return severeThunderstormWarningBody(reason: .update, severeTags: severeTags)
+        case .severeThunderstormWatch:
+            return "Severe storm risk continues for your area."
         case .flashFloodWarning:
-            return "Avoid flooded roads and low-lying areas."
-        case .blizzardWarning, .winterStormWarning:
-            return "Travel conditions may still worsen."
-        case .fireWarning, .fireWeatherWatch, .extremeFireDanger, .redFlagWarning:
-            return "Fire danger may still increase quickly."
+            return flashFloodWarningBody(reason: .update, severeTags: severeTags)
+        case .blizzardWarning:
+            return "Blizzard conditions continue in your area."
+        case .winterStormWarning:
+            return "Dangerous winter weather continues in your area."
+        case .fireWarning, .redFlagWarning:
+            return "Critical fire weather conditions continue in your area."
+        case .fireWeatherWatch:
+            return "Fire weather risk continues for your area."
+        case .extremeFireDanger:
+            return "Extreme fire danger continues in your area."
         case .genericWarning:
-            return warningAction(for: tone)
+            return "Weather alert updated for your area."
         case .genericWatch:
-            return "Stay ready for changing conditions."
+            return "Weather risk continues for your area."
         case .generic:
-            return genericAction(for: tone)
+            return genericUpdateBody(for: tone)
         }
     }
 
-    private func warningAction(for tone: NotificationTone) -> String {
-        switch tone {
-        case .critical:
-            return "Take action now."
-        case .high:
-            return "Be ready to act quickly."
-        case .elevated:
-            return "Use caution and stay alert."
-        case .informational:
-            return "Stay aware of changing conditions."
+    private func endedAction(for eventKind: NotificationEventKind) -> String {
+        switch eventKind {
+        case .tornadoWarning:
+            return "This tornado warning is no longer active."
+        case .tornadoWatch:
+            return "This tornado watch has ended."
+        case .severeThunderstormWarning:
+            return "This severe thunderstorm warning is no longer active."
+        case .severeThunderstormWatch:
+            return "This severe thunderstorm watch has ended."
+        case .flashFloodWarning:
+            return "This flash flood warning is no longer active."
+        case .blizzardWarning:
+            return "This blizzard warning is no longer active."
+        case .winterStormWarning:
+            return "This winter storm warning is no longer active."
+        case .fireWarning, .redFlagWarning:
+            return "This red flag warning is no longer active."
+        case .fireWeatherWatch:
+            return "This fire weather watch has ended."
+        case .extremeFireDanger:
+            return "Extreme fire danger is no longer indicated for your area."
+        case .genericWarning, .generic:
+            return "This weather alert is no longer active."
+        case .genericWatch:
+            return "This weather watch has ended."
         }
     }
 
-    private func genericAction(for tone: NotificationTone) -> String {
-        switch tone {
-        case .critical:
-            return "Take action now."
-        case .high:
-            return "Stay alert and be ready to act quickly."
-        case .elevated:
-            return "Stay alert."
-        case .informational:
-            return "Monitor conditions."
+    private func cancelledAction(for eventKind: NotificationEventKind) -> String {
+        switch eventKind {
+        case .tornadoWarning:
+            return "This tornado warning was cancelled by the issuer."
+        case .tornadoWatch:
+            return "This tornado watch was cancelled by the issuer."
+        case .severeThunderstormWarning:
+            return "This severe thunderstorm warning was cancelled by the issuer."
+        case .severeThunderstormWatch:
+            return "This severe thunderstorm watch was cancelled by the issuer."
+        case .flashFloodWarning:
+            return "This flash flood warning was cancelled by the issuer."
+        case .blizzardWarning:
+            return "This blizzard warning was cancelled by the issuer."
+        case .winterStormWarning:
+            return "This winter storm warning was cancelled by the issuer."
+        case .fireWarning, .redFlagWarning:
+            return "This red flag warning was cancelled by the issuer."
+        case .fireWeatherWatch:
+            return "This fire weather watch was cancelled by the issuer."
+        case .extremeFireDanger, .genericWarning, .genericWatch, .generic:
+            return "This weather alert was cancelled by the issuer."
         }
     }
+
+    private func tornadoWarningBody(reason: NotificationReason, severeTags: [String]) -> String {
+        if severeTags.contains("Catastrophic tornado damage possible") {
+            return reason == .update
+                ? "Catastrophic tornado damage remains possible in your area."
+                : "Catastrophic tornado damage possible in your area."
+        }
+
+        if severeTags.contains("Considerable tornado damage possible") {
+            return reason == .update
+                ? "Considerable tornado damage remains possible in your area."
+                : "Considerable tornado damage possible in your area."
+        }
+
+        if severeTags.contains("Observed tornado") {
+            return reason == .update
+                ? "Observed tornado still indicated in your area."
+                : "Observed tornado in your area."
+        }
+
+        if severeTags.contains("Radar-indicated tornado") {
+            return reason == .update
+                ? "Radar-indicated tornado still indicated in your area."
+                : "Radar-indicated tornado in your area."
+        }
+
+        return reason == .update
+            ? "Tornado warning continues for your area."
+            : "Tornado danger in your area."
+    }
+
+    private func severeThunderstormWarningBody(reason: NotificationReason, severeTags: [String]) -> String {
+        if severeTags.contains("Tornado possible") {
+            return reason == .update
+                ? "Tornado possible remains in this warning."
+                : "Tornado possible in this warning."
+        }
+
+        if severeTags.contains("Destructive winds possible") {
+            return reason == .update
+                ? "Destructive winds remain possible in your area."
+                : "Destructive winds possible in your area."
+        }
+
+        if severeTags.contains("Considerable damage possible") {
+            return reason == .update
+                ? "Considerable damage remains possible in your area."
+                : "Considerable damage possible in your area."
+        }
+
+        if let magnitude = severeThunderstormMagnitudeDetail(from: severeTags) {
+            let prefix = reason == .update ? "remain possible" : "possible"
+            return "\(magnitude) \(prefix) in your area."
+        }
+
+        return reason == .update
+            ? "Severe thunderstorm warning continues for your area."
+            : "Damaging winds or large hail possible in your area."
+    }
+
+    private func flashFloodWarningBody(reason: NotificationReason, severeTags: [String]) -> String {
+        if severeTags.contains("Catastrophic flash flooding possible") {
+            return reason == .update
+                ? "Catastrophic flash flooding remains possible in your area."
+                : "Catastrophic flash flooding possible in your area."
+        }
+
+        if severeTags.contains("Considerable flash flooding possible") {
+            return reason == .update
+                ? "Considerable flash flooding remains possible in your area."
+                : "Considerable flash flooding possible in your area."
+        }
+
+        if severeTags.contains("Observed flooding") {
+            return reason == .update
+                ? "Observed flooding continues in your area."
+                : "Observed flooding in your area."
+        }
+
+        if severeTags.contains("Radar-indicated flooding") {
+            return reason == .update
+                ? "Radar-indicated flooding continues in your area."
+                : "Radar-indicated flooding in your area."
+        }
+
+        return reason == .update
+            ? "Flash flood warning continues for your area."
+            : "Flash flooding expected in your area."
+    }
+
+    private func severeThunderstormMagnitudeDetail(from severeTags: [String]) -> String? {
+        let preferred = severeTags.filter {
+            $0.hasPrefix("Wind gusts up to") || $0.hasPrefix("Hail up to")
+        }
+
+        guard preferred.isEmpty == false else {
+            return nil
+        }
+
+        if preferred.count == 1 {
+            return preferred[0]
+        }
+
+        let wind = preferred.first { $0.hasPrefix("Wind gusts up to") }
+        let hail = preferred.first { $0.hasPrefix("Hail up to") }
+
+        switch (wind, hail) {
+        case let (wind?, hail?):
+            let windValue = wind.replacingOccurrences(of: "Wind gusts up to ", with: "")
+            let hailValue = hail.replacingOccurrences(of: "Hail up to ", with: "")
+            return "Wind gusts up to \(windValue) and hail up to \(hailValue)"
+        case let (wind?, nil):
+            return wind
+        case let (nil, hail?):
+            return hail
+        default:
+            return preferred[0]
+        }
+    }
+
+    private func genericWarningBody(for tone: NotificationTone) -> String {
+        switch tone {
+        case .critical:
+            return "Dangerous weather alert for your area."
+        case .high:
+            return "Significant weather alert for your area."
+        case .elevated:
+            return "Weather alert for your area."
+        case .informational:
+            return "Weather information for your area."
+        }
+    }
+
+    private func genericInformationalBody(for tone: NotificationTone) -> String {
+        switch tone {
+        case .critical:
+            return "Dangerous weather conditions indicated for your area."
+        case .high:
+            return "Significant weather conditions indicated for your area."
+        case .elevated:
+            return "Weather conditions indicated for your area."
+        case .informational:
+            return "Weather information for your area."
+        }
+    }
+
+    private func genericUpdateBody(for tone: NotificationTone) -> String {
+        switch tone {
+        case .critical, .high, .elevated, .informational:
+            return "Weather information updated for your area."
+        }
+    }
+
+    // message, conciseSecondaryDetail, warningAction, genericAction functions removed
 
     private func trimmedNonEmpty(_ value: String?) -> String? {
         guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -289,5 +524,115 @@ struct NotificationEngine: Sendable {
         }
 
         return trimmed
+    }
+
+    private func normalizedCategory(_ value: String?) -> String? {
+        guard let trimmed = trimmedNonEmpty(value) else {
+            return nil
+        }
+
+        let normalized = trimmed.normalizedLowercased
+        guard normalized.isEmpty == false,
+              normalized != "none",
+              normalized != "unknown",
+              normalized != "n/a" else {
+            return nil
+        }
+
+        return normalized
+    }
+
+    private func severeThunderstormDamageThreatTag(_ value: String?) -> String? {
+        switch normalizedCategory(value) {
+        case "considerable":
+            return "Considerable damage possible"
+        case "destructive":
+            return "Destructive winds possible"
+        default:
+            return nil
+        }
+    }
+
+    private func tornadoDamageThreatTag(_ value: String?) -> String? {
+        switch normalizedCategory(value) {
+        case "considerable":
+            return "Considerable tornado damage possible"
+        case "catastrophic":
+            return "Catastrophic tornado damage possible"
+        default:
+            return nil
+        }
+    }
+
+    private func flashFloodDamageThreatTag(_ value: String?) -> String? {
+        switch normalizedCategory(value) {
+        case "considerable":
+            return "Considerable flash flooding possible"
+        case "catastrophic":
+            return "Catastrophic flash flooding possible"
+        default:
+            return nil
+        }
+    }
+
+    private func tornadoDetectionTag(_ value: String?) -> String? {
+        switch normalizedCategory(value) {
+        case "observed":
+            return "Observed tornado"
+        case "radar indicated":
+            return "Radar-indicated tornado"
+        case "possible":
+            return "Tornado possible"
+        default:
+            return nil
+        }
+    }
+
+    private func floodDetectionTag(_ value: String?) -> String? {
+        switch normalizedCategory(value) {
+        case "observed":
+            return "Observed flooding"
+        case "radar indicated":
+            return "Radar-indicated flooding"
+        default:
+            return nil
+        }
+    }
+
+    private func hazardThreatTag(_ value: String?, noun: String) -> String? {
+        switch normalizedCategory(value) {
+        case "observed":
+            return "Observed \(noun)"
+        case "radar indicated":
+            return "Radar-indicated \(noun)"
+        default:
+            return nil
+        }
+    }
+
+    private func windGustTag(_ value: String?) -> String? {
+        guard let trimmed = trimmedNonEmpty(value) else {
+            return nil
+        }
+
+        let normalized = trimmed.normalizedLowercased
+        if normalized.contains("mph") {
+            return "Wind gusts up to \(trimmed)"
+        }
+
+        return "Wind gusts up to \(trimmed) mph"
+    }
+
+    private func hailSizeTag(_ value: String?) -> String? {
+        guard let trimmed = trimmedNonEmpty(value) else {
+            return nil
+        }
+
+        let normalized = trimmed.normalizedLowercased
+        if normalized.contains("inch") || normalized.contains("in.") || normalized.contains("\"") {
+            return "Hail up to \(trimmed)"
+        }
+
+        return "Hail up to \(trimmed) in"
     }
 }

--- a/Sources/App/Jobs/IngestNWSAlertsJob.swift
+++ b/Sources/App/Jobs/IngestNWSAlertsJob.swift
@@ -430,6 +430,15 @@ private extension IngestNWSAlertsJob {
         series.instructions = event.instructions
         series.response = event.response
         series.status  = event.status
+        series.tornadoDetection = event.tornadoDetection
+        series.tornadoDamageThreat = event.tornadoDamageThreat
+        series.maxWindGust = event.maxWindGust
+        series.maxHailSize = event.maxHailSize
+        series.windThreat = event.windThreat
+        series.hailThreat = event.hailThreat
+        series.thunderstormDamageThreat = event.thunderstormDamageThreat
+        series.flashFloodDetection = event.flashFloodDetection
+        series.flashFloodDamageThreat = event.flashFloodDamageThreat
         
         series.contentFingerprint = try event.computeContentFingerprint()
     }

--- a/Sources/App/Jobs/NotificationSendJob.swift
+++ b/Sources/App/Jobs/NotificationSendJob.swift
@@ -314,6 +314,19 @@ private extension NotificationSendJob {
         using context: QueueContext
     ) async throws {
         guard candidates.count > 0 else {
+            let preview = engine.buildPreviewNotification(for: series, with: payload)
+            await saveNotificationDebugSnapshot(
+                seriesID: payload.seriesId,
+                installationID: nil,
+                notificationLedgerID: nil,
+                revisionUrn: payload.revisionUrn,
+                mode: payload.mode,
+                reason: payload.reason,
+                recordKind: .previewNoCandidates,
+                alert: preview,
+                using: context
+            )
+
             context.logger.info(
                 "No matching candidates. No notification sent",
                 metadata: [
@@ -340,8 +353,19 @@ private extension NotificationSendJob {
                 continue
             }
             
-            // Build your notification payload here.
             let alert = engine.buildNotification(for: series, with: payload, on: candidate)
+            await saveNotificationDebugSnapshot(
+                seriesID: payload.seriesId,
+                installationID: candidate.id,
+                notificationLedgerID: claim.id,
+                revisionUrn: payload.revisionUrn,
+                mode: payload.mode,
+                reason: payload.reason,
+                recordKind: .candidate,
+                alert: alert,
+                using: context
+            )
+
             do {
                 // Use per-installation APNs environment so sandbox/prod tokens route correctly.
                 let apnsEnvironment = APNsEnvironment(rawValue: candidate.apnsEnvironment) ?? .prod
@@ -439,6 +463,59 @@ private extension NotificationSendJob {
                 existingClaim.status = "failed"
                 try await existingClaim.save(on: context.application.db)
             }
+        }
+    }
+
+    func saveNotificationDebugSnapshot(
+        seriesID: UUID,
+        installationID: UUID?,
+        notificationLedgerID: UUID?,
+        revisionUrn: String,
+        mode: NotificationTargetMode,
+        reason: NotificationReason,
+        recordKind: NotificationDebugRecordKind,
+        alert: AlertDetails,
+        using context: QueueContext
+    ) async {
+        let snapshot = NotificationDebugModel(
+            seriesID: seriesID,
+            installationID: installationID,
+            notificationLedgerID: notificationLedgerID,
+            revisionUrn: revisionUrn,
+            mode: mode.rawValue,
+            reason: reason.rawValue,
+            recordKind: recordKind,
+            title: alert.title,
+            subtitle: alert.subTitle,
+            body: alert.body
+        )
+
+        do {
+            try await snapshot.create(on: context.application.db)
+        } catch {
+            if DbUtils.isUniqueConstraintViolation(error) {
+                context.logger.debug(
+                    "Notification debug snapshot already recorded.",
+                    metadata: [
+                        "seriesId": .string(seriesID.uuidString),
+                        "revisionUrn": .string(revisionUrn),
+                        "mode": .string(mode.rawValue),
+                        "recordKind": .string(recordKind.rawValue)
+                    ]
+                )
+                return
+            }
+
+            context.logger.error(
+                "Failed to save notification debug snapshot.",
+                metadata: [
+                    "seriesId": .string(seriesID.uuidString),
+                    "revisionUrn": .string(revisionUrn),
+                    "mode": .string(mode.rawValue),
+                    "recordKind": .string(recordKind.rawValue),
+                    "error": .string(String(reflecting: error))
+                ]
+            )
         }
     }
 }

--- a/Sources/App/Migrations/CreateAlertSeries.swift
+++ b/Sources/App/Migrations/CreateAlertSeries.swift
@@ -116,3 +116,33 @@ public struct CreateAlertSeriesModel: AsyncMigration {
         try await database.schema(ArcusSeriesModel.schema).delete()
     }
 }
+
+public struct AddCAPParamFields: AsyncMigration {
+    public func prepare(on db: any Database) async throws {
+        try await db.schema(ArcusSeriesModel.schema)
+            .field("tornado_detection", .string)
+            .field("tornado_damage_threat", .string)
+            .field("max_wind_gust", .string)
+            .field("max_hail_size", .string)
+            .field("wind_threat", .string)
+            .field("hail_threat", .string)
+            .field("thunderstorm_damage_threat", .string)
+            .field("flash_flood_detection", .string)
+            .field("flash_flood_damage_threat", .string)
+            .update()
+    }
+
+    public func revert(on db: any Database) async throws {
+        try await db.schema(ArcusSeriesModel.schema)
+            .deleteField("tornado_detection")
+            .deleteField("tornado_damage_threat")
+            .deleteField("max_wind_gust")
+            .deleteField("max_hail_size")
+            .deleteField("wind_threat")
+            .deleteField("hail_threat")
+            .deleteField("thunderstorm_damage_threat")
+            .deleteField("flash_flood_detection")
+            .deleteField("flash_flood_damage_threat")
+            .update()
+    }
+}

--- a/Sources/App/Migrations/CreateNotificationDebug.swift
+++ b/Sources/App/Migrations/CreateNotificationDebug.swift
@@ -1,0 +1,54 @@
+//
+//  CreateNotificationDebug.swift
+//  ArcusSignal
+//
+//  Created by Codex on 4/9/26.
+//
+
+import Fluent
+import SQLKit
+
+struct CreateNotificationDebug: AsyncMigration {
+    func prepare(on db: any Database) async throws {
+        try await db.schema(NotificationDebugModel.schema)
+            .field("id", .uuid, .identifier(auto: false))
+            .field("series_id", .uuid, .required,
+                   .references(ArcusSeriesModel.schema, "id", onDelete: .cascade))
+            .field("installation_id", .uuid,
+                   .references(DeviceInstallationModel.schema, "installation_id", onDelete: .setNull))
+            .field("notification_ledger_id", .uuid,
+                   .references(NotificationLedgerModel.schema, "id", onDelete: .setNull))
+            .field("revision_urn", .string, .required)
+            .field("mode", .string, .required)
+            .field("reason", .string, .required)
+            .field("record_kind", .string, .required)
+            .field("title", .string, .required)
+            .field("subtitle", .string, .required)
+            .field("body", .string, .required)
+            .field("created", .datetime)
+            .unique(on: "notification_ledger_id")
+            .create()
+
+        guard let sql = db as? any SQLDatabase else { return }
+
+        try await sql.raw("""
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_debug_preview_unique
+            ON notification_debug (series_id, revision_urn, mode, record_kind)
+            WHERE record_kind = 'preview_no_candidates';
+        """).run()
+
+        try await sql.raw("""
+            CREATE INDEX IF NOT EXISTS idx_notification_debug_series_created
+            ON notification_debug (series_id, created DESC);
+        """).run()
+    }
+
+    func revert(on db: any Database) async throws {
+        if let sql = db as? any SQLDatabase {
+            try await sql.raw("DROP INDEX IF EXISTS idx_notification_debug_preview_unique;").run()
+            try await sql.raw("DROP INDEX IF EXISTS idx_notification_debug_series_created;").run()
+        }
+
+        try await db.schema(NotificationDebugModel.schema).delete()
+    }
+}

--- a/Sources/App/Models/API/AlertSeriesRow.swift
+++ b/Sources/App/Models/API/AlertSeriesRow.swift
@@ -36,6 +36,15 @@ struct AlertSeriesRow: Decodable, Sendable {
     let response: String?
     let ugcCodes: [String]
     let h3Cells: [Int64]
+    let tornadoDetection: String?
+    let tornadoDamageThreat: String?
+    let maxWindGust: String?
+    let maxHailSize: String?
+    let windThreat: String?
+    let hailThreat: String?
+    let thunderstormDamageThreat: String?
+    let flashFloodDetection: String?
+    let flashFloodDamageThreat: String?
 
     func asDeviceAlertPayload() -> DeviceAlertPayload {
         .init(
@@ -63,7 +72,16 @@ struct AlertSeriesRow: Decodable, Sendable {
             instructions: instructions,
             response: response,
             ugc: ugcCodes,
-            h3Cells: h3Cells
+            h3Cells: h3Cells,
+            tornadoDetection: tornadoDetection,
+            tornadoDamageThreat: tornadoDamageThreat,
+            maxWindGust: maxWindGust,
+            maxHailSize: maxHailSize,
+            windThreat: windThreat,
+            hailThreat: hailThreat,
+            thunderstormDamageThreat: thunderstormDamageThreat,
+            flashFloodDetection: flashFloodDetection,
+            flashFloodDamageThreat: flashFloodDamageThreat
         )
     }
 }
@@ -99,6 +117,15 @@ extension AlertSeriesRow {
             "\(ident: seriesAlias).\(ident: "instructions") AS \(ident: "instructions")",
             "\(ident: seriesAlias).\(ident: "response") AS \(ident: "response")",
             "\(ident: seriesAlias).\(ident: "ugc_codes") AS \(ident: "ugcCodes")",
+            "\(ident: seriesAlias).\(ident: "tornado_detection") AS \(ident: "tornadoDetection")",
+            "\(ident: seriesAlias).\(ident: "tornado_damage_threat") AS \(ident: "tornadoDamageThreat")",
+            "\(ident: seriesAlias).\(ident: "max_wind_gust") AS \(ident: "maxWindGust")",
+            "\(ident: seriesAlias).\(ident: "max_hail_size") AS \(ident: "maxHailSize")",
+            "\(ident: seriesAlias).\(ident: "wind_threat") AS \(ident: "windThreat")",
+            "\(ident: seriesAlias).\(ident: "hail_threat") AS \(ident: "hailThreat")",
+            "\(ident: seriesAlias).\(ident: "thunderstorm_damage_threat") AS \(ident: "thunderstormDamageThreat")",
+            "\(ident: seriesAlias).\(ident: "flash_flood_detection") AS \(ident: "flashFloodDetection")",
+            "\(ident: seriesAlias).\(ident: "flash_flood_damage_threat") AS \(ident: "flashFloodDamageThreat")",
             "COALESCE(\(ident: geolocationAlias).\(ident: "h3_cells"), '{}'::bigint[]) AS \(ident: "h3Cells")"
         ]
         .joined(separator: ",\n")

--- a/Sources/App/Models/Device/DeviceAlertPayload.swift
+++ b/Sources/App/Models/Device/DeviceAlertPayload.swift
@@ -49,5 +49,16 @@ public struct DeviceAlertPayload: Sendable, Codable, Content {
     
     let ugc: [String]
     var h3Cells: [Int64]
+    
+    // CAP Params
+    let tornadoDetection: String?
+    let tornadoDamageThreat: String?
+    let maxWindGust: String?
+    let maxHailSize: String?
+    let windThreat: String?
+    let hailThreat: String?
+    let thunderstormDamageThreat: String?
+    let flashFloodDetection: String?
+    let flashFloodDamageThreat: String?
 }
 

--- a/Sources/App/Models/NWS/ArcusEvent.swift
+++ b/Sources/App/Models/NWS/ArcusEvent.swift
@@ -208,7 +208,7 @@ public extension NwsEventFeatureDTO {
         let messageID = Self.normalizeMessageID(properties.id) ?? Self.normalizeMessageID(id) ?? properties.id
         let endsAt = properties.ends
         let messageType = NWSAlertMessageType.fromNws(properties.messageType)
-        let vtec = properties.parameters?["VTEC"]?.first ?? ""
+        let vtec = properties.parameters?.vtec?.first ?? ""
         let vtecP = vtec.parseVTEC()
         let refs = properties.references?.compactMap{ $0.identifier }
         let geometry = geometry?.toGeoShape()

--- a/Sources/App/Models/NWS/ArcusEvent.swift
+++ b/Sources/App/Models/NWS/ArcusEvent.swift
@@ -115,6 +115,17 @@ public struct ArcusEvent: Codable, Sendable, Equatable {
 
     // Raw payload reference
     public let rawRef: String?
+    
+    // CAP Params
+    public let tornadoDetection: String?
+    public let tornadoDamageThreat: String?
+    public let maxWindGust: String?
+    public let maxHailSize: String?
+    public let windThreat: String?
+    public let hailThreat: String?
+    public let thunderstormDamageThreat: String?
+    public let flashFloodDetection: String?
+    public let flashFloodDamageThreat: String?
 
     public init(
         urn: String,
@@ -146,7 +157,16 @@ public struct ArcusEvent: Codable, Sendable, Equatable {
         description: String?,
         instructions: String?,
         response: String?,
-        status: String?
+        status: String?,
+        tornadoDetection: String?,
+        tornadoDamageThreat: String?,
+        maxWindGust: String?,
+        maxHailSize: String?,
+        windThreat: String?,
+        hailThreat: String?,
+        thunderstormDamageThreat: String?,
+        flashFloodDetection: String?,
+        flashFloodDamageThreat: String?
     ) {
         self.id = urn
         self.source = source
@@ -178,6 +198,15 @@ public struct ArcusEvent: Codable, Sendable, Equatable {
         self.instructions = instructions
         self.response = response
         self.status = status
+        self.tornadoDetection = tornadoDetection
+        self.tornadoDamageThreat = tornadoDamageThreat
+        self.maxWindGust = maxWindGust
+        self.maxHailSize = maxHailSize
+        self.windThreat = windThreat
+        self.hailThreat = hailThreat
+        self.thunderstormDamageThreat = thunderstormDamageThreat
+        self.flashFloodDetection = flashFloodDetection
+        self.flashFloodDamageThreat = flashFloodDamageThreat
     }
 }
 
@@ -213,6 +242,16 @@ public extension NwsEventFeatureDTO {
         let refs = properties.references?.compactMap{ $0.identifier }
         let geometry = geometry?.toGeoShape()
         
+        let tornadoDetectionValue = properties.parameters?.tornadoDetection?.first ?? ""
+        let tornadoDamageThreatValue = properties.parameters?.tornadoDamageThreat?.first ?? ""
+        let maxWindGustValue = properties.parameters?.maxWindGust?.first ?? ""
+        let maxHailSizeValue = properties.parameters?.maxHailSize?.first ?? ""
+        let windThreatValue = properties.parameters?.windThreat?.first ?? ""
+        let hailThreatValue = properties.parameters?.hailThreat?.first ?? ""
+        let thunderstormDamageThreatValue = properties.parameters?.thunderstormDamageThreat?.first ?? ""
+        let flashFloodDetectionValue = properties.parameters?.flashFloodDetection?.first ?? ""
+        let flashFloodDamageThreatValue = properties.parameters?.flashFloodDamageThreat?.first ?? ""
+        
 
         return .init(
             urn: messageID,
@@ -244,7 +283,16 @@ public extension NwsEventFeatureDTO {
             description: properties.description,
             instructions: properties.instruction,
             response: properties.response,
-            status: properties.status
+            status: properties.status,
+            tornadoDetection: tornadoDetectionValue,
+            tornadoDamageThreat: tornadoDamageThreatValue,
+            maxWindGust: maxWindGustValue,
+            maxHailSize: maxHailSizeValue,
+            windThreat: windThreatValue,
+            hailThreat: hailThreatValue,
+            thunderstormDamageThreat: thunderstormDamageThreatValue,
+            flashFloodDetection: flashFloodDetectionValue,
+            flashFloodDamageThreat: flashFloodDamageThreatValue
         )
     }
 
@@ -291,6 +339,15 @@ extension ArcusEvent {
             let instructions: String?
             let response: String?
             let status: String?
+            let tornadoDetection: String?
+            let tornadoDamageThreat: String?
+            let maxWindGust: String?
+            let maxHailSize: String?
+            let windThreat: String?
+            let hailThreat: String?
+            let thunderstormDamageThreat: String?
+            let flashFloodDetection: String?
+            let flashFloodDamageThreat: String?
         }
 
         let fingerprint = ArcusEventContentFingerprint(
@@ -314,7 +371,16 @@ extension ArcusEvent {
             description: self.description,
             instructions: self.instructions,
             response: self.response,
-            status: self.status
+            status: self.status,
+            tornadoDetection: self.tornadoDetection,
+            tornadoDamageThreat: self.tornadoDamageThreat,
+            maxWindGust: self.maxWindGust,
+            maxHailSize: self.maxHailSize,
+            windThreat: self.windThreat,
+            hailThreat: self.hailThreat,
+            thunderstormDamageThreat: self.thunderstormDamageThreat,
+            flashFloodDetection: self.flashFloodDetection,
+            flashFloodDamageThreat: self.flashFloodDamageThreat
         )
 
         return try StableContentHasher.sha256Hex(of: fingerprint)

--- a/Sources/App/Models/NWS/ArcusSeriesModel.swift
+++ b/Sources/App/Models/NWS/ArcusSeriesModel.swift
@@ -129,6 +129,33 @@ public final class ArcusSeriesModel: Model, @unchecked Sendable {
     @OptionalField(key:"status")
     public var status: String?
     
+    @OptionalField(key:"tornado_detection")
+    public var tornadoDetection: String?
+    
+    @OptionalField(key:"tornado_damage_threat")
+    public var tornadoDamageThreat: String?
+    
+    @OptionalField(key:"max_wind_gust")
+    public var maxWindGust: String?
+    
+    @OptionalField(key:"max_hail_size")
+    public var maxHailSize: String?
+    
+    @OptionalField(key:"wind_threat")
+    public var windThreat: String?
+    
+    @OptionalField(key:"hail_threat")
+    public var hailThreat: String?
+    
+    @OptionalField(key:"thunderstorm_damage_threat")
+    public var thunderstormDamageThreat: String?
+    
+    @OptionalField(key:"flash_flood_detection")
+    public var flashFloodDetection: String?
+    
+    @OptionalField(key:"flash_flood_damage_threat")
+    public var flashFloodDamageThreat: String?
+    
     @OptionalChild(for: \.$series)
     var geolocation: ArcusGeolocationModel?
     
@@ -170,7 +197,16 @@ public final class ArcusSeriesModel: Model, @unchecked Sendable {
         description: String? = nil,
         instructions: String? = nil,
         response: String? = nil,
-        status: String? = nil
+        status: String? = nil,
+        tornadoDetection: String? = nil,
+        tornadoDamageThreat: String? = nil,
+        maxWindGust: String? = nil,
+        maxHailSize: String? = nil,
+        windThreat: String? = nil,
+        hailThreat: String? = nil,
+        thunderstormDamageThreat: String? = nil,
+        flashFloodDetection: String? = nil,
+        flashFloodDamageThreat: String? = nil
     ) {
         self.id = id
         self.source = source
@@ -203,6 +239,15 @@ public final class ArcusSeriesModel: Model, @unchecked Sendable {
         self.instructions = instructions
         self.response = response
         self.status = status
+        self.tornadoDetection = tornadoDetection
+        self.tornadoDamageThreat = tornadoDamageThreat
+        self.maxWindGust = maxWindGust
+        self.maxHailSize = maxHailSize
+        self.windThreat = windThreat
+        self.hailThreat = hailThreat
+        self.thunderstormDamageThreat = thunderstormDamageThreat
+        self.flashFloodDetection = flashFloodDetection
+        self.flashFloodDamageThreat = flashFloodDamageThreat
     }
 }
 
@@ -250,7 +295,16 @@ public extension ArcusSeriesModel {
             description: event.description,
             instructions: event.instructions,
             response: event.response,
-            status: event.status
+            status: event.status,
+            tornadoDetection: event.tornadoDetection,
+            tornadoDamageThreat: event.tornadoDamageThreat,
+            maxWindGust: event.maxWindGust,
+            maxHailSize: event.maxHailSize,
+            windThreat: event.windThreat,
+            hailThreat: event.hailThreat,
+            thunderstormDamageThreat: event.thunderstormDamageThreat,
+            flashFloodDetection: event.flashFloodDetection,
+            flashFloodDamageThreat: event.flashFloodDamageThreat,
         )
     }
     
@@ -351,7 +405,16 @@ public extension ArcusSeriesModel {
             description: description,
             instructions: instructions,
             response: response,
-            status: status
+            status: status,
+            tornadoDetection: tornadoDetection,
+            tornadoDamageThreat: tornadoDamageThreat,
+            maxWindGust: maxWindGust,
+            maxHailSize: maxHailSize,
+            windThreat: windThreat,
+            hailThreat: hailThreat,
+            thunderstormDamageThreat: thunderstormDamageThreat,
+            flashFloodDetection: flashFloodDetection,
+            flashFloodDamageThreat: flashFloodDamageThreat
         )
     }
 }

--- a/Sources/App/Models/NWS/ArcusSeriesModel.swift
+++ b/Sources/App/Models/NWS/ArcusSeriesModel.swift
@@ -346,7 +346,16 @@ public extension ArcusSeriesModel {
             instructions: instructions,
             response: response,
             ugc: ugcCodes,
-            h3Cells: h3Cells
+            h3Cells: h3Cells,
+            tornadoDetection: tornadoDetection,
+            tornadoDamageThreat: tornadoDamageThreat,
+            maxWindGust: maxWindGust,
+            maxHailSize: maxHailSize,
+            windThreat: windThreat,
+            hailThreat: hailThreat,
+            thunderstormDamageThreat: thunderstormDamageThreat,
+            flashFloodDetection: flashFloodDetection,
+            flashFloodDamageThreat: flashFloodDamageThreat
         )
     }
     

--- a/Sources/App/Models/NWS/NwsEventDTO.swift
+++ b/Sources/App/Models/NWS/NwsEventDTO.swift
@@ -123,7 +123,7 @@ public struct NwsEventPropertiesDTO: Codable, Sendable {
     public let instruction: String?
     public let response: String?      // e.g. "Shelter"
 
-    public let parameters: [String: [String]]?
+    public let parameters: NWSAlertParameters?
     public let scope: String?
     public let code: String?
     public let language: String?
@@ -191,6 +191,61 @@ public struct NWSReferenceDTO: Codable, Sendable {
         case identifier
         case sender
         case sent
+    }
+}
+
+public struct NWSAlertParameters: Sendable, Codable {
+    // Core lifecycle / motion
+    public let vtec: [String]?
+    public let eventEndingTime: [String]?
+    public let eventMotionDescription: [String]?
+
+    // Severe thunderstorm warning parameters
+    public let maxWindGust: [String]?
+    public let windThreat: [String]?
+    public let maxHailSize: [String]?
+    public let hailThreat: [String]?
+    public let thunderstormDamageThreat: [String]?
+
+    // Tornado / waterspout parameters
+    public let tornadoDetection: [String]?
+    public let tornadoDamageThreat: [String]?
+    public let waterspoutDetection: [String]?
+
+    // Flash flood parameters
+    public let flashFloodDetection: [String]?
+    public let flashFloodDamageThreat: [String]?
+
+    // WEA / dissemination parameters
+    public let weaHandling: [String]?
+    public let cmamText: [String]?
+    public let cmamLongText: [String]?
+    public let easOrg: [String]?
+    public let blockChannels: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case vtec = "VTEC"
+        case eventEndingTime
+        case eventMotionDescription
+
+        case maxWindGust
+        case windThreat
+        case maxHailSize
+        case hailThreat
+        case thunderstormDamageThreat
+
+        case tornadoDetection
+        case tornadoDamageThreat
+        case waterspoutDetection
+
+        case flashFloodDetection
+        case flashFloodDamageThreat
+
+        case weaHandling = "WEAHandling"
+        case cmamText = "CMAMtext"
+        case cmamLongText = "CMAMlongtext"
+        case easOrg = "EAS-ORG"
+        case blockChannels = "BLOCKCHANNEL"
     }
 }
 

--- a/Sources/App/Models/Notification/NotificationDebugModel.swift
+++ b/Sources/App/Models/Notification/NotificationDebugModel.swift
@@ -1,0 +1,82 @@
+//
+//  NotificationDebugModel.swift
+//  ArcusSignal
+//
+//  Created by Codex on 4/9/26.
+//
+
+import Fluent
+import Foundation
+
+public enum NotificationDebugRecordKind: String, Codable, Sendable {
+    case previewNoCandidates = "preview_no_candidates"
+    case candidate
+}
+
+public final class NotificationDebugModel: Model, @unchecked Sendable {
+    public static let schema = "notification_debug"
+
+    @ID(key: .id)
+    public var id: UUID?
+
+    @Parent(key: "series_id")
+    public var series: ArcusSeriesModel
+
+    @OptionalField(key: "installation_id")
+    public var installationID: UUID?
+
+    @OptionalField(key: "notification_ledger_id")
+    public var notificationLedgerID: UUID?
+
+    @Field(key: "revision_urn")
+    public var revisionUrn: String
+
+    @Field(key: "mode")
+    public var mode: String
+
+    @Field(key: "reason")
+    public var reason: String
+
+    @Field(key: "record_kind")
+    public var recordKind: String
+
+    @Field(key: "title")
+    public var title: String
+
+    @Field(key: "subtitle")
+    public var subtitle: String
+
+    @Field(key: "body")
+    public var body: String
+
+    @Timestamp(key: "created", on: .create)
+    public var created: Date?
+
+    public init() {}
+
+    public init(
+        id: UUID? = nil,
+        seriesID: UUID,
+        installationID: UUID? = nil,
+        notificationLedgerID: UUID? = nil,
+        revisionUrn: String,
+        mode: String,
+        reason: String,
+        recordKind: NotificationDebugRecordKind,
+        title: String,
+        subtitle: String,
+        body: String
+    ) {
+        self.id = id
+        self.$series.id = seriesID
+        self.installationID = installationID
+        self.notificationLedgerID = notificationLedgerID
+        self.revisionUrn = revisionUrn
+        self.mode = mode
+        self.reason = reason
+        self.recordKind = recordKind.rawValue
+        self.title = title
+        self.subtitle = subtitle
+        self.body = body
+    }
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -71,6 +71,7 @@ private func configureMigrations(on app: Application) {
     app.migrations.add(UpdateArcusSeriesConstraints())
     app.migrations.add(AddApnsErrorCodeToNotificationLedger())
     app.migrations.add(AddCAPParamFields())
+    app.migrations.add(CreateNotificationDebug())
 }
 
 private func configureAPNs(on app: Application) async throws {

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -70,6 +70,7 @@ private func configureMigrations(on app: Application) {
     app.migrations.add(FixIsSubscribedToDeviceInstallation())
     app.migrations.add(UpdateArcusSeriesConstraints())
     app.migrations.add(AddApnsErrorCodeToNotificationLedger())
+    app.migrations.add(AddCAPParamFields())
 }
 
 private func configureAPNs(on app: Application) async throws {

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -65,49 +65,50 @@ struct AppTests {
     }
 
     private func makeEvent(
-        key: String,
-        revision: Int = 1,
-        expiresAt: Date? = nil,
-        title: String? = nil
+        urn: String = "urn:oid:test-event",
+        sourceURL: String = "https://api.weather.gov/alerts/test-event",
+        title: String? = "Tornado Warning for Test Area"
     ) -> ArcusEvent {
-        let sourceURL = key.hasPrefix("http") ? key : "https://api.weather.gov/alerts/\(key)"
-        return ArcusEvent(
-            eventKey: key,
+        ArcusEvent(
+            urn: urn,
             source: .nws,
-            kind: .torWarning,
+            kind: "Tornado Warning",
             sourceURL: sourceURL,
-            status: .active,
-            revision: revision,
-            issuedAt: isoDate("2026-02-21T16:00:00Z"),
-            effectiveAt: isoDate("2026-02-21T16:05:00Z"),
-            expiresAt: expiresAt,
-            severity: .warning,
+            vtec: nil,
+            messageType: .alert,
+            state: .active,
+            references: [],
+            sent: isoDate("2026-02-21T16:00:00Z"),
+            effective: isoDate("2026-02-21T16:05:00Z"),
+            onset: isoDate("2026-02-21T16:10:00Z"),
+            expires: isoDate("2026-02-21T17:00:00Z"),
+            ends: nil,
+            lastSeenActive: isoDate("2026-02-21T16:30:00Z"),
+            severity: .severe,
             urgency: .immediate,
             certainty: .observed,
             geometry: nil,
-            ugcCodes: [],
-            h3Resolution: nil,
-            h3CoverHash: nil,
+            ugcCodes: ["COC031"],
             title: title,
             areaDesc: "Test Area",
-            rawRef: nil
-        )
-    }
-
-    private func makeIngestEvent(
-        key: String,
-        revision: Int = 1,
-        expiresAt: Date? = nil,
-        title: String? = nil,
-        messageType: NWSAlertMessageType = .alert,
-        sentAt: Date? = nil,
-        supersededEventKeys: [String] = []
-    ) -> ArcusIngestEvent {
-        ArcusIngestEvent(
-            event: makeEvent(key: key, revision: revision, expiresAt: expiresAt, title: title),
-            messageType: messageType,
-            sentAt: sentAt,
-            supersededEventKeys: supersededEventKeys
+            rawRef: nil,
+            category: "Met",
+            event: "Tornado Warning",
+            senderName: "NWS Boulder CO",
+            headline: title,
+            description: "Storm text",
+            instructions: "Take shelter now",
+            response: "Shelter",
+            status: "Actual",
+            tornadoDetection: "observed",
+            tornadoDamageThreat: nil,
+            maxWindGust: nil,
+            maxHailSize: nil,
+            windThreat: nil,
+            hailThreat: nil,
+            thunderstormDamageThreat: nil,
+            flashFloodDetection: nil,
+            flashFloodDamageThreat: nil
         )
     }
 
@@ -143,7 +144,16 @@ struct AppTests {
             instructions: "Take shelter now",
             response: "Shelter",
             ugcCodes: ugcCodes,
-            h3Cells: h3Cells
+            h3Cells: h3Cells,
+            tornadoDetection: nil,
+            tornadoDamageThreat: nil,
+            maxWindGust: nil,
+            maxHailSize: nil,
+            windThreat: nil,
+            hailThreat: nil,
+            thunderstormDamageThreat: nil,
+            flashFloodDetection: nil,
+            flashFloodDamageThreat: nil
         )
     }
 
@@ -152,7 +162,7 @@ struct AppTests {
         try await withApp(mode: .api) { app in
             try await app.testing().test(.GET, "health", afterResponse: { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "ok")
+                #expect(res.body.string == "")
             })
         }
     }
@@ -170,9 +180,12 @@ struct AppTests {
     @Test("Worker testing bootstrap allows missing APNS config")
     func workerTestingBootstrapAllowsMissingAPNSConfig() async throws {
         try await withEnvironment([
-            "APNS_PRIVATE_KEY_PATH": nil,
-            "APNS_KEY_ID": nil,
-            "APNS_TEAM_ID": nil
+            "APNS_TEAM_ID": nil,
+            "APNS_TOPIC": nil,
+            "APNS_SANDBOX_KEY_ID": nil,
+            "APNS_SANDBOX_PRIVATE_KEY_PATH": nil,
+            "APNS_PROD_KEY_ID": nil,
+            "APNS_PROD_PRIVATE_KEY_PATH": nil
         ]) {
             try await withApp(mode: .worker) { app in
                 let productionContainer = await app.apns.containers.container(for: .production)
@@ -188,9 +201,12 @@ struct AppTests {
         try await withEnvironment([
             "DATABASE_URL": "postgres://arcus:arcus@127.0.0.1:5432/arcus_signal?tlsmode=disable",
             "REDIS_URL": "redis://127.0.0.1:6379",
-            "APNS_PRIVATE_KEY_PATH": nil,
-            "APNS_KEY_ID": nil,
-            "APNS_TEAM_ID": nil
+            "APNS_TEAM_ID": nil,
+            "APNS_TOPIC": nil,
+            "APNS_SANDBOX_KEY_ID": nil,
+            "APNS_SANDBOX_PRIVATE_KEY_PATH": nil,
+            "APNS_PROD_KEY_ID": nil,
+            "APNS_PROD_PRIVATE_KEY_PATH": nil
         ]) {
             let app = try await Application.make(.production)
             var capturedError: (any Error)?
@@ -410,7 +426,7 @@ struct AppTests {
         }
     }
 
-    @Test("NWS feature maps to canonical ArcusEvent")
+    @Test("NWS feature maps to current ArcusEvent fields")
     func nwsFeatureMapsToArcusEvent() throws {
         let json = """
         {
@@ -456,16 +472,16 @@ struct AppTests {
             return
         }
 
-        #expect(event.eventKey == "https://api.weather.gov/alerts/abc123")
+        #expect(event.id == "https://api.weather.gov/alerts/abc123")
         #expect(event.source == .nws)
-        #expect(event.kind == .torWarning)
-        #expect(event.sourceURL == "https://api.weather.gov/alerts/abc123")
-        #expect(event.status == .active)
-        #expect(event.severity == .warning)
+        #expect(event.kind == "Tornado Warning")
+        #expect(event.sourceURL == "urn:oid:abc123")
+        #expect(event.state == .active)
+        #expect(event.severity == .severe)
         #expect(event.urgency == .immediate)
         #expect(event.certainty == .observed)
         #expect(event.areaDesc == "Denver County")
-        #expect(event.title == "Tornado Warning for Denver County")
+        #expect(event.headline == "Tornado Warning for Denver County")
         #expect(event.ugcCodes == ["COC031", "COC005"])
 
         switch event.geometry {
@@ -477,7 +493,7 @@ struct AppTests {
         }
     }
 
-    @Test("NWS mapper marks event ended when message is cancel")
+    @Test("NWS mapper marks cancel messages as cancelled in error")
     func nwsMapperMarksEndedWhenCancel() throws {
         let json = """
         {
@@ -508,10 +524,10 @@ struct AppTests {
         let events = decoded.toArcusEvents(now: now)
 
         #expect(events.count == 1)
-        #expect(events.first?.status == .ended)
+        #expect(events.first?.state == .cancelled_in_error)
     }
 
-    @Test("NWS mapper converts polygon geometry and filters unsupported events")
+    @Test("NWS mapper keeps supported and unsupported events while preserving polygon geometry")
     func nwsMapperConvertsPolygonAndFiltersUnsupported() throws {
         let json = """
         {
@@ -558,10 +574,16 @@ struct AppTests {
         let decoded = try decoder.decode(NwsEventDTO.self, from: Data(json.utf8))
         let events = decoded.toArcusEvents(now: isoDate("2026-02-21T16:30:00Z"))
 
-        #expect(events.count == 1)
-        #expect(events.first?.kind == .ffWarning)
+        #expect(events.count == 2)
+        #expect(events.map(\.kind).contains("Flash Flood Warning"))
+        #expect(events.map(\.kind).contains("Special Weather Statement"))
 
-        switch events.first?.geometry {
+        guard let polygonEvent = events.first(where: { $0.kind == "Flash Flood Warning" }) else {
+            Issue.record("Expected polygon event in mapped results.")
+            return
+        }
+
+        switch polygonEvent.geometry {
         case .polygon(let rings):
             #expect(rings.isEmpty == false)
             #expect(rings.first?.isEmpty == false)
@@ -600,10 +622,10 @@ struct AppTests {
         let events = decoded.toArcusEvents(now: isoDate("2026-02-21T16:30:00Z"))
 
         #expect(events.count == 1)
-        #expect(events.first?.status == .active)
+        #expect(events.first?.state == .active)
     }
 
-    @Test("NWS mapper preserves superseded event keys for ingest linkage")
+    @Test("NWS mapper preserves reference identifiers on ArcusEvent")
     func nwsMapperPreservesReferenceSourceURLs() throws {
         let json = """
         {
@@ -637,26 +659,32 @@ struct AppTests {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let decoded = try decoder.decode(NwsEventDTO.self, from: Data(json.utf8))
-        let ingestEvents = decoded.toArcusIngestEvents(now: isoDate("2026-02-21T16:30:00Z"))
+        let events = decoded.toArcusEvents(now: isoDate("2026-02-21T16:30:00Z"))
 
-        #expect(ingestEvents.count == 1)
-        #expect(ingestEvents.first?.supersededEventKeys == ["https://api.weather.gov/alerts/update-1"])
-        #expect(ingestEvents.first?.event.sourceURL == "https://api.weather.gov/alerts/update-2")
+        #expect(events.count == 1)
+        #expect(events.first?.id == "https://api.weather.gov/alerts/update-2")
+        #expect(events.first?.sourceURL == "urn:oid:update-2")
+        #expect(events.first?.references == ["ABC-123"])
     }
 
-    @Test("ArcusEventModel round-trips canonical event")
+    @Test("ArcusSeriesModel round-trips canonical event fields")
     func arcusEventModelRoundTrip() throws {
         let domain = ArcusEvent(
-            eventKey: "nws:urn:oid:roundtrip-1",
+            urn: "urn:oid:roundtrip-1",
             source: .nws,
-            kind: .torWarning,
+            kind: "Tornado Warning",
             sourceURL: "https://api.weather.gov/alerts/roundtrip-1",
-            status: .active,
-            revision: 2,
-            issuedAt: isoDate("2026-02-21T16:00:00Z"),
-            effectiveAt: isoDate("2026-02-21T16:05:00Z"),
-            expiresAt: isoDate("2026-02-21T17:00:00Z"),
-            severity: .warning,
+            vtec: nil,
+            messageType: .alert,
+            state: .active,
+            references: [],
+            sent: isoDate("2026-02-21T16:00:00Z"),
+            effective: isoDate("2026-02-21T16:05:00Z"),
+            onset: isoDate("2026-02-21T16:06:00Z"),
+            expires: isoDate("2026-02-21T17:00:00Z"),
+            ends: nil,
+            lastSeenActive: isoDate("2026-02-21T16:30:00Z"),
+            severity: .severe,
             urgency: .immediate,
             certainty: .observed,
             geometry: .polygon(
@@ -667,109 +695,58 @@ struct AppTests {
                 ]]
             ),
             ugcCodes: ["COC031", "COC005"],
-            h3Resolution: 8,
-            h3CoverHash: "test-cover-hash",
             title: "Round trip test",
             areaDesc: "Denver Metro",
-            rawRef: "raw/nws/roundtrip-1.json"
+            rawRef: nil,
+            category: "Met",
+            event: "Tornado Warning",
+            senderName: "NWS Boulder CO",
+            headline: "Round trip headline",
+            description: "Round trip description",
+            instructions: "Round trip instruction",
+            response: "Shelter",
+            status: "Actual",
+            tornadoDetection: "observed",
+            tornadoDamageThreat: "considerable",
+            maxWindGust: "80",
+            maxHailSize: "1.75",
+            windThreat: "observed",
+            hailThreat: "radar indicated",
+            thunderstormDamageThreat: "destructive",
+            flashFloodDetection: "observed",
+            flashFloodDamageThreat: "considerable"
         )
 
-        let model = try ArcusEventModel(from: domain, asOf: isoDate("2026-02-21T16:30:00Z"))
-        #expect(model.isExpired == false)
-
-        let expiredModel = try ArcusEventModel(from: domain, asOf: isoDate("2026-02-21T18:00:00Z"))
-        #expect(expiredModel.isExpired == true)
-
+        let model = try ArcusSeriesModel(from: domain, asOf: domain.lastSeenActive)
         let roundTrip = try model.asDomain()
 
         #expect(roundTrip == domain)
     }
 
-    @Test("Ingest deduplicator ignores duplicates and keeps latest payload")
-    func ingestDeduplicatorKeepsLatest() throws {
-        let first = makeIngestEvent(key: "nws:dup-1", revision: 1, title: "First")
-        let second = makeIngestEvent(key: "nws:dup-1", revision: 99, title: "Second")
-        let distinct = makeIngestEvent(key: "nws:dup-2", revision: 1, title: "Distinct")
-
-        let deduped = ArcusIngestMessageDeduplicator.deduplicate([first, second, distinct])
-
-        #expect(deduped.events.count == 2)
-        #expect(deduped.duplicatesIgnored == 1)
-        #expect(deduped.events[0].event.eventKey == "nws:dup-1")
-        #expect(deduped.events[0].event.title == "Second")
-        #expect(deduped.events[1].event.eventKey == "nws:dup-2")
-    }
-
-    @Test("Ingest lineage resolver keeps only final superseding message in a chain")
-    func ingestLineageResolverKeepsLatestSupersedingMessage() {
-        let alert = makeIngestEvent(
-            key: "https://api.weather.gov/alerts/a",
-            sentAt: isoDate("2026-02-21T16:00:00Z")
-        )
-        let update1 = makeIngestEvent(
-            key: "https://api.weather.gov/alerts/b",
-            messageType: .update,
-            sentAt: isoDate("2026-02-21T16:05:00Z"),
-            supersededEventKeys: ["https://api.weather.gov/alerts/a"]
-        )
-        let update2 = makeIngestEvent(
-            key: "https://api.weather.gov/alerts/c",
-            messageType: .update,
-            sentAt: isoDate("2026-02-21T16:10:00Z"),
-            supersededEventKeys: [
-                "https://api.weather.gov/alerts/a",
-                "https://api.weather.gov/alerts/b"
-            ]
-        )
-
-        let resolved = ArcusIngestLineageResolver.resolve(
-            events: [alert, update1, update2],
-            existingByEventKey: [:]
-        )
-
-        #expect(resolved.count == 1)
-        #expect(resolved.first?.winner.event.eventKey == "https://api.weather.gov/alerts/c")
-        #expect(resolved.first?.supersededInRun == 2)
-    }
-
-    @Test("Ingest lineage resolver links update chain to existing event key")
-    func ingestLineageResolverLinksToExistingEvent() throws {
-        let existingEventKey = "https://api.weather.gov/alerts/existing-a"
-        let existingModel = try ArcusEventModel(
-            from: makeEvent(key: existingEventKey, title: "Existing"),
-            asOf: isoDate("2026-02-21T16:00:00Z")
-        )
-
-        let incomingUpdate = makeIngestEvent(
-            key: "https://api.weather.gov/alerts/existing-b",
-            messageType: .update,
-            sentAt: isoDate("2026-02-21T16:05:00Z"),
-            supersededEventKeys: [existingEventKey]
-        )
-
-        let resolved = ArcusIngestLineageResolver.resolve(
-            events: [incomingUpdate],
-            existingByEventKey: [existingEventKey: existingModel]
-        )
-
-        #expect(resolved.count == 1)
-        #expect(resolved.first?.existing?.eventKey == existingEventKey)
-        #expect(resolved.first?.winner.event.eventKey == "https://api.weather.gov/alerts/existing-b")
-    }
-
-    @Test("ArcusEventModel content hash ignores revision but tracks payload changes")
+    @Test("ArcusEvent fingerprint ignores identifiers but tracks payload changes")
     func arcusEventContentHashSemantics() throws {
-        let base = makeEvent(key: "nws:hash-1", revision: 1, title: "Title A")
-        let samePayloadDifferentRevision = makeEvent(key: "nws:hash-1", revision: 42, title: "Title A")
-        let changedPayload = makeEvent(key: "nws:hash-1", revision: 1, title: "Title B")
+        let base = makeEvent(
+            urn: "urn:oid:hash-1",
+            sourceURL: "https://api.weather.gov/alerts/hash-1",
+            title: "Title A"
+        )
+        let samePayloadDifferentIdentifiers = makeEvent(
+            urn: "urn:oid:hash-2",
+            sourceURL: "https://api.weather.gov/alerts/hash-2",
+            title: "Title A"
+        )
+        let changedPayload = makeEvent(
+            urn: "urn:oid:hash-1",
+            sourceURL: "https://api.weather.gov/alerts/hash-1",
+            title: "Title B"
+        )
 
-        let asOf = isoDate("2026-02-21T16:30:00Z")
-        let baseModel = try ArcusEventModel(from: base, asOf: asOf)
-        let samePayloadModel = try ArcusEventModel(from: samePayloadDifferentRevision, asOf: asOf)
-        let changedPayloadModel = try ArcusEventModel(from: changedPayload, asOf: asOf)
+        let baseHash = try base.computeContentFingerprint()
+        let sameHash = try samePayloadDifferentIdentifiers.computeContentFingerprint()
+        let changedHash = try changedPayload.computeContentFingerprint()
 
-        #expect(baseModel.contentHash == samePayloadModel.contentHash)
-        #expect(baseModel.contentHash != changedPayloadModel.contentHash)
+        #expect(baseHash == sameHash)
+        #expect(baseHash != changedHash)
     }
 
     @Test("Scheduler dispatches ingest job to ingest lane")

--- a/Tests/AppTests/ArcusEventFingerprintTests.swift
+++ b/Tests/AppTests/ArcusEventFingerprintTests.swift
@@ -12,7 +12,7 @@ struct ArcusEventFingerprintTests {
         ArcusEvent(
             urn: "urn:oid:test-fingerprint",
             source: .nws,
-            kind: .torWarning,
+            kind: "Tornado Warning",
             sourceURL: "https://api.weather.gov/alerts/test-fingerprint",
             vtec: nil,
             messageType: .alert,
@@ -29,11 +29,26 @@ struct ArcusEventFingerprintTests {
             certainty: .observed,
             geometry: nil,
             ugcCodes: ugcCodes,
-            h3Resolution: nil,
-            h3CoverHash: nil,
             title: title,
             areaDesc: areaDesc,
-            rawRef: nil
+            rawRef: nil,
+            category: "Met",
+            event: "Tornado Warning",
+            senderName: "NWS Boulder CO",
+            headline: "Tornado Warning for Test County",
+            description: "Storm text",
+            instructions: "Take shelter now",
+            response: "Shelter",
+            status: "Actual",
+            tornadoDetection: nil,
+            tornadoDamageThreat: nil,
+            maxWindGust: nil,
+            maxHailSize: nil,
+            windThreat: nil,
+            hailThreat: nil,
+            thunderstormDamageThreat: nil,
+            flashFloodDetection: nil,
+            flashFloodDamageThreat: nil
         )
     }
 

--- a/Tests/AppTests/NotificationEngineTests.swift
+++ b/Tests/AppTests/NotificationEngineTests.swift
@@ -58,7 +58,7 @@ struct NotificationEngineTests {
         )
     }
 
-    @Test("H3 tornado warning notifications stay direct and minimal")
+    @Test("H3 tornado warning notifications use the current generic location wording")
     func h3TornadoWarning() {
         let details = engine.buildNotification(
             for: makeSeries(event: "Tornado Warning", severity: "extreme"),
@@ -67,11 +67,11 @@ struct NotificationEngineTests {
         )
 
         #expect(details.title == "Tornado Warning")
-        #expect(details.subTitle == "At your location")
-        #expect(details.body == "Take shelter now. Tap for details.")
+        #expect(details.subTitle == "Includes your location")
+        #expect(details.body == "Tornado danger in your area.")
     }
 
-    @Test("UGC updates use the best available local label")
+    @Test("UGC updates use the current generic area wording")
     func ugcUpdateUsesCountyLabel() {
         let details = engine.buildNotification(
             for: makeSeries(event: "Severe Thunderstorm Watch"),
@@ -79,12 +79,12 @@ struct NotificationEngineTests {
             on: makeCandidate(countyLabel: "  Boulder County  ", fireZoneLabel: "Zone 217")
         )
 
-        #expect(details.title == "Severe Thunderstorm Watch Update")
-        #expect(details.subTitle == "Updated for Boulder County")
-        #expect(details.body == "Stay ready to act quickly. Tap for details.")
+        #expect(details.title == "Severe Thunderstorm Watch - Update")
+        #expect(details.subTitle == "Updated for your area")
+        #expect(details.body == "Severe storm risk continues for your area.")
     }
 
-    @Test("UGC fire alerts fall back to fire zone labels when needed")
+    @Test("UGC fire alerts keep generic area wording")
     func ugcFireAlertUsesFireZoneLabel() {
         let details = engine.buildNotification(
             for: makeSeries(event: "Fire Warning"),
@@ -93,8 +93,8 @@ struct NotificationEngineTests {
         )
 
         #expect(details.title == "Fire Warning")
-        #expect(details.subTitle == "For Fire Weather Zone 217")
-        #expect(details.body == "Be ready to act quickly if fire conditions worsen. Tap for details.")
+        #expect(details.subTitle == "For your area")
+        #expect(details.body == "Critical fire weather conditions in your area.")
     }
 
     @Test("Cancellation messaging is explicit")
@@ -106,8 +106,8 @@ struct NotificationEngineTests {
         )
 
         #expect(details.title == "Tornado Warning Cancelled")
-        #expect(details.subTitle == "Cancelled for your location")
-        #expect(details.body == "This alert was cancelled by the issuer. Tap for details.")
+        #expect(details.subTitle == "Cancelled for your area")
+        #expect(details.body == "This tornado warning was cancelled by the issuer.")
     }
 
     @Test("Generic alerts fall back to trimmed headline or title text")
@@ -127,6 +127,18 @@ struct NotificationEngineTests {
 
         #expect(details.title == "Hazardous Weather Outlook")
         #expect(details.subTitle == "For your area")
-        #expect(details.body == "Monitor conditions. Tap for details.")
+        #expect(details.body == "Weather information for your area.")
+    }
+
+    @Test("Preview notifications stay generic when there are no candidates")
+    func previewNotificationUsesGenericUGCFallback() {
+        let details = engine.buildPreviewNotification(
+            for: makeSeries(event: "Severe Thunderstorm Watch"),
+            with: makePayload(mode: .ugc, reason: .update)
+        )
+
+        #expect(details.title == "Severe Thunderstorm Watch Update")
+        #expect(details.subTitle == "Updated for your area")
+        #expect(details.body == "Severe storm risk continues for your area.")
     }
 }

--- a/Tests/AppTests/NotificationEngineTests.swift
+++ b/Tests/AppTests/NotificationEngineTests.swift
@@ -137,7 +137,7 @@ struct NotificationEngineTests {
             with: makePayload(mode: .ugc, reason: .update)
         )
 
-        #expect(details.title == "Severe Thunderstorm Watch Update")
+        #expect(details.title == "Severe Thunderstorm Watch - Update")
         #expect(details.subTitle == "Updated for your area")
         #expect(details.body == "Severe storm risk continues for your area.")
     }

--- a/docs/Sql/NotificationDebug.sql
+++ b/docs/Sql/NotificationDebug.sql
@@ -1,0 +1,55 @@
+-- Check the notification debug table
+-- preview_no_candidates means we built a notification
+-- but there were no matching devices for that revision
+
+SELECT
+    d.created,
+    d.record_kind,
+    d.series_id,
+    d.revision_urn,
+    d.mode,
+    d.reason,
+    d.title,
+    d.subtitle,
+    d.body,
+    d.installation_id,
+    l.status AS ledger_status,
+    l.apns_error_code
+FROM notification_debug d
+LEFT JOIN notification_ledger l
+  ON l.id = d.notification_ledger_id
+ORDER BY d.created DESC;
+
+
+-- Check snapshots for one alert series
+-- replace the series_id with the one you care about
+
+SELECT
+    d.created,
+    d.record_kind,
+    d.revision_urn,
+    d.mode,
+    d.reason,
+    d.title,
+    d.subtitle,
+    d.body,
+    d.installation_id,
+    l.status AS ledger_status,
+    l.apns_error_code
+FROM notification_debug d
+LEFT JOIN notification_ledger l
+  ON l.id = d.notification_ledger_id
+WHERE d.series_id = '92e9bdfd-0c14-4b6a-9377-026250270a69'
+ORDER BY d.created DESC;
+
+
+-- Quick sanity check
+-- shows whether rows are mostly previews or actual candidates
+
+SELECT
+    record_kind,
+    mode,
+    count(*) AS c
+FROM notification_debug
+GROUP BY record_kind, mode
+ORDER BY record_kind, mode;


### PR DESCRIPTION
# Summary
This branch extends NWS alert ingestion to decode and persist CAP parameter fields, adds DB-backed notification debug snapshots so we can inspect what would have been sent even when no devices match, and refreshes the test suite to align with the current backend behavior.

# What Changed
- Decoded NWS CAP alert parameters into typed model fields instead of keeping them as raw string dictionaries.
- Persisted CAP parameter values on alert series records and carried them through the current API and device alert payload models.
- Added a new `notification_debug` table, model, and migration for stored notification snapshots with optional links back to the notification ledger.
- Updated the notification send worker to save one preview snapshot when a revision has no candidates and one candidate snapshot per successful ledger claim before APNs delivery, so failed sends still leave a debug record.
- Added a simple SQL helper for inspecting notification debug rows alongside any linked ledger records.
- Updated the existing unit tests to match the current notification engine, fingerprinting, bootstrap, and mapping behavior.

# User Impact
There is no direct end-user UI change in this branch. Operationally, it becomes much easier to troubleshoot notification behavior, including the zero-device case, and downstream consumers now receive richer CAP parameter data in the current alert payloads.

# Testing
- `swift test` passed
- 27 tests across 3 suites passed locally

# Notes
- The notification debug data is DB-only in this branch; there is no new API surface for reading it yet.
