### PR TITLE
[codex] Add operator dashboard snapshot API and server-rendered dashboard

### DIFF
--- a/Sources/App/Controllers/OperatorDashboardController.swift
+++ b/Sources/App/Controllers/OperatorDashboardController.swift
@@ -1,0 +1,40 @@
+import Vapor
+
+struct OperatorDashboardController: RouteCollection {
+    func boot(routes: any RoutesBuilder) throws {
+        let metrics = routes.grouped("v1")
+        metrics.get("metrics", use: metricsSnapshot)
+        routes.get("dashboard", use: dashboard)
+    }
+
+    func metricsSnapshot(req: Request) async throws -> OperatorDashboardSnapshotResponse {
+        guard let snapshot = try await req.application.operatorDashboardSnapshotStore.load(on: req.db) else {
+            throw Abort(.serviceUnavailable, reason: "Operator dashboard snapshot unavailable.")
+        }
+
+        return .init(snapshot: snapshot, renderedAt: .now)
+    }
+
+    func dashboard(req: Request) async throws -> Response {
+        if let snapshot = try await req.application.operatorDashboardSnapshotStore.load(on: req.db) {
+            return htmlResponse(
+                status: .ok,
+                html: OperatorDashboardPageRenderer.render(
+                    snapshot: .init(snapshot: snapshot, renderedAt: .now)
+                )
+            )
+        }
+
+        return htmlResponse(
+            status: .serviceUnavailable,
+            html: OperatorDashboardPageRenderer.renderUnavailable()
+        )
+    }
+
+    private func htmlResponse(status: HTTPResponseStatus, html: String) -> Response {
+        let response = Response(status: status)
+        response.headers.contentType = .html
+        response.body = .init(string: html)
+        return response
+    }
+}

--- a/Sources/App/Infrastructure/Notifications/NotificationEngine.swift
+++ b/Sources/App/Infrastructure/Notifications/NotificationEngine.swift
@@ -394,13 +394,13 @@ struct NotificationEngine: Sendable {
 
         if severeTags.contains("Observed tornado") {
             return reason == .update
-                ? "Observed tornado still indicated in your area."
+                ? "Observed tornado still in your area."
                 : "Observed tornado in your area."
         }
 
         if severeTags.contains("Radar-indicated tornado") {
             return reason == .update
-                ? "Radar-indicated tornado still indicated in your area."
+                ? "Radar-indicated tornado still detected in your area."
                 : "Radar-indicated tornado in your area."
         }
 

--- a/Sources/App/Jobs/IngestNWSAlertsJob.swift
+++ b/Sources/App/Jobs/IngestNWSAlertsJob.swift
@@ -58,7 +58,8 @@ public struct IngestNWSAlertsJob: AsyncJob {
                 "runLabel": .string(payload.runLabel ?? "none")
             ]
         )
-        let runTimestamp = Date()
+        let startedAt = Date()
+        let runTimestamp = startedAt
 
         do {
             let ingestEvents = try await resolveIngestEvents(
@@ -106,9 +107,30 @@ public struct IngestNWSAlertsJob: AsyncJob {
                     "Events Ended": .string("\(cleanResults.endedCount)"),
                     "Events Expired": .string("\(cleanResults.expiredCount)")
                 ])
+
+            await recordIngestSweepRun(
+                context: context,
+                payload: payload,
+                status: .succeeded,
+                startedAt: startedAt,
+                completedAt: Date(),
+                eventCount: ingestEvents.count,
+                persistResult: result,
+                errorMessage: nil
+            )
             
             context.logger.info("IngestNWSAlertsJob finished")
         } catch {
+            await recordIngestSweepRun(
+                context: context,
+                payload: payload,
+                status: .failed,
+                startedAt: startedAt,
+                completedAt: Date(),
+                eventCount: nil,
+                persistResult: nil,
+                errorMessage: String(reflecting: error)
+            )
             context.logger.report(error: error)
             throw error
         }
@@ -123,6 +145,44 @@ public struct IngestNWSAlertsJob: AsyncJob {
 }
 
 private extension IngestNWSAlertsJob {
+    func recordIngestSweepRun(
+        context: QueueContext,
+        payload: Payload,
+        status: IngestSweepRunStatus,
+        startedAt: Date,
+        completedAt: Date,
+        eventCount: Int?,
+        persistResult: PersistResult?,
+        errorMessage: String?
+    ) async {
+        let run = IngestSweepRunModel(
+            source: payload.source.rawValue,
+            fixtureName: payload.fixtureName,
+            runLabel: payload.runLabel,
+            status: status,
+            startedAt: startedAt,
+            completedAt: completedAt,
+            eventCount: eventCount,
+            newSeriesCount: persistResult?.newSeriesCreated,
+            newRevisionCount: persistResult?.newRevisionsCreated,
+            targetOutboxQueuedCount: persistResult?.targetOutboxQueued,
+            notificationOutboxQueuedCount: persistResult?.notificationOutboxQueued,
+            errorMessage: errorMessage
+        )
+
+        do {
+            try await run.create(on: context.application.db)
+        } catch {
+            context.logger.warning(
+                "Failed to record ingest sweep run.",
+                metadata: [
+                    "status": .string(status.rawValue),
+                    "error": .string(String(reflecting: error))
+                ]
+            )
+        }
+    }
+
     func startEventCleanup(on database: any Database, asOf: Date, logger: Logger) async throws -> CleanupResult {
         // Expired
         let expired = ArcusSeriesModel.query(on: database)

--- a/Sources/App/Jobs/NotificationSendJob.swift
+++ b/Sources/App/Jobs/NotificationSendJob.swift
@@ -27,6 +27,15 @@ struct LedgerClaimResult {
     let id: UUID?
 }
 
+struct DispatchNotificationsResult {
+    let candidateResolutionReached: Bool
+    let candidateCount: Int
+    let claimedCount: Int
+    let sentCount: Int
+    let failedCount: Int
+    let noOpReason: NotificationSendNoOpReason?
+}
+
 public enum NotificationTargetMode: String, Codable, Sendable {
     case h3
     case ugc
@@ -75,6 +84,7 @@ public struct NotificationSendJob: AsyncJob {
                 "reason": .string("\(String.init(reflecting: payload.reason))")
             ]
         )
+        let attemptedAt = Date()
         
         // Grab the associated series, revisions, & geometry
         let series = try await ArcusSeriesModel.query(on: context.application.db)
@@ -97,6 +107,19 @@ public struct NotificationSendJob: AsyncJob {
                     "reason": .string("\(String.init(reflecting: payload.reason))")
                 ]
             )
+            await recordAttempt(
+                context: context,
+                payload: payload,
+                attemptedAt: attemptedAt,
+                summary: .init(
+                    candidateResolutionReached: false,
+                    candidateCount: 0,
+                    claimedCount: 0,
+                    sentCount: 0,
+                    failedCount: 0,
+                    noOpReason: .staleRevisionMismatch
+                )
+            )
             return
         }
         
@@ -110,6 +133,19 @@ public struct NotificationSendJob: AsyncJob {
                         "seriesId": .string(payload.seriesId.uuidString)
                     ]
                 )
+                await recordAttempt(
+                    context: context,
+                    payload: payload,
+                    attemptedAt: attemptedAt,
+                    summary: .init(
+                        candidateResolutionReached: false,
+                        candidateCount: 0,
+                        claimedCount: 0,
+                        sentCount: 0,
+                        failedCount: 0,
+                        noOpReason: .missingGeolocation
+                    )
+                )
                 return
             }
             
@@ -120,11 +156,17 @@ public struct NotificationSendJob: AsyncJob {
                 on: context.application.db
             )
             
-            try await dispatchNotifications(
+            let summary = try await dispatchNotifications(
                 to: h3Candidates,
                 with: payload,
                 and: series,
                 using: context
+            )
+            await recordAttempt(
+                context: context,
+                payload: payload,
+                attemptedAt: attemptedAt,
+                summary: summary
             )
         } else {
             // we only have 2 modes right now, so its ugc
@@ -134,11 +176,17 @@ public struct NotificationSendJob: AsyncJob {
                 on: context.application.db
             )
 
-            try await dispatchNotifications(
+            let summary = try await dispatchNotifications(
                 to: ugcCandidates,
                 with: payload,
                 and: series,
                 using: context
+            )
+            await recordAttempt(
+                context: context,
+                payload: payload,
+                attemptedAt: attemptedAt,
+                summary: summary
             )
         }
 
@@ -312,7 +360,7 @@ private extension NotificationSendJob {
         with payload: NotificationSendJobPayload,
         and series: ArcusSeriesModel,
         using context: QueueContext
-    ) async throws {
+    ) async throws -> DispatchNotificationsResult {
         guard candidates.count > 0 else {
             let preview = engine.buildPreviewNotification(for: series, with: payload)
             await saveNotificationDebugSnapshot(
@@ -336,9 +384,20 @@ private extension NotificationSendJob {
                     "reason": .string("\(String.init(reflecting: payload.reason))")
                 ]
             )
-            return
+            return .init(
+                candidateResolutionReached: true,
+                candidateCount: 0,
+                claimedCount: 0,
+                sentCount: 0,
+                failedCount: 0,
+                noOpReason: .zeroCandidates
+            )
         }
-        
+
+        var claimedCount = 0
+        var sentCount = 0
+        var failedCount = 0
+
         for candidate in candidates {
             let claim = try await claimNotificationLedger(
                 installationID: candidate.id,
@@ -352,6 +411,8 @@ private extension NotificationSendJob {
             guard claim.inserted else {
                 continue
             }
+
+            claimedCount += 1
             
             let alert = engine.buildNotification(for: series, with: payload, on: candidate)
             await saveNotificationDebugSnapshot(
@@ -378,8 +439,10 @@ private extension NotificationSendJob {
 
                 if let existingClaim = try await NotificationLedgerModel.find(claim.id, on: context.application.db) {
                     existingClaim.status = "sent"
+                    existingClaim.completedAt = .now
                     try await existingClaim.save(on: context.application.db)
                 }
+                sentCount += 1
                 
                 context.logger.info(
                     "Notification sent to device",
@@ -418,7 +481,9 @@ private extension NotificationSendJob {
                 }
 
                 existingClaim.status = "failed"
+                existingClaim.completedAt = .now
                 try await existingClaim.save(on: context.application.db)
+                failedCount += 1
                 
 //
 //                200
@@ -461,9 +526,27 @@ private extension NotificationSendJob {
                 // TODO: figure out retries
                 // At least we aren't dropping them now
                 existingClaim.status = "failed"
+                existingClaim.completedAt = .now
                 try await existingClaim.save(on: context.application.db)
+                failedCount += 1
             }
         }
+
+        let noOpReason: NotificationSendNoOpReason?
+        if sentCount == 0 && failedCount == 0 {
+            noOpReason = .allCandidatesPreviouslyClaimed
+        } else {
+            noOpReason = nil
+        }
+
+        return .init(
+            candidateResolutionReached: true,
+            candidateCount: candidates.count,
+            claimedCount: claimedCount,
+            sentCount: sentCount,
+            failedCount: failedCount,
+            noOpReason: noOpReason
+        )
     }
 
     func saveNotificationDebugSnapshot(
@@ -513,6 +596,50 @@ private extension NotificationSendJob {
                     "revisionUrn": .string(revisionUrn),
                     "mode": .string(mode.rawValue),
                     "recordKind": .string(recordKind.rawValue),
+                    "error": .string(String(reflecting: error))
+                ]
+            )
+        }
+    }
+
+    func recordAttempt(
+        context: QueueContext,
+        payload: NotificationSendJobPayload,
+        attemptedAt: Date,
+        summary: DispatchNotificationsResult
+    ) async {
+        let outcome: NotificationSendAttemptOutcome
+        if summary.noOpReason != nil {
+            outcome = .noOp
+        } else if summary.sentCount > 0 {
+            outcome = .delivered
+        } else {
+            outcome = .failed
+        }
+
+        let attempt = NotificationSendAttemptModel(
+            seriesID: payload.seriesId,
+            revisionUrn: payload.revisionUrn,
+            mode: payload.mode,
+            reason: payload.reason,
+            outcome: outcome,
+            noOpReason: summary.noOpReason,
+            candidateResolutionReached: summary.candidateResolutionReached,
+            candidateCount: summary.candidateCount,
+            claimedCount: summary.claimedCount,
+            sentCount: summary.sentCount,
+            failedCount: summary.failedCount,
+            attemptedAt: attemptedAt
+        )
+
+        do {
+            try await attempt.create(on: context.application.db)
+        } catch {
+            context.logger.warning(
+                "Failed to record notification send attempt.",
+                metadata: [
+                    "seriesId": .string(payload.seriesId.uuidString),
+                    "revisionUrn": .string(payload.revisionUrn),
                     "error": .string(String(reflecting: error))
                 ]
             )

--- a/Sources/App/Jobs/TargetEventRevisionJob.swift
+++ b/Sources/App/Jobs/TargetEventRevisionJob.swift
@@ -53,19 +53,36 @@ public struct TargetEventRevisionJob: AsyncJob {
                 "reason": .string(payload.reason.rawValue)
             ]
         )
-        
-        try await context.application.db.transaction { database in
-            try await persistGeolocation(payload, on: database, logger: context.logger)
+
+        do {
+            let result = try await context.application.db.transaction { database in
+                try await persistGeolocation(payload, on: database, logger: context.logger)
+            }
+
+            try await markDispatchResult(
+                payload: payload,
+                result: result.rawValue,
+                errorMessage: nil,
+                on: context.application.db
+            )
+
+            let drainNotificationsResult = try await DispatchAgent.dispatchPendingNotificationJobs(context: context, mode: "h3")
+            context.logger.info(
+                "Notification dispatch outbox drain finished for h3",
+                metadata: [
+                    "dispatched": .stringConvertible(drainNotificationsResult.dispatched),
+                    "failed": .stringConvertible(drainNotificationsResult.failed)
+                ]
+            )
+        } catch {
+            try? await markDispatchResult(
+                payload: payload,
+                result: TargetDispatchCompletionResult.failed.rawValue,
+                errorMessage: String(reflecting: error),
+                on: context.application.db
+            )
+            throw error
         }
-        
-        let drainNotificationsResult = try await DispatchAgent.dispatchPendingNotificationJobs(context: context, mode: "h3")
-        context.logger.info(
-            "Notification dispatch outbox drain finished for h3",
-            metadata: [
-                "dispatched": .stringConvertible(drainNotificationsResult.dispatched),
-                "failed": .stringConvertible(drainNotificationsResult.failed)
-            ]
-        )
     }
 
     public func error(_ context: QueueContext, _ error: any Error, _ payload: Payload) async throws {
@@ -82,11 +99,17 @@ public struct TargetEventRevisionJob: AsyncJob {
 }
 
 private extension TargetEventRevisionJob {
+    enum TargetDispatchCompletionResult: String {
+        case succeeded
+        case unsupportedGeometry = "unsupported_geometry"
+        case failed
+    }
+
     func persistGeolocation(
         _ payload: TargetEventRevisionPayload,
         on database: any Database,
         logger: Logger
-    ) async throws {
+    ) async throws -> TargetDispatchCompletionResult {
         let cover = try buildH3Cover(for: payload.geometry)
 
         guard let cover else {
@@ -94,7 +117,7 @@ private extension TargetEventRevisionJob {
                 "No polygon geometry available; skipping H3 persistence",
                 metadata: ["seriesId": .string(payload.seriesId.uuidString)]
             )
-            return
+            return .unsupportedGeometry
         }
 
         let geometryHash = try hashGeometry(payload.geometry)
@@ -120,7 +143,7 @@ private extension TargetEventRevisionJob {
                     "Geolocation unchanged; skipping update.",
                     metadata: ["seriesId": .string(payload.seriesId.uuidString)]
                 )
-                return
+                return .succeeded
             }
 
             existing.geometry = payload.geometry
@@ -153,6 +176,26 @@ private extension TargetEventRevisionJob {
         ) {
             logger.info("Notification job queued.", metadata: ["seriesId": .stringConvertible(payload.seriesId)])
         }
+
+        return .succeeded
+    }
+
+    func markDispatchResult(
+        payload: TargetEventRevisionPayload,
+        result: String,
+        errorMessage: String?,
+        on database: any Database
+    ) async throws {
+        guard let row = try await ArcusTargetDispatchOutboxModel.query(on: database)
+            .filter(\.$revisionUrn == payload.revisionUrn)
+            .first() else {
+            return
+        }
+
+        row.completed = .now
+        row.result = result
+        row.lastError = errorMessage
+        try await row.update(on: database)
     }
     
     // MARK: H3 HASHING

--- a/Sources/App/Migrations/CreateOperatorDashboardSupport.swift
+++ b/Sources/App/Migrations/CreateOperatorDashboardSupport.swift
@@ -1,0 +1,154 @@
+import Fluent
+import SQLKit
+
+struct CreateIngestSweepRuns: AsyncMigration {
+    func prepare(on database: any Database) async throws {
+        try await database.schema(IngestSweepRunModel.schema)
+            .id()
+            .field("source", .string, .required)
+            .field("fixture_name", .string)
+            .field("run_label", .string)
+            .field("status", .string, .required)
+            .field("started_at", .datetime, .required)
+            .field("completed_at", .datetime, .required)
+            .field("event_count", .int)
+            .field("new_series_count", .int)
+            .field("new_revision_count", .int)
+            .field("target_outbox_queued_count", .int)
+            .field("notification_outbox_queued_count", .int)
+            .field("error_message", .string)
+            .create()
+
+        guard let sql = database as? any SQLDatabase else { return }
+
+        try await sql.raw("""
+            CREATE INDEX IF NOT EXISTS idx_ingest_sweep_runs_completed_at
+            ON ingest_sweep_runs (completed_at DESC);
+        """).run()
+
+        try await sql.raw("""
+            CREATE INDEX IF NOT EXISTS idx_ingest_sweep_runs_status_completed_at
+            ON ingest_sweep_runs (status, completed_at DESC);
+        """).run()
+    }
+
+    func revert(on database: any Database) async throws {
+        if let sql = database as? any SQLDatabase {
+            try await sql.raw("DROP INDEX IF EXISTS idx_ingest_sweep_runs_completed_at;").run()
+            try await sql.raw("DROP INDEX IF EXISTS idx_ingest_sweep_runs_status_completed_at;").run()
+        }
+        try await database.schema(IngestSweepRunModel.schema).delete()
+    }
+}
+
+struct AddCompletedAtToNotificationLedger: AsyncMigration {
+    func prepare(on db: any Database) async throws {
+        try await db.schema(NotificationLedgerModel.schema)
+            .field("completed_at", .datetime)
+            .update()
+
+        guard let sql = db as? any SQLDatabase else { return }
+
+        try await sql.raw("""
+            CREATE INDEX IF NOT EXISTS idx_notification_ledger_status_completed_at
+            ON notification_ledger (status, completed_at DESC);
+        """).run()
+    }
+
+    func revert(on db: any Database) async throws {
+        if let sql = db as? any SQLDatabase {
+            try await sql.raw("DROP INDEX IF EXISTS idx_notification_ledger_status_completed_at;").run()
+        }
+        try await db.schema(NotificationLedgerModel.schema)
+            .deleteField("completed_at")
+            .update()
+    }
+}
+
+struct AddCompletionFieldsToTargetDispatchOutbox: AsyncMigration {
+    func prepare(on db: any Database) async throws {
+        try await db.schema(ArcusTargetDispatchOutboxModel.schema)
+            .field("completed", .datetime)
+            .field("result", .string)
+            .update()
+
+        guard let sql = db as? any SQLDatabase else { return }
+
+        try await sql.raw("""
+            CREATE INDEX IF NOT EXISTS idx_target_dispatch_outbox_result_completed
+            ON target_dispatch_outbox (result, completed DESC);
+        """).run()
+    }
+
+    func revert(on db: any Database) async throws {
+        if let sql = db as? any SQLDatabase {
+            try await sql.raw("DROP INDEX IF EXISTS idx_target_dispatch_outbox_result_completed;").run()
+        }
+        try await db.schema(ArcusTargetDispatchOutboxModel.schema)
+            .deleteField("completed")
+            .deleteField("result")
+            .update()
+    }
+}
+
+struct CreateNotificationSendAttempts: AsyncMigration {
+    func prepare(on database: any Database) async throws {
+        try await database.schema(NotificationSendAttemptModel.schema)
+            .id()
+            .field("series_id", .uuid, .required,
+                   .references(ArcusSeriesModel.schema, "id", onDelete: .cascade))
+            .field("revision_urn", .string, .required)
+            .field("mode", .string, .required)
+            .field("reason", .string, .required)
+            .field("outcome", .string, .required)
+            .field("no_op_reason", .string)
+            .field("candidate_resolution_reached", .bool, .required)
+            .field("candidate_count", .int, .required)
+            .field("claimed_count", .int, .required)
+            .field("sent_count", .int, .required)
+            .field("failed_count", .int, .required)
+            .field("attempted_at", .datetime, .required)
+            .create()
+
+        guard let sql = database as? any SQLDatabase else { return }
+
+        try await sql.raw("""
+            CREATE INDEX IF NOT EXISTS idx_notification_send_attempts_attempted_at
+            ON notification_send_attempts (attempted_at DESC);
+        """).run()
+
+        try await sql.raw("""
+            CREATE INDEX IF NOT EXISTS idx_notification_send_attempts_outcome_attempted_at
+            ON notification_send_attempts (outcome, attempted_at DESC);
+        """).run()
+
+        try await sql.raw("""
+            CREATE INDEX IF NOT EXISTS idx_notification_send_attempts_no_op_reason_attempted_at
+            ON notification_send_attempts (no_op_reason, attempted_at DESC);
+        """).run()
+    }
+
+    func revert(on database: any Database) async throws {
+        if let sql = database as? any SQLDatabase {
+            try await sql.raw("DROP INDEX IF EXISTS idx_notification_send_attempts_attempted_at;").run()
+            try await sql.raw("DROP INDEX IF EXISTS idx_notification_send_attempts_outcome_attempted_at;").run()
+            try await sql.raw("DROP INDEX IF EXISTS idx_notification_send_attempts_no_op_reason_attempted_at;").run()
+        }
+        try await database.schema(NotificationSendAttemptModel.schema).delete()
+    }
+}
+
+struct CreateOperatorDashboardSnapshots: AsyncMigration {
+    func prepare(on database: any Database) async throws {
+        try await database.schema(OperatorDashboardSnapshotModel.schema)
+            .field("id", .string, .identifier(auto: false))
+            .field("snapshot", .dictionary, .required)
+            .field("created_at", .datetime)
+            .field("updated_at", .datetime)
+            .create()
+    }
+
+    func revert(on database: any Database) async throws {
+        try await database.schema(OperatorDashboardSnapshotModel.schema).delete()
+    }
+}

--- a/Sources/App/Models/API/OperatorDashboardSnapshotResponse.swift
+++ b/Sources/App/Models/API/OperatorDashboardSnapshotResponse.swift
@@ -1,0 +1,859 @@
+import Foundation
+import Vapor
+
+public struct OperatorDashboardStoredSnapshot: Codable, Sendable {
+    public static let currentSchemaVersion = 2
+
+    public var schemaVersion: Int
+    public var generatedAt: Date
+
+    public var fastRefreshedAt: Date?
+    public var standardRefreshedAt: Date?
+    public var slowRefreshedAt: Date?
+
+    public var ingestFreshness: StoredIngestFreshnessMetric
+    public var pipelineBacklog: StoredPipelineBacklogMetric
+    public var stuckClaimedRows: StoredStuckClaimedRowsMetric
+    public var staleActiveSeries: StoredStaleActiveSeriesMetric
+    public var endToEndLatency: StoredEndToEndLatencyMetric
+    public var apnsDelivery: StoredAPNsDeliveryMetric
+    public var sendNoOps: StoredSendNoOpsMetric
+    public var zeroCandidateRate: StoredZeroCandidateRateMetric
+    public var targetableCoverage: StoredTargetableCoverageMetric
+    public var h3Derivation: StoredH3DerivationMetric
+    public var recentNotificationDebugEntries: [StoredRecentNotificationDebugEntry]
+    public var touchedSeries: [StoredTouchedSeriesEntry]
+
+    public init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        generatedAt: Date,
+        fastRefreshedAt: Date? = nil,
+        standardRefreshedAt: Date? = nil,
+        slowRefreshedAt: Date? = nil,
+        ingestFreshness: StoredIngestFreshnessMetric = .init(),
+        pipelineBacklog: StoredPipelineBacklogMetric = .init(),
+        stuckClaimedRows: StoredStuckClaimedRowsMetric = .init(),
+        staleActiveSeries: StoredStaleActiveSeriesMetric = .init(),
+        endToEndLatency: StoredEndToEndLatencyMetric = .init(),
+        apnsDelivery: StoredAPNsDeliveryMetric = .init(),
+        sendNoOps: StoredSendNoOpsMetric = .init(),
+        zeroCandidateRate: StoredZeroCandidateRateMetric = .init(),
+        targetableCoverage: StoredTargetableCoverageMetric = .init(),
+        h3Derivation: StoredH3DerivationMetric = .init(),
+        recentNotificationDebugEntries: [StoredRecentNotificationDebugEntry] = [],
+        touchedSeries: [StoredTouchedSeriesEntry] = []
+    ) {
+        self.schemaVersion = schemaVersion
+        self.generatedAt = generatedAt
+        self.fastRefreshedAt = fastRefreshedAt
+        self.standardRefreshedAt = standardRefreshedAt
+        self.slowRefreshedAt = slowRefreshedAt
+        self.ingestFreshness = ingestFreshness
+        self.pipelineBacklog = pipelineBacklog
+        self.stuckClaimedRows = stuckClaimedRows
+        self.staleActiveSeries = staleActiveSeries
+        self.endToEndLatency = endToEndLatency
+        self.apnsDelivery = apnsDelivery
+        self.sendNoOps = sendNoOps
+        self.zeroCandidateRate = zeroCandidateRate
+        self.targetableCoverage = targetableCoverage
+        self.h3Derivation = h3Derivation
+        self.recentNotificationDebugEntries = recentNotificationDebugEntries
+        self.touchedSeries = touchedSeries
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case generatedAt
+        case fastRefreshedAt
+        case standardRefreshedAt
+        case slowRefreshedAt
+        case ingestFreshness
+        case pipelineBacklog
+        case stuckClaimedRows
+        case staleActiveSeries
+        case endToEndLatency
+        case apnsDelivery
+        case sendNoOps
+        case zeroCandidateRate
+        case targetableCoverage
+        case h3Derivation
+        case recentNotificationDebugEntries
+        case touchedSeries
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 0
+        self.generatedAt = try container.decode(Date.self, forKey: .generatedAt)
+        self.fastRefreshedAt = try container.decodeIfPresent(Date.self, forKey: .fastRefreshedAt)
+        self.standardRefreshedAt = try container.decodeIfPresent(Date.self, forKey: .standardRefreshedAt)
+        self.slowRefreshedAt = try container.decodeIfPresent(Date.self, forKey: .slowRefreshedAt)
+        self.ingestFreshness = try container.decode(StoredIngestFreshnessMetric.self, forKey: .ingestFreshness)
+        self.pipelineBacklog = try container.decode(StoredPipelineBacklogMetric.self, forKey: .pipelineBacklog)
+        self.stuckClaimedRows = try container.decode(StoredStuckClaimedRowsMetric.self, forKey: .stuckClaimedRows)
+        self.staleActiveSeries = try container.decode(StoredStaleActiveSeriesMetric.self, forKey: .staleActiveSeries)
+        self.endToEndLatency = try container.decode(StoredEndToEndLatencyMetric.self, forKey: .endToEndLatency)
+        self.apnsDelivery = try container.decode(StoredAPNsDeliveryMetric.self, forKey: .apnsDelivery)
+        self.sendNoOps = try container.decode(StoredSendNoOpsMetric.self, forKey: .sendNoOps)
+        self.zeroCandidateRate = try container.decode(StoredZeroCandidateRateMetric.self, forKey: .zeroCandidateRate)
+        self.targetableCoverage = try container.decode(StoredTargetableCoverageMetric.self, forKey: .targetableCoverage)
+        self.h3Derivation = try container.decode(StoredH3DerivationMetric.self, forKey: .h3Derivation)
+        self.recentNotificationDebugEntries = try container.decode([StoredRecentNotificationDebugEntry].self, forKey: .recentNotificationDebugEntries)
+        self.touchedSeries = try container.decode([StoredTouchedSeriesEntry].self, forKey: .touchedSeries)
+    }
+}
+
+public extension OperatorDashboardStoredSnapshot {
+    static func empty(now: Date = .now) -> Self {
+        .init(generatedAt: now)
+    }
+}
+
+public struct StoredIngestFreshnessMetric: Codable, Sendable {
+    public var recentAttemptLimit: Int
+    public var lastSuccessfulCompletedAt: Date?
+    public var lastAttemptCompletedAt: Date?
+    public var recentSuccessCount: Int
+    public var recentFailureCount: Int
+    public var lastFailureCompletedAt: Date?
+    public var lastFailureMessage: String?
+
+    public init(
+        recentAttemptLimit: Int = OperatorDashboardConfig.ingestRecentAttemptLimit,
+        lastSuccessfulCompletedAt: Date? = nil,
+        lastAttemptCompletedAt: Date? = nil,
+        recentSuccessCount: Int = 0,
+        recentFailureCount: Int = 0,
+        lastFailureCompletedAt: Date? = nil,
+        lastFailureMessage: String? = nil
+    ) {
+        self.recentAttemptLimit = recentAttemptLimit
+        self.lastSuccessfulCompletedAt = lastSuccessfulCompletedAt
+        self.lastAttemptCompletedAt = lastAttemptCompletedAt
+        self.recentSuccessCount = recentSuccessCount
+        self.recentFailureCount = recentFailureCount
+        self.lastFailureCompletedAt = lastFailureCompletedAt
+        self.lastFailureMessage = lastFailureMessage
+    }
+}
+
+public struct StoredPipelineBacklogMetric: Codable, Sendable {
+    public var pendingTargetDispatchCount: Int
+    public var oldestPendingTargetDispatchCreatedAt: Date?
+    public var pendingNotificationDispatchCount: Int
+    public var oldestPendingNotificationDispatchCreatedAt: Date?
+
+    public init(
+        pendingTargetDispatchCount: Int = 0,
+        oldestPendingTargetDispatchCreatedAt: Date? = nil,
+        pendingNotificationDispatchCount: Int = 0,
+        oldestPendingNotificationDispatchCreatedAt: Date? = nil
+    ) {
+        self.pendingTargetDispatchCount = pendingTargetDispatchCount
+        self.oldestPendingTargetDispatchCreatedAt = oldestPendingTargetDispatchCreatedAt
+        self.pendingNotificationDispatchCount = pendingNotificationDispatchCount
+        self.oldestPendingNotificationDispatchCreatedAt = oldestPendingNotificationDispatchCreatedAt
+    }
+}
+
+public struct StoredStuckClaimedRowsMetric: Codable, Sendable {
+    public var thresholdSeconds: Int
+    public var count: Int
+    public var oldestClaimedCreatedAt: Date?
+
+    public init(
+        thresholdSeconds: Int = OperatorDashboardConfig.claimedStuckThresholdSeconds,
+        count: Int = 0,
+        oldestClaimedCreatedAt: Date? = nil
+    ) {
+        self.thresholdSeconds = thresholdSeconds
+        self.count = count
+        self.oldestClaimedCreatedAt = oldestClaimedCreatedAt
+    }
+}
+
+public struct StoredStaleActiveSeriesMetric: Codable, Sendable {
+    public var graceSeconds: Int
+    public var count: Int
+
+    public init(
+        graceSeconds: Int = OperatorDashboardConfig.staleActiveSeriesGraceSeconds,
+        count: Int = 0
+    ) {
+        self.graceSeconds = graceSeconds
+        self.count = count
+    }
+}
+
+public struct StoredEndToEndLatencyMetric: Codable, Sendable {
+    public var windowHours: Int
+    public var successfulRevisionCount: Int
+    public var p95Seconds: Double?
+
+    public init(
+        windowHours: Int = OperatorDashboardConfig.rollingWindowHours,
+        successfulRevisionCount: Int = 0,
+        p95Seconds: Double? = nil
+    ) {
+        self.windowHours = windowHours
+        self.successfulRevisionCount = successfulRevisionCount
+        self.p95Seconds = p95Seconds
+    }
+}
+
+public struct StoredReasonCount: Codable, Sendable {
+    public var reason: String
+    public var count: Int
+
+    public init(reason: String, count: Int) {
+        self.reason = reason
+        self.count = count
+    }
+}
+
+public struct StoredAPNsDeliveryMetric: Codable, Sendable {
+    public var windowHours: Int
+    public var sentCount: Int
+    public var failedCount: Int
+    public var topFailureReasons: [StoredReasonCount]
+
+    public init(
+        windowHours: Int = OperatorDashboardConfig.rollingWindowHours,
+        sentCount: Int = 0,
+        failedCount: Int = 0,
+        topFailureReasons: [StoredReasonCount] = []
+    ) {
+        self.windowHours = windowHours
+        self.sentCount = sentCount
+        self.failedCount = failedCount
+        self.topFailureReasons = topFailureReasons
+    }
+}
+
+public struct StoredSendNoOpsMetric: Codable, Sendable {
+    public var windowHours: Int
+    public var totalAttemptCount: Int
+    public var noOpAttemptCount: Int
+    public var reasons: [StoredReasonCount]
+
+    public init(
+        windowHours: Int = OperatorDashboardConfig.rollingWindowHours,
+        totalAttemptCount: Int = 0,
+        noOpAttemptCount: Int = 0,
+        reasons: [StoredReasonCount] = []
+    ) {
+        self.windowHours = windowHours
+        self.totalAttemptCount = totalAttemptCount
+        self.noOpAttemptCount = noOpAttemptCount
+        self.reasons = reasons
+    }
+}
+
+public struct StoredZeroCandidateRateMetric: Codable, Sendable {
+    public var windowHours: Int
+    public var candidateResolutionAttemptCount: Int
+    public var zeroCandidateAttemptCount: Int
+
+    public init(
+        windowHours: Int = OperatorDashboardConfig.rollingWindowHours,
+        candidateResolutionAttemptCount: Int = 0,
+        zeroCandidateAttemptCount: Int = 0
+    ) {
+        self.windowHours = windowHours
+        self.candidateResolutionAttemptCount = candidateResolutionAttemptCount
+        self.zeroCandidateAttemptCount = zeroCandidateAttemptCount
+    }
+}
+
+public struct StoredTargetableCoverageBreakdown: Codable, Sendable {
+    public var missingDeviceTokenCount: Int
+    public var staleInstallationHeartbeatCount: Int
+    public var stalePresenceCount: Int
+    public var missingTargetingDataCount: Int
+
+    public init(
+        missingDeviceTokenCount: Int = 0,
+        staleInstallationHeartbeatCount: Int = 0,
+        stalePresenceCount: Int = 0,
+        missingTargetingDataCount: Int = 0
+    ) {
+        self.missingDeviceTokenCount = missingDeviceTokenCount
+        self.staleInstallationHeartbeatCount = staleInstallationHeartbeatCount
+        self.stalePresenceCount = stalePresenceCount
+        self.missingTargetingDataCount = missingTargetingDataCount
+    }
+}
+
+public struct StoredTargetableCoverageMetric: Codable, Sendable {
+    public var installationFreshnessSeconds: Int
+    public var presenceFreshnessSeconds: Int
+    public var activeSubscribedInstallationCount: Int
+    public var targetableInstallationCount: Int
+    public var lossBreakdown: StoredTargetableCoverageBreakdown
+
+    public init(
+        installationFreshnessSeconds: Int = OperatorDashboardConfig.installationFreshnessThresholdSeconds,
+        presenceFreshnessSeconds: Int = OperatorDashboardConfig.presenceFreshnessThresholdSeconds,
+        activeSubscribedInstallationCount: Int = 0,
+        targetableInstallationCount: Int = 0,
+        lossBreakdown: StoredTargetableCoverageBreakdown = .init()
+    ) {
+        self.installationFreshnessSeconds = installationFreshnessSeconds
+        self.presenceFreshnessSeconds = presenceFreshnessSeconds
+        self.activeSubscribedInstallationCount = activeSubscribedInstallationCount
+        self.targetableInstallationCount = targetableInstallationCount
+        self.lossBreakdown = lossBreakdown
+    }
+}
+
+public struct StoredH3DerivationMetric: Codable, Sendable {
+    public var windowHours: Int
+    public var geometryBearingRevisionCount: Int
+    public var successfulConversionCount: Int
+    public var p95ConversionSeconds: Double?
+
+    public init(
+        windowHours: Int = OperatorDashboardConfig.rollingWindowHours,
+        geometryBearingRevisionCount: Int = 0,
+        successfulConversionCount: Int = 0,
+        p95ConversionSeconds: Double? = nil
+    ) {
+        self.windowHours = windowHours
+        self.geometryBearingRevisionCount = geometryBearingRevisionCount
+        self.successfulConversionCount = successfulConversionCount
+        self.p95ConversionSeconds = p95ConversionSeconds
+    }
+}
+
+public struct StoredRecentNotificationDebugEntry: Codable, Sendable {
+    public var createdAt: Date
+    public var seriesID: UUID
+    public var eventName: String
+    public var recordKind: String
+    public var mode: String
+    public var reason: String
+    public var title: String
+    public var subtitle: String
+    public var body: String
+    public var ledgerStatus: String?
+    public var apnsErrorCode: String?
+
+    public init(
+        createdAt: Date,
+        seriesID: UUID,
+        eventName: String,
+        recordKind: String,
+        mode: String,
+        reason: String,
+        title: String,
+        subtitle: String,
+        body: String,
+        ledgerStatus: String?,
+        apnsErrorCode: String?
+    ) {
+        self.createdAt = createdAt
+        self.seriesID = seriesID
+        self.eventName = eventName
+        self.recordKind = recordKind
+        self.mode = mode
+        self.reason = reason
+        self.title = title
+        self.subtitle = subtitle
+        self.body = body
+        self.ledgerStatus = ledgerStatus
+        self.apnsErrorCode = apnsErrorCode
+    }
+}
+
+public struct StoredTouchedSeriesEntry: Codable, Sendable {
+    public var seriesID: UUID
+    public var eventName: String
+    public var state: String
+    public var ugcCodes: [String]
+    public var tornadoDetection: String?
+    public var tornadoDamageThreat: String?
+    public var currentRevisionUrn: String
+    public var touchedAt: Date
+    public var latestRevisionReceivedAt: Date?
+    public var seriesUpdatedAt: Date?
+
+    public init(
+        seriesID: UUID,
+        eventName: String,
+        state: String,
+        ugcCodes: [String] = [],
+        tornadoDetection: String? = nil,
+        tornadoDamageThreat: String? = nil,
+        currentRevisionUrn: String,
+        touchedAt: Date,
+        latestRevisionReceivedAt: Date?,
+        seriesUpdatedAt: Date?
+    ) {
+        self.seriesID = seriesID
+        self.eventName = eventName
+        self.state = state
+        self.ugcCodes = ugcCodes
+        self.tornadoDetection = tornadoDetection
+        self.tornadoDamageThreat = tornadoDamageThreat
+        self.currentRevisionUrn = currentRevisionUrn
+        self.touchedAt = touchedAt
+        self.latestRevisionReceivedAt = latestRevisionReceivedAt
+        self.seriesUpdatedAt = seriesUpdatedAt
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case seriesID
+        case eventName
+        case state
+        case ugcCodes
+        case tornadoDetection
+        case tornadoDamageThreat
+        case currentRevisionUrn
+        case touchedAt
+        case latestRevisionReceivedAt
+        case seriesUpdatedAt
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.seriesID = try container.decode(UUID.self, forKey: .seriesID)
+        self.eventName = try container.decode(String.self, forKey: .eventName)
+        self.state = try container.decode(String.self, forKey: .state)
+        self.ugcCodes = try container.decodeIfPresent([String].self, forKey: .ugcCodes) ?? []
+        self.tornadoDetection = try container.decodeIfPresent(String.self, forKey: .tornadoDetection)
+        self.tornadoDamageThreat = try container.decodeIfPresent(String.self, forKey: .tornadoDamageThreat)
+        self.currentRevisionUrn = try container.decode(String.self, forKey: .currentRevisionUrn)
+        self.touchedAt = try container.decode(Date.self, forKey: .touchedAt)
+        self.latestRevisionReceivedAt = try container.decodeIfPresent(Date.self, forKey: .latestRevisionReceivedAt)
+        self.seriesUpdatedAt = try container.decodeIfPresent(Date.self, forKey: .seriesUpdatedAt)
+    }
+}
+
+public struct OperatorDashboardSnapshotResponse: Content, Sendable {
+    public var renderedAt: Date
+    public var generatedAt: Date
+    public var redLights: OperatorDashboardRedLightsSectionResponse
+    public var deliveryKPIs: OperatorDashboardDeliveryKPIsSectionResponse
+    public var audienceTargeting: OperatorDashboardAudienceTargetingSectionResponse
+    public var operatorContext: OperatorDashboardOperatorContextSectionResponse
+
+    public init(snapshot: OperatorDashboardStoredSnapshot, renderedAt: Date = .now) {
+        self.renderedAt = renderedAt
+        self.generatedAt = snapshot.generatedAt
+        self.redLights = .init(snapshot: snapshot, renderedAt: renderedAt)
+        self.deliveryKPIs = .init(snapshot: snapshot, renderedAt: renderedAt)
+        self.audienceTargeting = .init(snapshot: snapshot, renderedAt: renderedAt)
+        self.operatorContext = .init(snapshot: snapshot)
+    }
+}
+
+public struct OperatorDashboardRedLightsSectionResponse: Content, Sendable {
+    public var ingestFreshness: IngestFreshnessMetricResponse
+    public var pipelineBacklogAge: PipelineBacklogMetricResponse
+    public var stuckClaimedRows: StuckClaimedRowsMetricResponse
+    public var staleActiveSeriesCount: StaleActiveSeriesMetricResponse
+
+    init(snapshot: OperatorDashboardStoredSnapshot, renderedAt: Date) {
+        self.ingestFreshness = .init(
+            refreshedAt: snapshot.fastRefreshedAt,
+            renderedAt: renderedAt,
+            metric: snapshot.ingestFreshness
+        )
+        self.pipelineBacklogAge = .init(
+            refreshedAt: snapshot.fastRefreshedAt,
+            renderedAt: renderedAt,
+            metric: snapshot.pipelineBacklog
+        )
+        self.stuckClaimedRows = .init(
+            refreshedAt: snapshot.fastRefreshedAt,
+            renderedAt: renderedAt,
+            metric: snapshot.stuckClaimedRows
+        )
+        self.staleActiveSeriesCount = .init(
+            refreshedAt: snapshot.standardRefreshedAt,
+            metric: snapshot.staleActiveSeries
+        )
+    }
+}
+
+public struct OperatorDashboardDeliveryKPIsSectionResponse: Content, Sendable {
+    public var endToEndAlertLatency: EndToEndLatencyMetricResponse
+    public var apnsDeliverySuccessRate: APNsDeliveryMetricResponse
+    public var sendNoOpRateByReason: SendNoOpsMetricResponse
+    public var zeroCandidateRevisionRate: ZeroCandidateRateMetricResponse
+
+    init(snapshot: OperatorDashboardStoredSnapshot, renderedAt: Date) {
+        self.endToEndAlertLatency = .init(
+            refreshedAt: snapshot.slowRefreshedAt,
+            metric: snapshot.endToEndLatency
+        )
+        self.apnsDeliverySuccessRate = .init(
+            refreshedAt: snapshot.slowRefreshedAt,
+            metric: snapshot.apnsDelivery
+        )
+        self.sendNoOpRateByReason = .init(
+            refreshedAt: snapshot.standardRefreshedAt,
+            metric: snapshot.sendNoOps
+        )
+        self.zeroCandidateRevisionRate = .init(
+            refreshedAt: snapshot.standardRefreshedAt,
+            metric: snapshot.zeroCandidateRate
+        )
+        _ = renderedAt
+    }
+}
+
+public struct OperatorDashboardAudienceTargetingSectionResponse: Content, Sendable {
+    public var freshTargetableInstallationCoverage: TargetableCoverageMetricResponse
+    public var alertsWithGeographyAndH3Success: H3DerivationMetricResponse
+
+    init(snapshot: OperatorDashboardStoredSnapshot, renderedAt: Date) {
+        self.freshTargetableInstallationCoverage = .init(
+            refreshedAt: snapshot.slowRefreshedAt,
+            metric: snapshot.targetableCoverage
+        )
+        self.alertsWithGeographyAndH3Success = .init(
+            refreshedAt: snapshot.standardRefreshedAt,
+            metric: snapshot.h3Derivation
+        )
+        _ = renderedAt
+    }
+}
+
+public struct OperatorDashboardOperatorContextSectionResponse: Content, Sendable {
+    public var recentNotificationDebugEntries: RecentNotificationDebugEntriesResponse
+    public var lastTouchedSeries: LastTouchedSeriesResponse
+
+    init(snapshot: OperatorDashboardStoredSnapshot) {
+        self.recentNotificationDebugEntries = .init(
+            refreshedAt: snapshot.fastRefreshedAt,
+            entries: snapshot.recentNotificationDebugEntries
+        )
+        self.lastTouchedSeries = .init(
+            refreshedAt: snapshot.fastRefreshedAt,
+            entries: snapshot.touchedSeries
+        )
+    }
+}
+
+public struct IngestFreshnessMetricResponse: Content, Sendable {
+    public var refreshedAt: Date?
+    public var lastSuccessfulSweepAt: Date?
+    public var timeSinceLastSuccessfulSweepSeconds: Int?
+    public var lastAttemptAt: Date?
+    public var recentAttemptLimit: Int
+    public var recentSuccessCount: Int
+    public var recentFailureCount: Int
+    public var lastFailureAt: Date?
+    public var lastFailureMessage: String?
+
+    init(refreshedAt: Date?, renderedAt: Date, metric: StoredIngestFreshnessMetric) {
+        self.refreshedAt = refreshedAt
+        self.lastSuccessfulSweepAt = metric.lastSuccessfulCompletedAt
+        self.timeSinceLastSuccessfulSweepSeconds = OperatorDashboardCalculations.ageSeconds(
+            since: metric.lastSuccessfulCompletedAt,
+            renderedAt: renderedAt
+        )
+        self.lastAttemptAt = metric.lastAttemptCompletedAt
+        self.recentAttemptLimit = metric.recentAttemptLimit
+        self.recentSuccessCount = metric.recentSuccessCount
+        self.recentFailureCount = metric.recentFailureCount
+        self.lastFailureAt = metric.lastFailureCompletedAt
+        self.lastFailureMessage = metric.lastFailureMessage
+    }
+}
+
+public struct PipelineBacklogMetricResponse: Content, Sendable {
+    public var refreshedAt: Date?
+    public var pendingTargetDispatchCount: Int
+    public var oldestPendingTargetDispatchCreatedAt: Date?
+    public var oldestPendingTargetDispatchAgeSeconds: Int?
+    public var pendingNotificationDispatchCount: Int
+    public var oldestPendingNotificationDispatchCreatedAt: Date?
+    public var oldestPendingNotificationDispatchAgeSeconds: Int?
+
+    init(refreshedAt: Date?, renderedAt: Date, metric: StoredPipelineBacklogMetric) {
+        self.refreshedAt = refreshedAt
+        self.pendingTargetDispatchCount = metric.pendingTargetDispatchCount
+        self.oldestPendingTargetDispatchCreatedAt = metric.oldestPendingTargetDispatchCreatedAt
+        self.oldestPendingTargetDispatchAgeSeconds = OperatorDashboardCalculations.ageSeconds(
+            since: metric.oldestPendingTargetDispatchCreatedAt,
+            renderedAt: renderedAt
+        )
+        self.pendingNotificationDispatchCount = metric.pendingNotificationDispatchCount
+        self.oldestPendingNotificationDispatchCreatedAt = metric.oldestPendingNotificationDispatchCreatedAt
+        self.oldestPendingNotificationDispatchAgeSeconds = OperatorDashboardCalculations.ageSeconds(
+            since: metric.oldestPendingNotificationDispatchCreatedAt,
+            renderedAt: renderedAt
+        )
+    }
+}
+
+public struct StuckClaimedRowsMetricResponse: Content, Sendable {
+    public var refreshedAt: Date?
+    public var thresholdSeconds: Int
+    public var count: Int
+    public var oldestClaimedCreatedAt: Date?
+    public var oldestClaimedAgeSeconds: Int?
+
+    init(refreshedAt: Date?, renderedAt: Date, metric: StoredStuckClaimedRowsMetric) {
+        self.refreshedAt = refreshedAt
+        self.thresholdSeconds = metric.thresholdSeconds
+        self.count = metric.count
+        self.oldestClaimedCreatedAt = metric.oldestClaimedCreatedAt
+        self.oldestClaimedAgeSeconds = OperatorDashboardCalculations.ageSeconds(
+            since: metric.oldestClaimedCreatedAt,
+            renderedAt: renderedAt
+        )
+    }
+}
+
+public struct StaleActiveSeriesMetricResponse: Content, Sendable {
+    public var refreshedAt: Date?
+    public var graceSeconds: Int
+    public var count: Int
+
+    init(refreshedAt: Date?, metric: StoredStaleActiveSeriesMetric) {
+        self.refreshedAt = refreshedAt
+        self.graceSeconds = metric.graceSeconds
+        self.count = metric.count
+    }
+}
+
+public struct EndToEndLatencyMetricResponse: Content, Sendable {
+    public var refreshedAt: Date?
+    public var windowHours: Int
+    public var successfulRevisionCount: Int
+    public var p95Seconds: Double?
+
+    init(refreshedAt: Date?, metric: StoredEndToEndLatencyMetric) {
+        self.refreshedAt = refreshedAt
+        self.windowHours = metric.windowHours
+        self.successfulRevisionCount = metric.successfulRevisionCount
+        self.p95Seconds = metric.p95Seconds
+    }
+}
+
+public struct ReasonBreakdownResponse: Content, Sendable {
+    public var reason: String
+    public var count: Int
+    public var rate: Double?
+
+    init(reason: String, count: Int, denominator: Int) {
+        self.reason = reason
+        self.count = count
+        self.rate = OperatorDashboardCalculations.rate(
+            numerator: count,
+            denominator: denominator
+        )
+    }
+}
+
+public struct APNsDeliveryMetricResponse: Content, Sendable {
+    public var refreshedAt: Date?
+    public var windowHours: Int
+    public var sentCount: Int
+    public var failedCount: Int
+    public var successRate: Double?
+    public var topFailureReasons: [ReasonBreakdownResponse]
+
+    init(refreshedAt: Date?, metric: StoredAPNsDeliveryMetric) {
+        let denominator = metric.sentCount + metric.failedCount
+        self.refreshedAt = refreshedAt
+        self.windowHours = metric.windowHours
+        self.sentCount = metric.sentCount
+        self.failedCount = metric.failedCount
+        self.successRate = OperatorDashboardCalculations.rate(
+            numerator: metric.sentCount,
+            denominator: denominator
+        )
+        self.topFailureReasons = metric.topFailureReasons.map {
+            .init(reason: $0.reason, count: $0.count, denominator: metric.failedCount)
+        }
+    }
+}
+
+public struct SendNoOpsMetricResponse: Content, Sendable {
+    public var refreshedAt: Date?
+    public var windowHours: Int
+    public var totalAttemptCount: Int
+    public var noOpAttemptCount: Int
+    public var noOpRate: Double?
+    public var reasons: [ReasonBreakdownResponse]
+
+    init(refreshedAt: Date?, metric: StoredSendNoOpsMetric) {
+        self.refreshedAt = refreshedAt
+        self.windowHours = metric.windowHours
+        self.totalAttemptCount = metric.totalAttemptCount
+        self.noOpAttemptCount = metric.noOpAttemptCount
+        self.noOpRate = OperatorDashboardCalculations.rate(
+            numerator: metric.noOpAttemptCount,
+            denominator: metric.totalAttemptCount
+        )
+        self.reasons = metric.reasons.map {
+            .init(reason: $0.reason, count: $0.count, denominator: metric.totalAttemptCount)
+        }
+    }
+}
+
+public struct ZeroCandidateRateMetricResponse: Content, Sendable {
+    public var refreshedAt: Date?
+    public var windowHours: Int
+    public var candidateResolutionAttemptCount: Int
+    public var zeroCandidateAttemptCount: Int
+    public var zeroCandidateRate: Double?
+
+    init(refreshedAt: Date?, metric: StoredZeroCandidateRateMetric) {
+        self.refreshedAt = refreshedAt
+        self.windowHours = metric.windowHours
+        self.candidateResolutionAttemptCount = metric.candidateResolutionAttemptCount
+        self.zeroCandidateAttemptCount = metric.zeroCandidateAttemptCount
+        self.zeroCandidateRate = OperatorDashboardCalculations.rate(
+            numerator: metric.zeroCandidateAttemptCount,
+            denominator: metric.candidateResolutionAttemptCount
+        )
+    }
+}
+
+public struct TargetableCoverageBreakdownResponse: Content, Sendable {
+    public var missingDeviceTokenCount: Int
+    public var staleInstallationHeartbeatCount: Int
+    public var stalePresenceCount: Int
+    public var missingTargetingDataCount: Int
+}
+
+public struct TargetableCoverageMetricResponse: Content, Sendable {
+    public var refreshedAt: Date?
+    public var installationFreshnessSeconds: Int
+    public var presenceFreshnessSeconds: Int
+    public var activeSubscribedInstallationCount: Int
+    public var targetableInstallationCount: Int
+    public var targetableRate: Double?
+    public var lossBreakdown: TargetableCoverageBreakdownResponse
+
+    init(refreshedAt: Date?, metric: StoredTargetableCoverageMetric) {
+        self.refreshedAt = refreshedAt
+        self.installationFreshnessSeconds = metric.installationFreshnessSeconds
+        self.presenceFreshnessSeconds = metric.presenceFreshnessSeconds
+        self.activeSubscribedInstallationCount = metric.activeSubscribedInstallationCount
+        self.targetableInstallationCount = metric.targetableInstallationCount
+        self.targetableRate = OperatorDashboardCalculations.rate(
+            numerator: metric.targetableInstallationCount,
+            denominator: metric.activeSubscribedInstallationCount
+        )
+        self.lossBreakdown = .init(
+            missingDeviceTokenCount: metric.lossBreakdown.missingDeviceTokenCount,
+            staleInstallationHeartbeatCount: metric.lossBreakdown.staleInstallationHeartbeatCount,
+            stalePresenceCount: metric.lossBreakdown.stalePresenceCount,
+            missingTargetingDataCount: metric.lossBreakdown.missingTargetingDataCount
+        )
+    }
+}
+
+public struct H3DerivationMetricResponse: Content, Sendable {
+    public var refreshedAt: Date?
+    public var windowHours: Int
+    public var geometryBearingRevisionCount: Int
+    public var successfulConversionCount: Int
+    public var successRate: Double?
+    public var p95ConversionSeconds: Double?
+
+    init(refreshedAt: Date?, metric: StoredH3DerivationMetric) {
+        self.refreshedAt = refreshedAt
+        self.windowHours = metric.windowHours
+        self.geometryBearingRevisionCount = metric.geometryBearingRevisionCount
+        self.successfulConversionCount = metric.successfulConversionCount
+        self.successRate = OperatorDashboardCalculations.rate(
+            numerator: metric.successfulConversionCount,
+            denominator: metric.geometryBearingRevisionCount
+        )
+        self.p95ConversionSeconds = metric.p95ConversionSeconds
+    }
+}
+
+public struct RecentNotificationDebugEntryResponse: Content, Sendable {
+    public var createdAt: Date
+    public var seriesID: UUID
+    public var eventName: String
+    public var recordKind: String
+    public var mode: String
+    public var reason: String
+    public var title: String
+    public var subtitle: String
+    public var body: String
+    public var ledgerStatus: String?
+    public var apnsErrorCode: String?
+}
+
+public struct RecentNotificationDebugEntriesResponse: Content, Sendable {
+    public var refreshedAt: Date?
+    public var entries: [RecentNotificationDebugEntryResponse]
+
+    init(refreshedAt: Date?, entries: [StoredRecentNotificationDebugEntry]) {
+        self.refreshedAt = refreshedAt
+        self.entries = entries.map {
+            .init(
+                createdAt: $0.createdAt,
+                seriesID: $0.seriesID,
+                eventName: $0.eventName,
+                recordKind: $0.recordKind,
+                mode: $0.mode,
+                reason: $0.reason,
+                title: $0.title,
+                subtitle: $0.subtitle,
+                body: $0.body,
+                ledgerStatus: $0.ledgerStatus,
+                apnsErrorCode: $0.apnsErrorCode
+            )
+        }
+    }
+}
+
+public struct TouchedSeriesEntryResponse: Content, Sendable {
+    public var seriesID: UUID
+    public var eventName: String
+    public var state: String
+    public var ugcCodes: [String]
+    public var tornadoDetection: String?
+    public var tornadoDamageThreat: String?
+    public var currentRevisionUrn: String
+    public var touchedAt: Date
+    public var latestRevisionReceivedAt: Date?
+    public var seriesUpdatedAt: Date?
+}
+
+public struct LastTouchedSeriesResponse: Content, Sendable {
+    public var refreshedAt: Date?
+    public var entries: [TouchedSeriesEntryResponse]
+
+    init(refreshedAt: Date?, entries: [StoredTouchedSeriesEntry]) {
+        self.refreshedAt = refreshedAt
+        self.entries = entries.map {
+            .init(
+                seriesID: $0.seriesID,
+                eventName: $0.eventName,
+                state: $0.state,
+                ugcCodes: $0.ugcCodes,
+                tornadoDetection: $0.tornadoDetection,
+                tornadoDamageThreat: $0.tornadoDamageThreat,
+                currentRevisionUrn: $0.currentRevisionUrn,
+                touchedAt: $0.touchedAt,
+                latestRevisionReceivedAt: $0.latestRevisionReceivedAt,
+                seriesUpdatedAt: $0.seriesUpdatedAt
+            )
+        }
+    }
+}
+
+enum OperatorDashboardCalculations {
+    static func ageSeconds(since date: Date?, renderedAt: Date) -> Int? {
+        guard let date else { return nil }
+        return max(0, Int(renderedAt.timeIntervalSince(date)))
+    }
+
+    static func rate(numerator: Int, denominator: Int) -> Double? {
+        guard denominator > 0 else { return nil }
+        return Double(numerator) / Double(denominator)
+    }
+}

--- a/Sources/App/Models/Data/ArcusTargetDispatchOutboxModel.swift
+++ b/Sources/App/Models/Data/ArcusTargetDispatchOutboxModel.swift
@@ -28,6 +28,12 @@ public final class ArcusTargetDispatchOutboxModel: Model, @unchecked Sendable {
     @OptionalField(key: "dispatched")
     public var dispatched: Date?
 
+    @OptionalField(key: "completed")
+    public var completed: Date?
+
+    @OptionalField(key: "result")
+    public var result: String?
+
     public init() {}
 
     public init(
@@ -38,7 +44,9 @@ public final class ArcusTargetDispatchOutboxModel: Model, @unchecked Sendable {
         attemptCount: Int = 0,
         lastError: String? = nil,
         created: Date = .now,
-        dispatched: Date? = nil
+        dispatched: Date? = nil,
+        completed: Date? = nil,
+        result: String? = nil
     ) {
         self.id = id
         self.revisionUrn = revisionUrn
@@ -48,5 +56,7 @@ public final class ArcusTargetDispatchOutboxModel: Model, @unchecked Sendable {
         self.lastError = lastError
         self.created = created
         self.dispatched = dispatched
+        self.completed = completed
+        self.result = result
     }
 }

--- a/Sources/App/Models/Data/IngestSweepRunModel.swift
+++ b/Sources/App/Models/Data/IngestSweepRunModel.swift
@@ -1,0 +1,82 @@
+import Fluent
+import Foundation
+
+public enum IngestSweepRunStatus: String, Codable, Sendable {
+    case succeeded
+    case failed
+}
+
+public final class IngestSweepRunModel: Model, @unchecked Sendable {
+    public static let schema = "ingest_sweep_runs"
+
+    @ID(key: .id)
+    public var id: UUID?
+
+    @Field(key: "source")
+    public var source: String
+
+    @OptionalField(key: "fixture_name")
+    public var fixtureName: String?
+
+    @OptionalField(key: "run_label")
+    public var runLabel: String?
+
+    @Field(key: "status")
+    public var status: String
+
+    @Field(key: "started_at")
+    public var startedAt: Date
+
+    @Field(key: "completed_at")
+    public var completedAt: Date
+
+    @OptionalField(key: "event_count")
+    public var eventCount: Int?
+
+    @OptionalField(key: "new_series_count")
+    public var newSeriesCount: Int?
+
+    @OptionalField(key: "new_revision_count")
+    public var newRevisionCount: Int?
+
+    @OptionalField(key: "target_outbox_queued_count")
+    public var targetOutboxQueuedCount: Int?
+
+    @OptionalField(key: "notification_outbox_queued_count")
+    public var notificationOutboxQueuedCount: Int?
+
+    @OptionalField(key: "error_message")
+    public var errorMessage: String?
+
+    public init() {}
+
+    public init(
+        id: UUID? = nil,
+        source: String,
+        fixtureName: String? = nil,
+        runLabel: String? = nil,
+        status: IngestSweepRunStatus,
+        startedAt: Date,
+        completedAt: Date,
+        eventCount: Int? = nil,
+        newSeriesCount: Int? = nil,
+        newRevisionCount: Int? = nil,
+        targetOutboxQueuedCount: Int? = nil,
+        notificationOutboxQueuedCount: Int? = nil,
+        errorMessage: String? = nil
+    ) {
+        self.id = id
+        self.source = source
+        self.fixtureName = fixtureName
+        self.runLabel = runLabel
+        self.status = status.rawValue
+        self.startedAt = startedAt
+        self.completedAt = completedAt
+        self.eventCount = eventCount
+        self.newSeriesCount = newSeriesCount
+        self.newRevisionCount = newRevisionCount
+        self.targetOutboxQueuedCount = targetOutboxQueuedCount
+        self.notificationOutboxQueuedCount = notificationOutboxQueuedCount
+        self.errorMessage = errorMessage
+    }
+}

--- a/Sources/App/Models/Data/OperatorDashboardSnapshotModel.swift
+++ b/Sources/App/Models/Data/OperatorDashboardSnapshotModel.swift
@@ -1,0 +1,28 @@
+import Fluent
+import Foundation
+
+public final class OperatorDashboardSnapshotModel: Model, @unchecked Sendable {
+    public static let schema = "operator_dashboard_snapshots"
+
+    @ID(custom: "id", generatedBy: .user)
+    public var id: String?
+
+    @Field(key: "snapshot")
+    public var snapshot: OperatorDashboardStoredSnapshot
+
+    @Timestamp(key: "created_at", on: .create)
+    public var createdAt: Date?
+
+    @Timestamp(key: "updated_at", on: .update)
+    public var updatedAt: Date?
+
+    public init() {}
+
+    public init(
+        id: String = OperatorDashboardSnapshotStoreConstants.snapshotID,
+        snapshot: OperatorDashboardStoredSnapshot
+    ) {
+        self.id = id
+        self.snapshot = snapshot
+    }
+}

--- a/Sources/App/Models/Notification/NotificationLedgerModel.swift
+++ b/Sources/App/Models/Notification/NotificationLedgerModel.swift
@@ -35,6 +35,9 @@ public final class NotificationLedgerModel: Model, @unchecked Sendable, Content 
     
     @OptionalField(key: "apns_error_code")
     public var apnsErrorCode: String?
+
+    @OptionalField(key: "completed_at")
+    public var completedAt: Date?
     
     // Bookkeeping
     @Timestamp(key: "created", on: .create)
@@ -49,7 +52,8 @@ public final class NotificationLedgerModel: Model, @unchecked Sendable, Content 
         revisionUrn: String,
         mode: String,
         reason: String,
-        status: String?
+        status: String?,
+        completedAt: Date? = nil
     ) {
         self.id = id
         self.$deviceInstallation.id = installationId
@@ -58,5 +62,6 @@ public final class NotificationLedgerModel: Model, @unchecked Sendable, Content 
         self.mode = mode
         self.reason = reason
         self.status = status
+        self.completedAt = completedAt
     }
 }

--- a/Sources/App/Models/Notification/NotificationSendAttemptModel.swift
+++ b/Sources/App/Models/Notification/NotificationSendAttemptModel.swift
@@ -1,0 +1,90 @@
+import Fluent
+import Foundation
+
+public enum NotificationSendAttemptOutcome: String, Codable, Sendable {
+    case delivered
+    case noOp = "no_op"
+    case failed
+}
+
+public enum NotificationSendNoOpReason: String, Codable, Sendable {
+    case staleRevisionMismatch = "stale_revision_mismatch"
+    case missingGeolocation = "missing_geolocation"
+    case zeroCandidates = "zero_candidates"
+    case allCandidatesPreviouslyClaimed = "all_candidates_previously_claimed"
+}
+
+public final class NotificationSendAttemptModel: Model, @unchecked Sendable {
+    public static let schema = "notification_send_attempts"
+
+    @ID(key: .id)
+    public var id: UUID?
+
+    @Parent(key: "series_id")
+    public var series: ArcusSeriesModel
+
+    @Field(key: "revision_urn")
+    public var revisionUrn: String
+
+    @Field(key: "mode")
+    public var mode: String
+
+    @Field(key: "reason")
+    public var reason: String
+
+    @Field(key: "outcome")
+    public var outcome: String
+
+    @OptionalField(key: "no_op_reason")
+    public var noOpReason: String?
+
+    @Field(key: "candidate_resolution_reached")
+    public var candidateResolutionReached: Bool
+
+    @Field(key: "candidate_count")
+    public var candidateCount: Int
+
+    @Field(key: "claimed_count")
+    public var claimedCount: Int
+
+    @Field(key: "sent_count")
+    public var sentCount: Int
+
+    @Field(key: "failed_count")
+    public var failedCount: Int
+
+    @Field(key: "attempted_at")
+    public var attemptedAt: Date
+
+    public init() {}
+
+    public init(
+        id: UUID? = nil,
+        seriesID: UUID,
+        revisionUrn: String,
+        mode: NotificationTargetMode,
+        reason: NotificationReason,
+        outcome: NotificationSendAttemptOutcome,
+        noOpReason: NotificationSendNoOpReason? = nil,
+        candidateResolutionReached: Bool,
+        candidateCount: Int,
+        claimedCount: Int,
+        sentCount: Int,
+        failedCount: Int,
+        attemptedAt: Date = .now
+    ) {
+        self.id = id
+        self.$series.id = seriesID
+        self.revisionUrn = revisionUrn
+        self.mode = mode.rawValue
+        self.reason = reason.rawValue
+        self.outcome = outcome.rawValue
+        self.noOpReason = noOpReason?.rawValue
+        self.candidateResolutionReached = candidateResolutionReached
+        self.candidateCount = candidateCount
+        self.claimedCount = claimedCount
+        self.sentCount = sentCount
+        self.failedCount = failedCount
+        self.attemptedAt = attemptedAt
+    }
+}

--- a/Sources/App/Worker/WorkerRuntime.swift
+++ b/Sources/App/Worker/WorkerRuntime.swift
@@ -60,5 +60,16 @@ public final class WorkerRuntime: LifecycleHandler, @unchecked Sendable {
         }
         try app.queues.startScheduledJobs()
         app.logger.info("Worker scheduled jobs started.")
+
+        Task {
+            do {
+                try await OperatorDashboardSnapshotRefresher().refreshIfDue(on: app, forceAll: true)
+            } catch {
+                app.logger.error(
+                    "Failed to bootstrap operator dashboard snapshot.",
+                    metadata: ["error": .string(String(reflecting: error))]
+                )
+            }
+        }
     }
 }

--- a/Sources/App/apiRoutes.swift
+++ b/Sources/App/apiRoutes.swift
@@ -10,6 +10,7 @@ func configureAPIRoutes(_ app: Application) throws {
     try app.register(collection: NotificationsController())
     try app.register(collection: AlertsController())
     try app.register(collection: DeviceController())
+    try app.register(collection: OperatorDashboardController())
 }
 
 public func normalizedOptional(_ value: String?) -> String? {

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -40,6 +40,7 @@ public func configure(_ app: Application, mode: AppRuntimeMode) async throws {
         configureWorkerQueueSettings(on: app)
         configureWorkerRuntime(on: app)
         app.queues.schedule(DispatchIngestNWSAlertsScheduledJob()).minutely().at(0)
+        app.queues.schedule(RefreshOperatorDashboardSnapshotScheduledJob()).every(seconds: OperatorDashboardConfig.fastRefreshIntervalSeconds)
         app.logger.info("Configured scheduled ingestion dispatch (every 60 seconds).")
         try configureWorkerRoutes(app)
     }
@@ -72,6 +73,11 @@ private func configureMigrations(on app: Application) {
     app.migrations.add(AddApnsErrorCodeToNotificationLedger())
     app.migrations.add(AddCAPParamFields())
     app.migrations.add(CreateNotificationDebug())
+    app.migrations.add(CreateIngestSweepRuns())
+    app.migrations.add(AddCompletedAtToNotificationLedger())
+    app.migrations.add(AddCompletionFieldsToTargetDispatchOutbox())
+    app.migrations.add(CreateNotificationSendAttempts())
+    app.migrations.add(CreateOperatorDashboardSnapshots())
 }
 
 private func configureAPNs(on app: Application) async throws {

--- a/Sources/App/lib/OperatorDashboardConfig.swift
+++ b/Sources/App/lib/OperatorDashboardConfig.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public enum OperatorDashboardConfig {
+    public static let rollingWindowHours = 24
+
+    public static let ingestRecentAttemptLimit = 60
+    public static let claimedStuckThresholdSeconds = 5 * 60
+    public static let staleActiveSeriesGraceSeconds = 15 * 60
+
+    public static let installationFreshnessThresholdSeconds = 24 * 60 * 60
+    public static let presenceFreshnessThresholdSeconds = 6 * 60 * 60
+
+    public static let fastRefreshIntervalSeconds = 30
+    public static let standardRefreshIntervalSeconds = 60
+    public static let slowRefreshIntervalSeconds = 5 * 60
+
+    public static let recentNotificationDebugLimit = 5
+    public static let touchedSeriesLimit = 5
+    public static let topFailureReasonLimit = 3
+}

--- a/Sources/App/lib/OperatorDashboardPageRenderer.swift
+++ b/Sources/App/lib/OperatorDashboardPageRenderer.swift
@@ -1,0 +1,1078 @@
+import Foundation
+
+enum OperatorDashboardPageRenderer {
+    static func render(snapshot: OperatorDashboardSnapshotResponse) -> String {
+        """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>Arcus Signal Operator Dashboard</title>
+          <style>
+            :root {
+              color-scheme: dark;
+              --bg: #07111c;
+              --panel: rgba(12, 24, 39, 0.92);
+              --panel-2: rgba(17, 33, 52, 0.88);
+              --line: rgba(117, 165, 196, 0.18);
+              --text: #eef6ff;
+              --muted: #8ca4ba;
+              --accent: #58d6c3;
+              --warn: #ffb15c;
+              --danger: #ff6f7d;
+              --shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+            }
+            * { box-sizing: border-box; }
+            body {
+              margin: 0;
+              font-family: "Avenir Next", "IBM Plex Sans", "Segoe UI", sans-serif;
+              background:
+                radial-gradient(circle at top left, rgba(88, 214, 195, 0.10), transparent 32%),
+                radial-gradient(circle at top right, rgba(255, 111, 125, 0.12), transparent 28%),
+                linear-gradient(180deg, #08121d 0%, #050a11 100%);
+              color: var(--text);
+            }
+            .shell {
+              width: min(1320px, calc(100vw - 32px));
+              margin: 0 auto;
+              padding: 28px 0 40px;
+            }
+            .hero {
+              display: flex;
+              gap: 16px;
+              justify-content: space-between;
+              align-items: flex-end;
+              padding: 24px;
+              border: 1px solid var(--line);
+              border-radius: 24px;
+              background: linear-gradient(135deg, rgba(14, 29, 46, 0.96), rgba(7, 15, 25, 0.94));
+              box-shadow: var(--shadow);
+            }
+            .hero h1 {
+              margin: 0;
+              font-family: "Space Grotesk", "Avenir Next", sans-serif;
+              font-size: clamp(2rem, 3vw, 3rem);
+              letter-spacing: -0.04em;
+            }
+            .hero p {
+              margin: 10px 0 0;
+              color: var(--muted);
+              max-width: 720px;
+            }
+            .hero-meta {
+              text-align: right;
+              color: var(--muted);
+              font-size: 0.95rem;
+            }
+            .hero-meta a {
+              color: var(--accent);
+              text-decoration: none;
+            }
+            .section {
+              margin-top: 28px;
+            }
+            .section h2 {
+              margin: 0 0 14px;
+              font-size: 1.05rem;
+              text-transform: uppercase;
+              letter-spacing: 0.12em;
+              color: var(--muted);
+            }
+            .grid {
+              display: grid;
+              grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+              gap: 16px;
+            }
+            .stack {
+              display: grid;
+              grid-template-columns: 1fr;
+              gap: 16px;
+            }
+            .live-slot {
+              min-width: 0;
+              transition: opacity 0.18s ease, transform 0.18s ease;
+            }
+            .live-slot.is-updating {
+              opacity: 0.78;
+              transform: translateY(1px);
+            }
+            .card {
+              padding: 18px;
+              border-radius: 20px;
+              border: 1px solid var(--line);
+              background: linear-gradient(180deg, var(--panel), var(--panel-2));
+              box-shadow: var(--shadow);
+            }
+            .card h3 {
+              margin: 0;
+              font-size: 0.92rem;
+              letter-spacing: 0.02em;
+              color: var(--muted);
+            }
+            .primary {
+              margin: 14px 0 6px;
+              font-size: 2rem;
+              font-weight: 700;
+              letter-spacing: -0.04em;
+            }
+            .subtle {
+              color: var(--muted);
+              font-size: 0.92rem;
+            }
+            .meta-list {
+              margin: 14px 0 0;
+              padding: 0;
+              list-style: none;
+            }
+            .meta-list li {
+              display: flex;
+              justify-content: space-between;
+              gap: 12px;
+              padding: 9px 0;
+              border-top: 1px solid rgba(117, 165, 196, 0.10);
+              color: var(--muted);
+              font-size: 0.92rem;
+            }
+            .meta-list li strong {
+              color: var(--text);
+              font-weight: 600;
+            }
+            .table-card {
+              padding: 0;
+              overflow: hidden;
+            }
+            table {
+              width: 100%;
+              border-collapse: collapse;
+            }
+            th, td {
+              padding: 13px 16px;
+              text-align: left;
+              vertical-align: top;
+              border-bottom: 1px solid rgba(117, 165, 196, 0.10);
+            }
+            th {
+              font-size: 0.8rem;
+              text-transform: uppercase;
+              letter-spacing: 0.08em;
+              color: var(--muted);
+              background: rgba(255, 255, 255, 0.02);
+            }
+            td {
+              font-size: 0.94rem;
+            }
+            .pill {
+              display: inline-block;
+              padding: 4px 10px;
+              border-radius: 999px;
+              font-size: 0.78rem;
+              letter-spacing: 0.04em;
+              text-transform: uppercase;
+              border: 1px solid rgba(117, 165, 196, 0.18);
+              color: var(--text);
+              background: rgba(255, 255, 255, 0.05);
+            }
+            .accent { color: var(--accent); }
+            .warn { color: var(--warn); }
+            .danger { color: var(--danger); }
+            .mono { font-family: "SF Mono", "IBM Plex Mono", monospace; font-size: 0.78rem; }
+            .micro-mono { font-family: "SF Mono", "IBM Plex Mono", monospace; font-size: 0.54rem; line-height: 1.3; }
+            .hero-meta, .primary, th, td, .mono, .micro-mono {
+              font-variant-numeric: tabular-nums;
+            }
+            .empty {
+              padding: 18px 16px;
+              color: var(--muted);
+            }
+            @media (max-width: 720px) {
+              .hero {
+                flex-direction: column;
+                align-items: stretch;
+              }
+              .hero-meta {
+                text-align: left;
+              }
+              th, td {
+                padding: 12px;
+              }
+            }
+          </style>
+        </head>
+        <body>
+          <main class="shell">
+            <section class="hero">
+              <div>
+                <h1>Arcus Signal</h1>
+                <p>Operational snapshot for ingest, targeting, and notification delivery. The page polls the canonical <span class="mono">/v1/metrics</span> snapshot and updates in place without a full reload.</p>
+              </div>
+              <div class="hero-meta">
+                <div id="hero-rendered-at">Rendered \(escape(formatDate(snapshot.renderedAt)))</div>
+                <div id="hero-generated-at">Snapshot generated \(escape(formatDate(snapshot.generatedAt)))</div>
+                <div><a href="/v1/metrics">View JSON API</a></div>
+              </div>
+            </section>
+
+            <section class="section">
+              <h2>Red Lights</h2>
+              <div class="grid">
+                \(slot("ingest-card", content: ingestCard(snapshot.redLights.ingestFreshness)))
+                \(slot("pipeline-backlog-card", content: pipelineBacklogCard(snapshot.redLights.pipelineBacklogAge)))
+                \(slot("stuck-claimed-card", content: stuckClaimedCard(snapshot.redLights.stuckClaimedRows)))
+                \(slot("stale-series-card", content: staleSeriesCard(snapshot.redLights.staleActiveSeriesCount)))
+              </div>
+            </section>
+
+            <section class="section">
+              <h2>Delivery KPIs</h2>
+              <div class="grid">
+                \(slot("latency-card", content: latencyCard(snapshot.deliveryKPIs.endToEndAlertLatency)))
+                \(slot("apns-success-card", content: apnsSuccessCard(snapshot.deliveryKPIs.apnsDeliverySuccessRate)))
+                \(slot("noop-card", content: noOpCard(snapshot.deliveryKPIs.sendNoOpRateByReason)))
+                \(slot("zero-candidate-card", content: zeroCandidateCard(snapshot.deliveryKPIs.zeroCandidateRevisionRate)))
+              </div>
+            </section>
+
+            <section class="section">
+              <h2>Audience / Targeting</h2>
+              <div class="grid">
+                \(slot("coverage-card", content: coverageCard(snapshot.audienceTargeting.freshTargetableInstallationCoverage)))
+                \(slot("h3-card", content: h3Card(snapshot.audienceTargeting.alertsWithGeographyAndH3Success)))
+              </div>
+            </section>
+
+            <section class="section">
+              <h2>Operator Context</h2>
+              <div class="stack">
+                \(slot("recent-debug-table", content: recentDebugTable(snapshot.operatorContext.recentNotificationDebugEntries)))
+                \(slot("touched-series-table", content: touchedSeriesTable(snapshot.operatorContext.lastTouchedSeries)))
+              </div>
+            </section>
+          </main>
+          \(liveUpdateScript(
+              pollIntervalMilliseconds: pollIntervalMilliseconds,
+              initialGeneratedAtMilliseconds: Int(snapshot.generatedAt.timeIntervalSince1970 * 1_000)
+          ))
+        </body>
+        </html>
+        """
+    }
+
+    static func renderUnavailable(renderedAt: Date = .now) -> String {
+        """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>Arcus Signal Operator Dashboard</title>
+          <style>
+            :root { color-scheme: dark; }
+            body {
+              margin: 0;
+              font-family: "Avenir Next", "IBM Plex Sans", sans-serif;
+              background: linear-gradient(180deg, #08121d 0%, #050a11 100%);
+              color: #eef6ff;
+              display: grid;
+              place-items: center;
+              min-height: 100vh;
+            }
+            .panel {
+              width: min(560px, calc(100vw - 32px));
+              padding: 28px;
+              border-radius: 24px;
+              border: 1px solid rgba(117, 165, 196, 0.18);
+              background: rgba(12, 24, 39, 0.94);
+              box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+            }
+            h1 { margin: 0 0 8px; }
+            p { color: #8ca4ba; line-height: 1.5; }
+            a { color: #58d6c3; text-decoration: none; }
+          </style>
+        </head>
+        <body>
+          <section class="panel">
+            <h1>Dashboard Snapshot Unavailable</h1>
+            <p>The API process has not received a worker-computed dashboard snapshot yet. The page will keep checking for a fresh snapshot in the background.</p>
+            <p>Rendered \(escape(formatDate(renderedAt)))</p>
+            <p><a href="/v1/metrics">Try the JSON API</a></p>
+          </section>
+          \(unavailablePollingScript(pollIntervalMilliseconds: pollIntervalMilliseconds))
+        </body>
+        </html>
+        """
+    }
+
+    private static let pollIntervalMilliseconds = max(15, OperatorDashboardConfig.fastRefreshIntervalSeconds / 2) * 1_000
+
+    private static func slot(_ id: String, content: String) -> String {
+        """
+        <div id="\(escape(id))" class="live-slot">\(content)</div>
+        """
+    }
+
+    private static func liveUpdateScript(
+        pollIntervalMilliseconds: Int,
+        initialGeneratedAtMilliseconds: Int
+    ) -> String {
+        #"""
+        <script>
+        (function() {
+          const pollIntervalMs = \#(pollIntervalMilliseconds);
+          const state = {
+            inFlight: false,
+            lastGeneratedAtMs: \#(initialGeneratedAtMilliseconds),
+            refreshKeys: Object.create(null)
+          };
+
+          function parseDateValue(value) {
+            if (value === null || value === undefined || value === '') {
+              return null;
+            }
+
+            if (typeof value === 'number') {
+              const millis = value > 1e12 ? value : value * 1000;
+              const numericDate = new Date(millis);
+              return Number.isNaN(numericDate.getTime()) ? null : numericDate;
+            }
+
+            const date = new Date(value);
+            return Number.isNaN(date.getTime()) ? null : date;
+          }
+
+          function dateToMillis(value) {
+            const date = parseDateValue(value);
+            return date ? date.getTime() : null;
+          }
+
+          function pad(value) {
+            return String(value).padStart(2, '0');
+          }
+
+          function timeZoneAbbreviation(date) {
+            try {
+              const parts = new Intl.DateTimeFormat('en-US', { timeZoneName: 'short' }).formatToParts(date);
+              const match = parts.find((part) => part.type === 'timeZoneName');
+              return match ? match.value : 'UTC';
+            } catch (_) {
+              return 'UTC';
+            }
+          }
+
+          function escapeHtml(value) {
+            return String(value ?? '')
+              .replaceAll('&', '&amp;')
+              .replaceAll('<', '&lt;')
+              .replaceAll('>', '&gt;')
+              .replaceAll('"', '&quot;')
+              .replaceAll("'", '&#39;');
+          }
+
+          function formatDate(value) {
+            const date = parseDateValue(value);
+            if (!date) {
+              return 'n/a';
+            }
+
+            return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())} ${timeZoneAbbreviation(date)}`;
+          }
+
+          function formatDuration(value) {
+            if (value === null || value === undefined || Number.isNaN(Number(value))) {
+              return 'n/a';
+            }
+
+            const seconds = Math.max(0, Math.round(Number(value)));
+            if (seconds < 60) {
+              return `${seconds}s`;
+            }
+
+            if (seconds < 3600) {
+              return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+            }
+
+            if (seconds < 86400) {
+              const hours = Math.floor(seconds / 3600);
+              const minutes = Math.floor((seconds % 3600) / 60);
+              return `${hours}h ${minutes}m`;
+            }
+
+            const days = Math.floor(seconds / 86400);
+            const hours = Math.floor((seconds % 86400) / 3600);
+            return `${days}d ${hours}h`;
+          }
+
+          function formatPercent(value) {
+            if (value === null || value === undefined || Number.isNaN(Number(value))) {
+              return 'n/a';
+            }
+
+            return `${(Number(value) * 100).toFixed(1)}%`;
+          }
+
+          function joinedReasons(reasons) {
+            if (!Array.isArray(reasons) || reasons.length === 0) {
+              return 'none';
+            }
+
+            return reasons.map((reason) => `${reason.reason} (${reason.count})`).join(', ');
+          }
+
+          function joinedCodes(codes) {
+            if (!Array.isArray(codes) || codes.length === 0) {
+              return 'none';
+            }
+
+            return codes.join(', ');
+          }
+
+          function renderCard(title, primary, refreshedAt, lines) {
+            return `
+              <div class="card">
+                <h3>${escapeHtml(title)}</h3>
+                <div class="primary">${escapeHtml(primary)}</div>
+                <div class="subtle">Refreshed ${escapeHtml(formatDate(refreshedAt))}</div>
+                <ul class="meta-list">
+                  ${lines.map((line) => `<li><span>${escapeHtml(line.label)}</span><strong>${escapeHtml(line.value)}</strong></li>`).join('')}
+                </ul>
+              </div>
+            `;
+          }
+
+          function renderIngestCard(metric) {
+            return renderCard('Ingest freshness', formatDuration(metric.timeSinceLastSuccessfulSweepSeconds), metric.refreshedAt, [
+              { label: 'Last success', value: formatDate(metric.lastSuccessfulSweepAt) },
+              { label: 'Last attempt', value: formatDate(metric.lastAttemptAt) },
+              { label: 'Recent', value: `${metric.recentSuccessCount} success / ${metric.recentFailureCount} failure` },
+              { label: 'Last error', value: metric.lastFailureMessage ?? 'none' }
+            ]);
+          }
+
+          function renderPipelineBacklogCard(metric) {
+            return renderCard('Pipeline backlog age', `Target ${formatDuration(metric.oldestPendingTargetDispatchAgeSeconds)}`, metric.refreshedAt, [
+              { label: 'Pending target rows', value: String(metric.pendingTargetDispatchCount) },
+              { label: 'Oldest target row', value: formatDate(metric.oldestPendingTargetDispatchCreatedAt) },
+              { label: 'Notification backlog', value: formatDuration(metric.oldestPendingNotificationDispatchAgeSeconds) },
+              { label: 'Pending notification rows', value: String(metric.pendingNotificationDispatchCount) }
+            ]);
+          }
+
+          function renderStuckClaimedCard(metric) {
+            return renderCard('Stuck claimed rows', String(metric.count), metric.refreshedAt, [
+              { label: 'Threshold', value: formatDuration(metric.thresholdSeconds) },
+              { label: 'Oldest claim age', value: formatDuration(metric.oldestClaimedAgeSeconds) },
+              { label: 'Oldest claim', value: formatDate(metric.oldestClaimedCreatedAt) }
+            ]);
+          }
+
+          function renderStaleSeriesCard(metric) {
+            return renderCard('Stale active series', String(metric.count), metric.refreshedAt, [
+              { label: 'Grace window', value: formatDuration(metric.graceSeconds) }
+            ]);
+          }
+
+          function renderLatencyCard(metric) {
+            return renderCard('End-to-end alert latency p95', formatDuration(metric.p95Seconds === null ? null : Math.round(metric.p95Seconds)), metric.refreshedAt, [
+              { label: 'Window', value: `${metric.windowHours}h` },
+              { label: 'Successful revisions', value: String(metric.successfulRevisionCount) }
+            ]);
+          }
+
+          function renderAPNsSuccessCard(metric) {
+            return renderCard('APNs delivery success rate', formatPercent(metric.successRate), metric.refreshedAt, [
+              { label: 'Sent', value: String(metric.sentCount) },
+              { label: 'Failed', value: String(metric.failedCount) },
+              { label: 'Top failures', value: joinedReasons(metric.topFailureReasons) }
+            ]);
+          }
+
+          function renderNoOpCard(metric) {
+            return renderCard('Send no-op rate by reason', formatPercent(metric.noOpRate), metric.refreshedAt, [
+              { label: 'Total attempts', value: String(metric.totalAttemptCount) },
+              { label: 'No-op attempts', value: String(metric.noOpAttemptCount) },
+              { label: 'Reasons', value: joinedReasons(metric.reasons) }
+            ]);
+          }
+
+          function renderZeroCandidateCard(metric) {
+            return renderCard('Zero-candidate revision rate', formatPercent(metric.zeroCandidateRate), metric.refreshedAt, [
+              { label: 'Candidate-resolution attempts', value: String(metric.candidateResolutionAttemptCount) },
+              { label: 'Zero-candidate attempts', value: String(metric.zeroCandidateAttemptCount) }
+            ]);
+          }
+
+          function renderCoverageCard(metric) {
+            return renderCard('Fresh targetable coverage', formatPercent(metric.targetableRate), metric.refreshedAt, [
+              { label: 'Targetable', value: `${metric.targetableInstallationCount} / ${metric.activeSubscribedInstallationCount}` },
+              { label: 'Missing token', value: String(metric.lossBreakdown.missingDeviceTokenCount) },
+              { label: 'Stale install', value: String(metric.lossBreakdown.staleInstallationHeartbeatCount) },
+              { label: 'Stale presence', value: String(metric.lossBreakdown.stalePresenceCount) },
+              { label: 'Missing targeting', value: String(metric.lossBreakdown.missingTargetingDataCount) }
+            ]);
+          }
+
+          function renderH3Card(metric) {
+            return renderCard('Geography to H3 conversion', formatPercent(metric.successRate), metric.refreshedAt, [
+              { label: 'Geometry-bearing revisions', value: String(metric.geometryBearingRevisionCount) },
+              { label: 'Successful conversions', value: String(metric.successfulConversionCount) },
+              { label: 'p95 conversion', value: formatDuration(metric.p95ConversionSeconds === null ? null : Math.round(metric.p95ConversionSeconds)) }
+            ]);
+          }
+
+          function renderRecentDebugRow(entry) {
+            return `
+              <tr>
+                <td>${escapeHtml(formatDate(entry.createdAt))}</td>
+                <td>
+                  <div>${escapeHtml(entry.eventName)}</div>
+                  <div class="subtle mono">${escapeHtml(entry.seriesID)}</div>
+                </td>
+                <td>
+                  <span class="pill">${escapeHtml(entry.mode)}</span>
+                  <div class="subtle">${escapeHtml(entry.reason)} / ${escapeHtml(entry.recordKind)}</div>
+                </td>
+                <td>
+                  <div><strong>${escapeHtml(entry.title)}</strong></div>
+                  <div class="subtle">${escapeHtml(entry.subtitle)}</div>
+                  <div class="subtle">${escapeHtml(entry.body)}</div>
+                </td>
+                <td>
+                  <div>${escapeHtml(entry.ledgerStatus ?? 'preview')}</div>
+                  <div class="subtle">${escapeHtml(entry.apnsErrorCode ?? 'none')}</div>
+                </td>
+              </tr>
+            `;
+          }
+
+          function renderRecentDebugTable(metric) {
+            const body = !Array.isArray(metric.entries) || metric.entries.length === 0
+              ? '<div class="empty">No recent notification debug entries.</div>'
+              : `
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Time</th>
+                      <th>Alert</th>
+                      <th>Mode / reason</th>
+                      <th>Message</th>
+                      <th>Outcome</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    ${metric.entries.map(renderRecentDebugRow).join('')}
+                  </tbody>
+                </table>
+              `;
+
+            return `
+              <div class="card table-card">
+                <div style="padding: 18px 18px 0;">
+                  <h3>Recent notification debug entries</h3>
+                  <div class="subtle">Refreshed ${escapeHtml(formatDate(metric.refreshedAt))}</div>
+                </div>
+                ${body}
+              </div>
+            `;
+          }
+
+          function renderTouchedSeriesRow(entry) {
+            return `
+              <tr>
+                <td>${escapeHtml(formatDate(entry.touchedAt))}</td>
+                <td>
+                  <div>${escapeHtml(entry.eventName)}</div>
+                  <div class="subtle mono">${escapeHtml(entry.seriesID)}</div>
+                  <div class="subtle micro-mono">${escapeHtml(entry.currentRevisionUrn)}</div>
+                </td>
+                <td><span class="pill">${escapeHtml(entry.state)}</span></td>
+                <td>${escapeHtml(entry.tornadoDetection ?? 'none')}</td>
+                <td>${escapeHtml(entry.tornadoDamageThreat ?? 'none')}</td>
+                <td class="mono">${escapeHtml(joinedCodes(entry.ugcCodes))}</td>
+              </tr>
+            `;
+          }
+
+          function renderTouchedSeriesTable(metric) {
+            const body = !Array.isArray(metric.entries) || metric.entries.length === 0
+              ? '<div class="empty">No recently touched series.</div>'
+              : `
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Touched</th>
+                      <th>Alert</th>
+                      <th>State</th>
+                      <th>Tornado detection</th>
+                      <th>Tornado damage threat</th>
+                      <th>ugc_codes</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    ${metric.entries.map(renderTouchedSeriesRow).join('')}
+                  </tbody>
+                </table>
+              `;
+
+            return `
+              <div class="card table-card">
+                <div style="padding: 18px 18px 0;">
+                  <h3>Last 5 touched series</h3>
+                  <div class="subtle">Refreshed ${escapeHtml(formatDate(metric.refreshedAt))}</div>
+                </div>
+                ${body}
+              </div>
+            `;
+          }
+
+          function refreshKey(value) {
+            return value ?? 'none';
+          }
+
+          function swapHTML(id, html) {
+            const node = document.getElementById(id);
+            if (!node) {
+              return;
+            }
+
+            node.classList.add('is-updating');
+            node.innerHTML = html;
+            window.requestAnimationFrame(() => node.classList.remove('is-updating'));
+          }
+
+          function updateSlot(id, key, html) {
+            if (state.refreshKeys[id] === key) {
+              return;
+            }
+
+            state.refreshKeys[id] = key;
+            swapHTML(id, html);
+          }
+
+          function updateHero(snapshot) {
+            const renderedNode = document.getElementById('hero-rendered-at');
+            if (renderedNode) {
+              renderedNode.textContent = `Rendered ${formatDate(snapshot.renderedAt)}`;
+            }
+
+            const generatedNode = document.getElementById('hero-generated-at');
+            if (generatedNode) {
+              generatedNode.textContent = `Snapshot generated ${formatDate(snapshot.generatedAt)}`;
+            }
+          }
+
+          function applySnapshot(snapshot) {
+            updateHero(snapshot);
+            updateSlot('ingest-card', refreshKey(snapshot.redLights.ingestFreshness.refreshedAt), renderIngestCard(snapshot.redLights.ingestFreshness));
+            updateSlot('pipeline-backlog-card', refreshKey(snapshot.redLights.pipelineBacklogAge.refreshedAt), renderPipelineBacklogCard(snapshot.redLights.pipelineBacklogAge));
+            updateSlot('stuck-claimed-card', refreshKey(snapshot.redLights.stuckClaimedRows.refreshedAt), renderStuckClaimedCard(snapshot.redLights.stuckClaimedRows));
+            updateSlot('stale-series-card', refreshKey(snapshot.redLights.staleActiveSeriesCount.refreshedAt), renderStaleSeriesCard(snapshot.redLights.staleActiveSeriesCount));
+            updateSlot('latency-card', refreshKey(snapshot.deliveryKPIs.endToEndAlertLatency.refreshedAt), renderLatencyCard(snapshot.deliveryKPIs.endToEndAlertLatency));
+            updateSlot('apns-success-card', refreshKey(snapshot.deliveryKPIs.apnsDeliverySuccessRate.refreshedAt), renderAPNsSuccessCard(snapshot.deliveryKPIs.apnsDeliverySuccessRate));
+            updateSlot('noop-card', refreshKey(snapshot.deliveryKPIs.sendNoOpRateByReason.refreshedAt), renderNoOpCard(snapshot.deliveryKPIs.sendNoOpRateByReason));
+            updateSlot('zero-candidate-card', refreshKey(snapshot.deliveryKPIs.zeroCandidateRevisionRate.refreshedAt), renderZeroCandidateCard(snapshot.deliveryKPIs.zeroCandidateRevisionRate));
+            updateSlot('coverage-card', refreshKey(snapshot.audienceTargeting.freshTargetableInstallationCoverage.refreshedAt), renderCoverageCard(snapshot.audienceTargeting.freshTargetableInstallationCoverage));
+            updateSlot('h3-card', refreshKey(snapshot.audienceTargeting.alertsWithGeographyAndH3Success.refreshedAt), renderH3Card(snapshot.audienceTargeting.alertsWithGeographyAndH3Success));
+            updateSlot('recent-debug-table', refreshKey(snapshot.operatorContext.recentNotificationDebugEntries.refreshedAt), renderRecentDebugTable(snapshot.operatorContext.recentNotificationDebugEntries));
+            updateSlot('touched-series-table', refreshKey(snapshot.operatorContext.lastTouchedSeries.refreshedAt), renderTouchedSeriesTable(snapshot.operatorContext.lastTouchedSeries));
+          }
+
+          async function fetchSnapshot() {
+            if (state.inFlight) {
+              return;
+            }
+
+            state.inFlight = true;
+            try {
+              const response = await fetch('/v1/metrics', {
+                headers: { 'Accept': 'application/json' },
+                cache: 'no-store'
+              });
+
+              if (!response.ok) {
+                return;
+              }
+
+              const snapshot = await response.json();
+              const generatedAtMs = dateToMillis(snapshot.generatedAt);
+              if (generatedAtMs !== null && generatedAtMs === state.lastGeneratedAtMs) {
+                return;
+              }
+
+              applySnapshot(snapshot);
+              state.lastGeneratedAtMs = generatedAtMs;
+            } catch (_) {
+            } finally {
+              state.inFlight = false;
+            }
+          }
+
+          window.setInterval(fetchSnapshot, pollIntervalMs);
+          window.addEventListener('focus', fetchSnapshot);
+          document.addEventListener('visibilitychange', function() {
+            if (document.visibilityState === 'visible') {
+              fetchSnapshot();
+            }
+          });
+          fetchSnapshot();
+        })();
+        </script>
+        """#
+    }
+
+    private static func unavailablePollingScript(pollIntervalMilliseconds: Int) -> String {
+        #"""
+        <script>
+        (function() {
+          const pollIntervalMs = \#(pollIntervalMilliseconds);
+
+          async function pollForSnapshot() {
+            try {
+              const response = await fetch('/v1/metrics', {
+                headers: { 'Accept': 'application/json' },
+                cache: 'no-store'
+              });
+
+              if (response.ok) {
+                window.location.replace('/dashboard');
+              }
+            } catch (_) {
+            }
+          }
+
+          window.setInterval(pollForSnapshot, pollIntervalMs);
+          pollForSnapshot();
+        })();
+        </script>
+        """#
+    }
+
+    private static func ingestCard(_ metric: IngestFreshnessMetricResponse) -> String {
+        card(
+            title: "Ingest freshness",
+            primary: maybeDuration(metric.timeSinceLastSuccessfulSweepSeconds),
+            refreshedAt: metric.refreshedAt,
+            lines: [
+                ("Last success", maybeDate(metric.lastSuccessfulSweepAt)),
+                ("Last attempt", maybeDate(metric.lastAttemptAt)),
+                ("Recent", "\(metric.recentSuccessCount) success / \(metric.recentFailureCount) failure"),
+                ("Last error", metric.lastFailureMessage ?? "none")
+            ]
+        )
+    }
+
+    private static func pipelineBacklogCard(_ metric: PipelineBacklogMetricResponse) -> String {
+        card(
+            title: "Pipeline backlog age",
+            primary: "Target \(maybeDuration(metric.oldestPendingTargetDispatchAgeSeconds))",
+            refreshedAt: metric.refreshedAt,
+            lines: [
+                ("Pending target rows", "\(metric.pendingTargetDispatchCount)"),
+                ("Oldest target row", maybeDate(metric.oldestPendingTargetDispatchCreatedAt)),
+                ("Notification backlog", maybeDuration(metric.oldestPendingNotificationDispatchAgeSeconds)),
+                ("Pending notification rows", "\(metric.pendingNotificationDispatchCount)")
+            ]
+        )
+    }
+
+    private static func stuckClaimedCard(_ metric: StuckClaimedRowsMetricResponse) -> String {
+        card(
+            title: "Stuck claimed rows",
+            primary: "\(metric.count)",
+            refreshedAt: metric.refreshedAt,
+            lines: [
+                ("Threshold", maybeDuration(metric.thresholdSeconds)),
+                ("Oldest claim age", maybeDuration(metric.oldestClaimedAgeSeconds)),
+                ("Oldest claim", maybeDate(metric.oldestClaimedCreatedAt))
+            ]
+        )
+    }
+
+    private static func staleSeriesCard(_ metric: StaleActiveSeriesMetricResponse) -> String {
+        card(
+            title: "Stale active series",
+            primary: "\(metric.count)",
+            refreshedAt: metric.refreshedAt,
+            lines: [("Grace window", maybeDuration(metric.graceSeconds))]
+        )
+    }
+
+    private static func latencyCard(_ metric: EndToEndLatencyMetricResponse) -> String {
+        card(
+            title: "End-to-end alert latency p95",
+            primary: maybeDuration(metric.p95Seconds.flatMap { Int($0.rounded()) }),
+            refreshedAt: metric.refreshedAt,
+            lines: [
+                ("Window", "\(metric.windowHours)h"),
+                ("Successful revisions", "\(metric.successfulRevisionCount)")
+            ]
+        )
+    }
+
+    private static func apnsSuccessCard(_ metric: APNsDeliveryMetricResponse) -> String {
+        card(
+            title: "APNs delivery success rate",
+            primary: maybePercent(metric.successRate),
+            refreshedAt: metric.refreshedAt,
+            lines: [
+                ("Sent", "\(metric.sentCount)"),
+                ("Failed", "\(metric.failedCount)"),
+                ("Top failures", joinedReasons(metric.topFailureReasons))
+            ]
+        )
+    }
+
+    private static func noOpCard(_ metric: SendNoOpsMetricResponse) -> String {
+        card(
+            title: "Send no-op rate by reason",
+            primary: maybePercent(metric.noOpRate),
+            refreshedAt: metric.refreshedAt,
+            lines: [
+                ("Total attempts", "\(metric.totalAttemptCount)"),
+                ("No-op attempts", "\(metric.noOpAttemptCount)"),
+                ("Reasons", joinedReasons(metric.reasons))
+            ]
+        )
+    }
+
+    private static func zeroCandidateCard(_ metric: ZeroCandidateRateMetricResponse) -> String {
+        card(
+            title: "Zero-candidate revision rate",
+            primary: maybePercent(metric.zeroCandidateRate),
+            refreshedAt: metric.refreshedAt,
+            lines: [
+                ("Candidate-resolution attempts", "\(metric.candidateResolutionAttemptCount)"),
+                ("Zero-candidate attempts", "\(metric.zeroCandidateAttemptCount)")
+            ]
+        )
+    }
+
+    private static func coverageCard(_ metric: TargetableCoverageMetricResponse) -> String {
+        card(
+            title: "Fresh targetable coverage",
+            primary: maybePercent(metric.targetableRate),
+            refreshedAt: metric.refreshedAt,
+            lines: [
+                ("Targetable", "\(metric.targetableInstallationCount) / \(metric.activeSubscribedInstallationCount)"),
+                ("Missing token", "\(metric.lossBreakdown.missingDeviceTokenCount)"),
+                ("Stale install", "\(metric.lossBreakdown.staleInstallationHeartbeatCount)"),
+                ("Stale presence", "\(metric.lossBreakdown.stalePresenceCount)"),
+                ("Missing targeting", "\(metric.lossBreakdown.missingTargetingDataCount)")
+            ]
+        )
+    }
+
+    private static func h3Card(_ metric: H3DerivationMetricResponse) -> String {
+        card(
+            title: "Geography to H3 conversion",
+            primary: maybePercent(metric.successRate),
+            refreshedAt: metric.refreshedAt,
+            lines: [
+                ("Geometry-bearing revisions", "\(metric.geometryBearingRevisionCount)"),
+                ("Successful conversions", "\(metric.successfulConversionCount)"),
+                ("p95 conversion", maybeDuration(metric.p95ConversionSeconds.flatMap { Int($0.rounded()) }))
+            ]
+        )
+    }
+
+    private static func recentDebugTable(_ metric: RecentNotificationDebugEntriesResponse) -> String {
+        let body: String
+        if metric.entries.isEmpty {
+            body = #"<div class="empty">No recent notification debug entries.</div>"#
+        } else {
+            body = """
+            <table>
+              <thead>
+                <tr>
+                  <th>Time</th>
+                  <th>Alert</th>
+                  <th>Mode / reason</th>
+                  <th>Message</th>
+                  <th>Outcome</th>
+                </tr>
+              </thead>
+              <tbody>
+                \(metric.entries.map(renderDebugRow).joined())
+              </tbody>
+            </table>
+            """
+        }
+
+        return """
+        <div class="card table-card">
+          <div style="padding: 18px 18px 0;">
+            <h3>Recent notification debug entries</h3>
+            <div class="subtle">Refreshed \(escape(maybeDate(metric.refreshedAt)))</div>
+          </div>
+          \(body)
+        </div>
+        """
+    }
+
+    private static func touchedSeriesTable(_ metric: LastTouchedSeriesResponse) -> String {
+        let body: String
+        if metric.entries.isEmpty {
+            body = #"<div class="empty">No recently touched series.</div>"#
+        } else {
+            body = """
+            <table>
+              <thead>
+                <tr>
+                  <th>Touched</th>
+                  <th>Alert</th>
+                  <th>State</th>
+                  <th>Tornado detection</th>
+                  <th>Tornado damage threat</th>
+                  <th>ugc_codes</th>
+                </tr>
+              </thead>
+              <tbody>
+                \(metric.entries.map(renderTouchedSeriesRow).joined())
+              </tbody>
+            </table>
+            """
+        }
+
+        return """
+        <div class="card table-card">
+          <div style="padding: 18px 18px 0;">
+            <h3>Last 5 touched series</h3>
+            <div class="subtle">Refreshed \(escape(maybeDate(metric.refreshedAt)))</div>
+          </div>
+          \(body)
+        </div>
+        """
+    }
+
+    private static func renderDebugRow(_ entry: RecentNotificationDebugEntryResponse) -> String {
+        """
+        <tr>
+          <td>\(escape(formatDate(entry.createdAt)))</td>
+          <td>
+            <div>\(escape(entry.eventName))</div>
+            <div class="subtle mono">\(escape(entry.seriesID.uuidString))</div>
+          </td>
+          <td>
+            <span class="pill">\(escape(entry.mode))</span>
+            <div class="subtle">\(escape(entry.reason)) / \(escape(entry.recordKind))</div>
+          </td>
+          <td>
+            <div><strong>\(escape(entry.title))</strong></div>
+            <div class="subtle">\(escape(entry.subtitle))</div>
+            <div class="subtle">\(escape(entry.body))</div>
+          </td>
+          <td>
+            <div>\(escape(entry.ledgerStatus ?? "preview"))</div>
+            <div class="subtle">\(escape(entry.apnsErrorCode ?? "none"))</div>
+          </td>
+        </tr>
+        """
+    }
+
+    private static func renderTouchedSeriesRow(_ entry: TouchedSeriesEntryResponse) -> String {
+        """
+        <tr>
+          <td>\(escape(formatDate(entry.touchedAt)))</td>
+          <td>
+            <div>\(escape(entry.eventName))</div>
+            <div class="subtle mono">\(escape(entry.seriesID.uuidString))</div>
+            <div class="subtle micro-mono">\(escape(entry.currentRevisionUrn))</div>
+          </td>
+          <td><span class="pill">\(escape(entry.state))</span></td>
+          <td>\(escape(entry.tornadoDetection ?? "none"))</td>
+          <td>\(escape(entry.tornadoDamageThreat ?? "none"))</td>
+          <td class="mono">\(escape(joinedCodes(entry.ugcCodes)))</td>
+        </tr>
+        """
+    }
+
+    private static func card(
+        title: String,
+        primary: String,
+        refreshedAt: Date?,
+        lines: [(String, String)]
+    ) -> String {
+        """
+        <div class="card">
+          <h3>\(escape(title))</h3>
+          <div class="primary">\(escape(primary))</div>
+          <div class="subtle">Refreshed \(escape(maybeDate(refreshedAt)))</div>
+          <ul class="meta-list">
+            \(lines.map { "<li><span>\(escape($0.0))</span><strong>\(escape($0.1))</strong></li>" }.joined())
+          </ul>
+        </div>
+        """
+    }
+
+    private static func joinedReasons(_ reasons: [ReasonBreakdownResponse]) -> String {
+        guard reasons.isEmpty == false else { return "none" }
+        return reasons.map { "\($0.reason) (\($0.count))" }.joined(separator: ", ")
+    }
+
+    private static func joinedCodes(_ codes: [String]) -> String {
+        guard codes.isEmpty == false else { return "none" }
+        return codes.joined(separator: ", ")
+    }
+
+    private static func maybeDate(_ date: Date?) -> String {
+        guard let date else { return "n/a" }
+        return formatDate(date)
+    }
+
+    private static func maybeDuration(_ seconds: Int?) -> String {
+        guard let seconds else { return "n/a" }
+        return formatDuration(seconds)
+    }
+
+    private static func maybePercent(_ value: Double?) -> String {
+        guard let value else { return "n/a" }
+        return formatPercent(value)
+    }
+
+    private static func formatDate(_ date: Date) -> String {
+        DateFormatter.dashboardDateFormatter.string(from: date)
+    }
+
+    private static func formatPercent(_ value: Double) -> String {
+        let percent = value * 100
+        return String(format: "%.1f%%", percent)
+    }
+
+    private static func formatDuration(_ seconds: Int) -> String {
+        if seconds < 60 {
+            return "\(seconds)s"
+        }
+
+        if seconds < 3_600 {
+            return "\(seconds / 60)m \(seconds % 60)s"
+        }
+
+        if seconds < 86_400 {
+            let hours = seconds / 3_600
+            let minutes = (seconds % 3_600) / 60
+            return "\(hours)h \(minutes)m"
+        }
+
+        let days = seconds / 86_400
+        let hours = (seconds % 86_400) / 3_600
+        return "\(days)d \(hours)h"
+    }
+
+    private static func escape(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+    }
+}
+
+private extension DateFormatter {
+    static let dashboardDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss z"
+        return formatter
+    }()
+}

--- a/Sources/App/lib/OperatorDashboardSnapshotRefresher.swift
+++ b/Sources/App/lib/OperatorDashboardSnapshotRefresher.swift
@@ -1,0 +1,496 @@
+import Fluent
+import FluentSQL
+import Foundation
+import Queues
+import Vapor
+
+struct RefreshOperatorDashboardSnapshotScheduledJob: AsyncScheduledJob {
+    func run(context: QueueContext) async throws {
+        try await OperatorDashboardSnapshotRefresher().refreshIfDue(on: context.application)
+    }
+}
+
+struct OperatorDashboardSnapshotRefresher {
+    func refreshIfDue(
+        on app: Application,
+        forceAll: Bool = false,
+        now: Date = .now
+    ) async throws {
+        guard let sql = app.db as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        var snapshot = try await app.operatorDashboardSnapshotStore.load(on: app.db) ?? .empty(now: now)
+        let fastDue = forceAll || shouldRefresh(snapshot.fastRefreshedAt, intervalSeconds: OperatorDashboardConfig.fastRefreshIntervalSeconds, now: now)
+        let standardDue = forceAll || shouldRefresh(snapshot.standardRefreshedAt, intervalSeconds: OperatorDashboardConfig.standardRefreshIntervalSeconds, now: now)
+        let slowDue = forceAll || shouldRefresh(snapshot.slowRefreshedAt, intervalSeconds: OperatorDashboardConfig.slowRefreshIntervalSeconds, now: now)
+
+        guard fastDue || standardDue || slowDue || forceAll else {
+            return
+        }
+
+        if fastDue {
+            snapshot.ingestFreshness = try await loadIngestFreshness(on: app.db)
+            snapshot.pipelineBacklog = try await loadPipelineBacklog(on: app.db)
+            snapshot.stuckClaimedRows = try await loadStuckClaimedRows(on: app.db, now: now)
+            snapshot.recentNotificationDebugEntries = try await loadRecentNotificationDebugEntries(on: sql)
+            snapshot.touchedSeries = try await loadTouchedSeries(on: sql)
+            snapshot.fastRefreshedAt = now
+        }
+
+        if standardDue {
+            snapshot.staleActiveSeries = try await loadStaleActiveSeries(on: sql, now: now)
+            snapshot.sendNoOps = try await loadSendNoOps(on: sql, now: now)
+            snapshot.zeroCandidateRate = try await loadZeroCandidateRate(on: sql, now: now)
+            snapshot.h3Derivation = try await loadH3Derivation(on: sql, now: now)
+            snapshot.standardRefreshedAt = now
+        }
+
+        if slowDue {
+            snapshot.endToEndLatency = try await loadEndToEndLatency(on: sql, now: now)
+            snapshot.apnsDelivery = try await loadAPNsDelivery(on: sql, now: now)
+            snapshot.targetableCoverage = try await loadTargetableCoverage(on: sql, now: now)
+            snapshot.slowRefreshedAt = now
+        }
+
+        snapshot.generatedAt = now
+        try await app.operatorDashboardSnapshotStore.save(snapshot, on: app.db)
+    }
+
+    private func shouldRefresh(_ refreshedAt: Date?, intervalSeconds: Int, now: Date) -> Bool {
+        guard let refreshedAt else { return true }
+        return now.timeIntervalSince(refreshedAt) >= Double(intervalSeconds)
+    }
+
+    private func loadIngestFreshness(on database: any Database) async throws -> StoredIngestFreshnessMetric {
+        let recentRuns = try await IngestSweepRunModel.query(on: database)
+            .sort(\.$completedAt, .descending)
+            .limit(OperatorDashboardConfig.ingestRecentAttemptLimit)
+            .all()
+
+        let lastSuccessful = recentRuns.first { $0.status == IngestSweepRunStatus.succeeded.rawValue }
+        let lastFailure = recentRuns.first { $0.status == IngestSweepRunStatus.failed.rawValue }
+
+        return .init(
+            recentAttemptLimit: OperatorDashboardConfig.ingestRecentAttemptLimit,
+            lastSuccessfulCompletedAt: lastSuccessful?.completedAt,
+            lastAttemptCompletedAt: recentRuns.first?.completedAt,
+            recentSuccessCount: recentRuns.filter { $0.status == IngestSweepRunStatus.succeeded.rawValue }.count,
+            recentFailureCount: recentRuns.filter { $0.status == IngestSweepRunStatus.failed.rawValue }.count,
+            lastFailureCompletedAt: lastFailure?.completedAt,
+            lastFailureMessage: lastFailure?.errorMessage
+        )
+    }
+
+    private func loadPipelineBacklog(on database: any Database) async throws -> StoredPipelineBacklogMetric {
+        let pendingTargetQuery = ArcusTargetDispatchOutboxModel.query(on: database)
+            .filter(\.$dispatched == nil)
+        let pendingNotificationQuery = ArcusNotificationOutboxModel.query(on: database)
+            .filter(\.$state == "ready")
+
+        let oldestTarget = try await pendingTargetQuery.copy().sort(\.$created, .ascending).first()
+        let oldestNotification = try await pendingNotificationQuery.copy().sort(\.$created, .ascending).first()
+
+        return .init(
+            pendingTargetDispatchCount: try await pendingTargetQuery.count(),
+            oldestPendingTargetDispatchCreatedAt: oldestTarget?.created,
+            pendingNotificationDispatchCount: try await pendingNotificationQuery.count(),
+            oldestPendingNotificationDispatchCreatedAt: oldestNotification?.created
+        )
+    }
+
+    private func loadStuckClaimedRows(on database: any Database, now: Date) async throws -> StoredStuckClaimedRowsMetric {
+        let cutoff = now.addingTimeInterval(-Double(OperatorDashboardConfig.claimedStuckThresholdSeconds))
+        let query = NotificationLedgerModel.query(on: database)
+            .group(.and) { group in
+                group.filter(\.$status == "claimed")
+                group.filter(\.$created <= cutoff)
+            }
+
+        let oldestClaim = try await query.copy().sort(\.$created, .ascending).first()
+
+        return .init(
+            thresholdSeconds: OperatorDashboardConfig.claimedStuckThresholdSeconds,
+            count: try await query.count(),
+            oldestClaimedCreatedAt: oldestClaim?.created
+        )
+    }
+
+    private func loadStaleActiveSeries(on sql: any SQLDatabase, now: Date) async throws -> StoredStaleActiveSeriesMetric {
+        let cutoff = now.addingTimeInterval(-Double(OperatorDashboardConfig.staleActiveSeriesGraceSeconds))
+        let row = try await sql.raw("""
+            SELECT COUNT(*) AS "count"
+            FROM arcus_series
+            WHERE state = 'active'
+              AND COALESCE(ends, expires) IS NOT NULL
+              AND COALESCE(ends, expires) < \(bind: cutoff)
+        """).first(decoding: SingleCountRow.self)
+
+        return .init(
+            graceSeconds: OperatorDashboardConfig.staleActiveSeriesGraceSeconds,
+            count: row.map { Int($0.count) } ?? 0
+        )
+    }
+
+    private func loadEndToEndLatency(on sql: any SQLDatabase, now: Date) async throws -> StoredEndToEndLatencyMetric {
+        let windowStart = now.addingTimeInterval(-Double(OperatorDashboardConfig.rollingWindowHours * 60 * 60))
+        let row = try await sql.raw("""
+            WITH first_success AS (
+                SELECT revision_urn, MIN(completed_at) AS first_completed_at
+                FROM notification_ledger
+                WHERE status = 'sent'
+                  AND completed_at IS NOT NULL
+                GROUP BY revision_urn
+            ),
+            windowed AS (
+                SELECT EXTRACT(EPOCH FROM (f.first_completed_at - r.received)) AS latency_seconds
+                FROM first_success f
+                JOIN alert_revisions r ON r.revision_urn = f.revision_urn
+                WHERE r.received >= \(bind: windowStart)
+                  AND f.first_completed_at >= r.received
+            )
+            SELECT COUNT(*) AS "successfulRevisionCount",
+                   PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY latency_seconds) AS "p95Seconds"
+            FROM windowed
+        """).first(decoding: LatencyAggregateRow.self)
+
+        return .init(
+            windowHours: OperatorDashboardConfig.rollingWindowHours,
+            successfulRevisionCount: row.map { Int($0.successfulRevisionCount) } ?? 0,
+            p95Seconds: row?.p95Seconds
+        )
+    }
+
+    private func loadAPNsDelivery(on sql: any SQLDatabase, now: Date) async throws -> StoredAPNsDeliveryMetric {
+        let windowStart = now.addingTimeInterval(-Double(OperatorDashboardConfig.rollingWindowHours * 60 * 60))
+        let aggregate = try await sql.raw("""
+            SELECT
+                COUNT(*) FILTER (WHERE status = 'sent') AS "sentCount",
+                COUNT(*) FILTER (WHERE status = 'failed') AS "failedCount"
+            FROM notification_ledger
+            WHERE completed_at >= \(bind: windowStart)
+              AND status IN ('sent', 'failed')
+        """).first(decoding: DeliveryAggregateRow.self)
+
+        let reasons = try await sql.raw("""
+            SELECT COALESCE(apns_error_code, 'unknown') AS "reason",
+                   COUNT(*) AS "count"
+            FROM notification_ledger
+            WHERE completed_at >= \(bind: windowStart)
+              AND status = 'failed'
+            GROUP BY COALESCE(apns_error_code, 'unknown')
+            ORDER BY COUNT(*) DESC, COALESCE(apns_error_code, 'unknown') ASC
+            LIMIT \(bind: OperatorDashboardConfig.topFailureReasonLimit)
+        """).all(decoding: ReasonAggregateRow.self)
+
+        return .init(
+            windowHours: OperatorDashboardConfig.rollingWindowHours,
+            sentCount: aggregate.map { Int($0.sentCount) } ?? 0,
+            failedCount: aggregate.map { Int($0.failedCount) } ?? 0,
+            topFailureReasons: reasons.map { .init(reason: $0.reason, count: Int($0.count)) }
+        )
+    }
+
+    private func loadSendNoOps(on sql: any SQLDatabase, now: Date) async throws -> StoredSendNoOpsMetric {
+        let windowStart = now.addingTimeInterval(-Double(OperatorDashboardConfig.rollingWindowHours * 60 * 60))
+        let aggregate = try await sql.raw("""
+            SELECT
+                COUNT(*) AS "totalAttemptCount",
+                COUNT(*) FILTER (WHERE outcome = 'no_op') AS "noOpAttemptCount"
+            FROM notification_send_attempts
+            WHERE attempted_at >= \(bind: windowStart)
+        """).first(decoding: SendAttemptAggregateRow.self)
+
+        let reasons = try await sql.raw("""
+            SELECT no_op_reason AS "reason",
+                   COUNT(*) AS "count"
+            FROM notification_send_attempts
+            WHERE attempted_at >= \(bind: windowStart)
+              AND outcome = 'no_op'
+              AND no_op_reason IS NOT NULL
+            GROUP BY no_op_reason
+            ORDER BY COUNT(*) DESC, no_op_reason ASC
+        """).all(decoding: ReasonAggregateRow.self)
+
+        return .init(
+            windowHours: OperatorDashboardConfig.rollingWindowHours,
+            totalAttemptCount: aggregate.map { Int($0.totalAttemptCount) } ?? 0,
+            noOpAttemptCount: aggregate.map { Int($0.noOpAttemptCount) } ?? 0,
+            reasons: reasons.map { .init(reason: $0.reason, count: Int($0.count)) }
+        )
+    }
+
+    private func loadZeroCandidateRate(on sql: any SQLDatabase, now: Date) async throws -> StoredZeroCandidateRateMetric {
+        let windowStart = now.addingTimeInterval(-Double(OperatorDashboardConfig.rollingWindowHours * 60 * 60))
+        let aggregate = try await sql.raw("""
+            SELECT
+                COUNT(*) FILTER (WHERE candidate_resolution_reached = TRUE) AS "candidateResolutionAttemptCount",
+                COUNT(*) FILTER (WHERE candidate_resolution_reached = TRUE AND candidate_count = 0) AS "zeroCandidateAttemptCount"
+            FROM notification_send_attempts
+            WHERE attempted_at >= \(bind: windowStart)
+        """).first(decoding: ZeroCandidateAggregateRow.self)
+
+        return .init(
+            windowHours: OperatorDashboardConfig.rollingWindowHours,
+            candidateResolutionAttemptCount: aggregate.map { Int($0.candidateResolutionAttemptCount) } ?? 0,
+            zeroCandidateAttemptCount: aggregate.map { Int($0.zeroCandidateAttemptCount) } ?? 0
+        )
+    }
+
+    private func loadTargetableCoverage(on sql: any SQLDatabase, now: Date) async throws -> StoredTargetableCoverageMetric {
+        let installationCutoff = now.addingTimeInterval(-Double(OperatorDashboardConfig.installationFreshnessThresholdSeconds))
+        let presenceCutoff = now.addingTimeInterval(-Double(OperatorDashboardConfig.presenceFreshnessThresholdSeconds))
+        let row = try await sql.raw("""
+            SELECT
+                COUNT(*) FILTER (
+                    WHERE i.is_active = TRUE AND i.is_subscribed = TRUE
+                ) AS "activeSubscribedInstallationCount",
+                COUNT(*) FILTER (
+                    WHERE i.is_active = TRUE
+                      AND i.is_subscribed = TRUE
+                      AND i.apns_device_token <> ''
+                      AND i.last_seen_at >= \(bind: installationCutoff)
+                      AND p.installation_id IS NOT NULL
+                      AND p.captured_at >= \(bind: presenceCutoff)
+                      AND (
+                          p.h3_cell IS NOT NULL
+                          OR COALESCE(BTRIM(p.county), '') <> ''
+                          OR COALESCE(BTRIM(p.zone), '') <> ''
+                          OR COALESCE(BTRIM(p.fire_zone), '') <> ''
+                      )
+                ) AS "targetableInstallationCount",
+                COUNT(*) FILTER (
+                    WHERE i.is_active = TRUE
+                      AND i.is_subscribed = TRUE
+                      AND i.apns_device_token = ''
+                ) AS "missingDeviceTokenCount",
+                COUNT(*) FILTER (
+                    WHERE i.is_active = TRUE
+                      AND i.is_subscribed = TRUE
+                      AND i.apns_device_token <> ''
+                      AND i.last_seen_at < \(bind: installationCutoff)
+                ) AS "staleInstallationHeartbeatCount",
+                COUNT(*) FILTER (
+                    WHERE i.is_active = TRUE
+                      AND i.is_subscribed = TRUE
+                      AND i.apns_device_token <> ''
+                      AND i.last_seen_at >= \(bind: installationCutoff)
+                      AND (
+                          p.installation_id IS NULL
+                          OR p.captured_at < \(bind: presenceCutoff)
+                      )
+                ) AS "stalePresenceCount",
+                COUNT(*) FILTER (
+                    WHERE i.is_active = TRUE
+                      AND i.is_subscribed = TRUE
+                      AND i.apns_device_token <> ''
+                      AND i.last_seen_at >= \(bind: installationCutoff)
+                      AND p.installation_id IS NOT NULL
+                      AND p.captured_at >= \(bind: presenceCutoff)
+                      AND NOT (
+                          p.h3_cell IS NOT NULL
+                          OR COALESCE(BTRIM(p.county), '') <> ''
+                          OR COALESCE(BTRIM(p.zone), '') <> ''
+                          OR COALESCE(BTRIM(p.fire_zone), '') <> ''
+                      )
+                ) AS "missingTargetingDataCount"
+            FROM device_installations i
+            LEFT JOIN device_presence p
+              ON p.installation_id = i.installation_id
+        """).first(decoding: TargetableCoverageRow.self)
+
+        return .init(
+            installationFreshnessSeconds: OperatorDashboardConfig.installationFreshnessThresholdSeconds,
+            presenceFreshnessSeconds: OperatorDashboardConfig.presenceFreshnessThresholdSeconds,
+            activeSubscribedInstallationCount: row.map { Int($0.activeSubscribedInstallationCount) } ?? 0,
+            targetableInstallationCount: row.map { Int($0.targetableInstallationCount) } ?? 0,
+            lossBreakdown: .init(
+                missingDeviceTokenCount: row.map { Int($0.missingDeviceTokenCount) } ?? 0,
+                staleInstallationHeartbeatCount: row.map { Int($0.staleInstallationHeartbeatCount) } ?? 0,
+                stalePresenceCount: row.map { Int($0.stalePresenceCount) } ?? 0,
+                missingTargetingDataCount: row.map { Int($0.missingTargetingDataCount) } ?? 0
+            )
+        )
+    }
+
+    private func loadH3Derivation(on sql: any SQLDatabase, now: Date) async throws -> StoredH3DerivationMetric {
+        let windowStart = now.addingTimeInterval(-Double(OperatorDashboardConfig.rollingWindowHours * 60 * 60))
+        let row = try await sql.raw("""
+            WITH base AS (
+                SELECT created, completed, result
+                FROM target_dispatch_outbox
+                WHERE created >= \(bind: windowStart)
+            ),
+            successful AS (
+                SELECT EXTRACT(EPOCH FROM (completed - created)) AS conversion_seconds
+                FROM base
+                WHERE result = 'succeeded'
+                  AND completed IS NOT NULL
+            )
+            SELECT
+                (SELECT COUNT(*) FROM base) AS "geometryBearingRevisionCount",
+                (SELECT COUNT(*) FROM base WHERE result = 'succeeded') AS "successfulConversionCount",
+                (SELECT PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY conversion_seconds) FROM successful) AS "p95ConversionSeconds"
+        """).first(decoding: H3AggregateRow.self)
+
+        return .init(
+            windowHours: OperatorDashboardConfig.rollingWindowHours,
+            geometryBearingRevisionCount: row.map { Int($0.geometryBearingRevisionCount) } ?? 0,
+            successfulConversionCount: row.map { Int($0.successfulConversionCount) } ?? 0,
+            p95ConversionSeconds: row?.p95ConversionSeconds
+        )
+    }
+
+    private func loadRecentNotificationDebugEntries(on sql: any SQLDatabase) async throws -> [StoredRecentNotificationDebugEntry] {
+        let rows = try await sql.raw("""
+            SELECT
+                d.created AS "createdAt",
+                d.series_id AS "seriesID",
+                COALESCE(s.event, s.headline, s.title, 'Unknown Alert') AS "eventName",
+                d.record_kind AS "recordKind",
+                d.mode AS "mode",
+                d.reason AS "reason",
+                d.title AS "title",
+                d.subtitle AS "subtitle",
+                d.body AS "body",
+                l.status AS "ledgerStatus",
+                l.apns_error_code AS "apnsErrorCode"
+            FROM notification_debug d
+            JOIN arcus_series s ON s.id = d.series_id
+            LEFT JOIN notification_ledger l ON l.id = d.notification_ledger_id
+            ORDER BY d.created DESC
+            LIMIT \(bind: OperatorDashboardConfig.recentNotificationDebugLimit)
+        """).all(decoding: RecentNotificationDebugRow.self)
+
+        return rows.map {
+            .init(
+                createdAt: $0.createdAt,
+                seriesID: $0.seriesID,
+                eventName: $0.eventName,
+                recordKind: $0.recordKind,
+                mode: $0.mode,
+                reason: $0.reason,
+                title: $0.title,
+                subtitle: $0.subtitle,
+                body: $0.body,
+                ledgerStatus: $0.ledgerStatus,
+                apnsErrorCode: $0.apnsErrorCode
+            )
+        }
+    }
+
+    private func loadTouchedSeries(on sql: any SQLDatabase) async throws -> [StoredTouchedSeriesEntry] {
+        let rows = try await sql.raw("""
+            WITH latest_revision AS (
+                SELECT series_id, MAX(received) AS latest_revision_received_at
+                FROM alert_revisions
+                GROUP BY series_id
+            )
+            SELECT
+                s.id AS "seriesID",
+                s.event AS "eventName",
+                s.state AS "state",
+                s.ugc_codes AS "ugcCodes",
+                s.tornado_detection AS "tornadoDetection",
+                s.tornado_damage_threat AS "tornadoDamageThreat",
+                s.current_revision_urn AS "currentRevisionUrn",
+                GREATEST(
+                    COALESCE(l.latest_revision_received_at, TIMESTAMP 'epoch'),
+                    COALESCE(s.updated, TIMESTAMP 'epoch')
+                ) AS "touchedAt",
+                l.latest_revision_received_at AS "latestRevisionReceivedAt",
+                s.updated AS "seriesUpdatedAt"
+            FROM arcus_series s
+            LEFT JOIN latest_revision l
+              ON l.series_id = s.id
+            ORDER BY "touchedAt" DESC, s.id ASC
+            LIMIT \(bind: OperatorDashboardConfig.touchedSeriesLimit)
+        """).all(decoding: TouchedSeriesRow.self)
+
+        return rows.map {
+            .init(
+                seriesID: $0.seriesID,
+                eventName: $0.eventName,
+                state: $0.state,
+                ugcCodes: $0.ugcCodes,
+                tornadoDetection: $0.tornadoDetection,
+                tornadoDamageThreat: $0.tornadoDamageThreat,
+                currentRevisionUrn: $0.currentRevisionUrn,
+                touchedAt: $0.touchedAt,
+                latestRevisionReceivedAt: $0.latestRevisionReceivedAt,
+                seriesUpdatedAt: $0.seriesUpdatedAt
+            )
+        }
+    }
+}
+
+private struct SingleCountRow: Decodable {
+    let count: Int64
+}
+
+private struct LatencyAggregateRow: Decodable {
+    let successfulRevisionCount: Int64
+    let p95Seconds: Double?
+}
+
+private struct DeliveryAggregateRow: Decodable {
+    let sentCount: Int64
+    let failedCount: Int64
+}
+
+private struct SendAttemptAggregateRow: Decodable {
+    let totalAttemptCount: Int64
+    let noOpAttemptCount: Int64
+}
+
+private struct ZeroCandidateAggregateRow: Decodable {
+    let candidateResolutionAttemptCount: Int64
+    let zeroCandidateAttemptCount: Int64
+}
+
+private struct ReasonAggregateRow: Decodable {
+    let reason: String
+    let count: Int64
+}
+
+private struct TargetableCoverageRow: Decodable {
+    let activeSubscribedInstallationCount: Int64
+    let targetableInstallationCount: Int64
+    let missingDeviceTokenCount: Int64
+    let staleInstallationHeartbeatCount: Int64
+    let stalePresenceCount: Int64
+    let missingTargetingDataCount: Int64
+}
+
+private struct H3AggregateRow: Decodable {
+    let geometryBearingRevisionCount: Int64
+    let successfulConversionCount: Int64
+    let p95ConversionSeconds: Double?
+}
+
+private struct RecentNotificationDebugRow: Decodable {
+    let createdAt: Date
+    let seriesID: UUID
+    let eventName: String
+    let recordKind: String
+    let mode: String
+    let reason: String
+    let title: String
+    let subtitle: String
+    let body: String
+    let ledgerStatus: String?
+    let apnsErrorCode: String?
+}
+
+private struct TouchedSeriesRow: Decodable {
+    let seriesID: UUID
+    let eventName: String
+    let state: String
+    let ugcCodes: [String]
+    let tornadoDetection: String?
+    let tornadoDamageThreat: String?
+    let currentRevisionUrn: String
+    let touchedAt: Date
+    let latestRevisionReceivedAt: Date?
+    let seriesUpdatedAt: Date?
+}

--- a/Sources/App/lib/OperatorDashboardSnapshotStore.swift
+++ b/Sources/App/lib/OperatorDashboardSnapshotStore.swift
@@ -1,0 +1,113 @@
+import Fluent
+import Foundation
+import Vapor
+
+public enum OperatorDashboardSnapshotStoreConstants {
+    public static let snapshotID = "current"
+}
+
+public protocol OperatorDashboardSnapshotStore: Sendable {
+    func load(on database: any Database) async throws -> OperatorDashboardStoredSnapshot?
+    func save(_ snapshot: OperatorDashboardStoredSnapshot, on database: any Database) async throws
+}
+
+public struct DatabaseOperatorDashboardSnapshotStore: OperatorDashboardSnapshotStore {
+    public init() {}
+
+    public func load(on database: any Database) async throws -> OperatorDashboardStoredSnapshot? {
+        guard let model = try await OperatorDashboardSnapshotModel
+            .find(OperatorDashboardSnapshotStoreConstants.snapshotID, on: database)
+        else {
+            return nil
+        }
+
+        if model.snapshot.schemaVersion < OperatorDashboardStoredSnapshot.currentSchemaVersion {
+            let upgraded = try await upgradeLegacySnapshot(model.snapshot, on: database)
+            model.snapshot = upgraded
+            try await model.update(on: database)
+            return upgraded
+        }
+
+        return model.snapshot
+    }
+
+    public func save(_ snapshot: OperatorDashboardStoredSnapshot, on database: any Database) async throws {
+        if let existing = try await OperatorDashboardSnapshotModel.find(
+            OperatorDashboardSnapshotStoreConstants.snapshotID,
+            on: database
+        ) {
+            existing.snapshot = snapshot
+            try await existing.update(on: database)
+            return
+        }
+
+        let created = OperatorDashboardSnapshotModel(snapshot: snapshot)
+        try await created.create(on: database)
+    }
+
+    private func upgradeLegacySnapshot(
+        _ snapshot: OperatorDashboardStoredSnapshot,
+        on database: any Database
+    ) async throws -> OperatorDashboardStoredSnapshot {
+        var detailsBySeriesID: [UUID: TouchedSeriesBackfillDetails] = [:]
+
+        for entry in snapshot.touchedSeries where entry.ugcCodes.isEmpty || entry.tornadoDetection == nil || entry.tornadoDamageThreat == nil {
+            if let series = try await ArcusSeriesModel.find(entry.seriesID, on: database) {
+                detailsBySeriesID[entry.seriesID] = .init(
+                    ugcCodes: series.ugcCodes,
+                    tornadoDetection: series.tornadoDetection,
+                    tornadoDamageThreat: series.tornadoDamageThreat
+                )
+            }
+        }
+
+        return backfillTouchedSeriesFields(in: snapshot, detailsBySeriesID: detailsBySeriesID)
+    }
+}
+
+struct TouchedSeriesBackfillDetails: Sendable {
+    let ugcCodes: [String]
+    let tornadoDetection: String?
+    let tornadoDamageThreat: String?
+}
+
+func backfillTouchedSeriesFields(
+    in snapshot: OperatorDashboardStoredSnapshot,
+    detailsBySeriesID: [UUID: TouchedSeriesBackfillDetails]
+) -> OperatorDashboardStoredSnapshot {
+    var upgraded = snapshot
+    upgraded.touchedSeries = upgraded.touchedSeries.map { entry in
+        guard let details = detailsBySeriesID[entry.seriesID] else {
+            return entry
+        }
+
+        var updatedEntry = entry
+        if updatedEntry.ugcCodes.isEmpty {
+            updatedEntry.ugcCodes = details.ugcCodes
+        }
+        if updatedEntry.tornadoDetection == nil {
+            updatedEntry.tornadoDetection = details.tornadoDetection
+        }
+        if updatedEntry.tornadoDamageThreat == nil {
+            updatedEntry.tornadoDamageThreat = details.tornadoDamageThreat
+        }
+        return updatedEntry
+    }
+    upgraded.schemaVersion = OperatorDashboardStoredSnapshot.currentSchemaVersion
+    return upgraded
+}
+
+private struct OperatorDashboardSnapshotStoreKey: StorageKey {
+    typealias Value = any OperatorDashboardSnapshotStore
+}
+
+public extension Application {
+    var operatorDashboardSnapshotStore: any OperatorDashboardSnapshotStore {
+        get {
+            storage[OperatorDashboardSnapshotStoreKey.self] ?? DatabaseOperatorDashboardSnapshotStore()
+        }
+        set {
+            storage[OperatorDashboardSnapshotStoreKey.self] = newValue
+        }
+    }
+}

--- a/Tests/AppTests/OperatorDashboardTests.swift
+++ b/Tests/AppTests/OperatorDashboardTests.swift
@@ -1,0 +1,377 @@
+@testable import App
+import Fluent
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@Suite("Operator dashboard", .serialized)
+struct OperatorDashboardTests {
+    private struct StubSnapshotStore: OperatorDashboardSnapshotStore {
+        let snapshot: OperatorDashboardStoredSnapshot?
+
+        func load(on database: any Database) async throws -> OperatorDashboardStoredSnapshot? {
+            snapshot
+        }
+
+        func save(_ snapshot: OperatorDashboardStoredSnapshot, on database: any Database) async throws {
+            _ = snapshot
+        }
+    }
+
+    private func withApp(
+        test: (Application) async throws -> Void
+    ) async throws {
+        let app = try await Application.make(.testing)
+        do {
+            try await configure(app, mode: .api)
+            try await test(app)
+        } catch {
+            try? await app.asyncShutdown()
+            throw error
+        }
+        try await app.asyncShutdown()
+    }
+
+    private func isoDate(_ value: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        guard let date = formatter.date(from: value) else {
+            fatalError("Invalid ISO8601 date in test fixture: \(value)")
+        }
+        return date
+    }
+
+    private func makeSnapshot() -> OperatorDashboardStoredSnapshot {
+        .init(
+            generatedAt: isoDate("2026-04-10T12:00:00Z"),
+            fastRefreshedAt: isoDate("2026-04-10T12:00:00Z"),
+            standardRefreshedAt: isoDate("2026-04-10T11:59:30Z"),
+            slowRefreshedAt: isoDate("2026-04-10T11:57:00Z"),
+            ingestFreshness: .init(
+                recentAttemptLimit: 60,
+                lastSuccessfulCompletedAt: isoDate("2026-04-10T11:55:00Z"),
+                lastAttemptCompletedAt: isoDate("2026-04-10T12:00:00Z"),
+                recentSuccessCount: 58,
+                recentFailureCount: 2,
+                lastFailureCompletedAt: isoDate("2026-04-10T11:31:00Z"),
+                lastFailureMessage: "temporary upstream timeout"
+            ),
+            pipelineBacklog: .init(
+                pendingTargetDispatchCount: 2,
+                oldestPendingTargetDispatchCreatedAt: isoDate("2026-04-10T11:54:00Z"),
+                pendingNotificationDispatchCount: 4,
+                oldestPendingNotificationDispatchCreatedAt: isoDate("2026-04-10T11:58:00Z")
+            ),
+            stuckClaimedRows: .init(
+                thresholdSeconds: 300,
+                count: 3,
+                oldestClaimedCreatedAt: isoDate("2026-04-10T11:48:00Z")
+            ),
+            staleActiveSeries: .init(
+                graceSeconds: 900,
+                count: 5
+            ),
+            endToEndLatency: .init(
+                windowHours: 24,
+                successfulRevisionCount: 22,
+                p95Seconds: 91
+            ),
+            apnsDelivery: .init(
+                windowHours: 24,
+                sentCount: 80,
+                failedCount: 20,
+                topFailureReasons: [
+                    .init(reason: "badDeviceToken", count: 12),
+                    .init(reason: "tooManyRequests", count: 5)
+                ]
+            ),
+            sendNoOps: .init(
+                windowHours: 24,
+                totalAttemptCount: 40,
+                noOpAttemptCount: 10,
+                reasons: [
+                    .init(reason: "zero_candidates", count: 6),
+                    .init(reason: "missing_geolocation", count: 4)
+                ]
+            ),
+            zeroCandidateRate: .init(
+                windowHours: 24,
+                candidateResolutionAttemptCount: 24,
+                zeroCandidateAttemptCount: 6
+            ),
+            targetableCoverage: .init(
+                installationFreshnessSeconds: 86_400,
+                presenceFreshnessSeconds: 21_600,
+                activeSubscribedInstallationCount: 100,
+                targetableInstallationCount: 61,
+                lossBreakdown: .init(
+                    missingDeviceTokenCount: 3,
+                    staleInstallationHeartbeatCount: 12,
+                    stalePresenceCount: 17,
+                    missingTargetingDataCount: 7
+                )
+            ),
+            h3Derivation: .init(
+                windowHours: 24,
+                geometryBearingRevisionCount: 18,
+                successfulConversionCount: 15,
+                p95ConversionSeconds: 24
+            ),
+            recentNotificationDebugEntries: [
+                .init(
+                    createdAt: isoDate("2026-04-10T11:59:00Z"),
+                    seriesID: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!,
+                    eventName: "Tornado Warning",
+                    recordKind: "candidate",
+                    mode: "h3",
+                    reason: "new",
+                    title: "Tornado Warning",
+                    subtitle: "Includes your location",
+                    body: "Take shelter now",
+                    ledgerStatus: "sent",
+                    apnsErrorCode: nil
+                ),
+                .init(
+                    createdAt: isoDate("2026-04-10T11:58:00Z"),
+                    seriesID: UUID(uuidString: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB")!,
+                    eventName: "Flash Flood Warning",
+                    recordKind: "preview_no_candidates",
+                    mode: "ugc",
+                    reason: "update",
+                    title: "Flash Flood Warning - Update",
+                    subtitle: "Updated for your area",
+                    body: "Avoid flooded roads",
+                    ledgerStatus: nil,
+                    apnsErrorCode: nil
+                )
+            ],
+            touchedSeries: [
+                .init(
+                    seriesID: UUID(uuidString: "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC")!,
+                    eventName: "Severe Thunderstorm Warning",
+                    state: "active",
+                    ugcCodes: ["COC005", "COC013"],
+                    tornadoDetection: "OBSERVED",
+                    tornadoDamageThreat: "CONSIDERABLE",
+                    currentRevisionUrn: "urn:oid:series-1",
+                    touchedAt: isoDate("2026-04-10T11:59:30Z"),
+                    latestRevisionReceivedAt: isoDate("2026-04-10T11:59:00Z"),
+                    seriesUpdatedAt: isoDate("2026-04-10T11:59:30Z")
+                ),
+                .init(
+                    seriesID: UUID(uuidString: "DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD")!,
+                    eventName: "Red Flag Warning",
+                    state: "expired",
+                    ugcCodes: [],
+                    tornadoDetection: nil,
+                    tornadoDamageThreat: nil,
+                    currentRevisionUrn: "urn:oid:series-2",
+                    touchedAt: isoDate("2026-04-10T11:54:00Z"),
+                    latestRevisionReceivedAt: isoDate("2026-04-10T11:53:00Z"),
+                    seriesUpdatedAt: isoDate("2026-04-10T11:54:00Z")
+                )
+            ]
+        )
+    }
+
+    @Test("snapshot response computes rates and ages")
+    func snapshotResponseComputesRatesAndAges() {
+        let renderedAt = isoDate("2026-04-10T12:00:00Z")
+        let response = OperatorDashboardSnapshotResponse(
+            snapshot: makeSnapshot(),
+            renderedAt: renderedAt
+        )
+
+        #expect(response.redLights.ingestFreshness.timeSinceLastSuccessfulSweepSeconds == 300)
+        #expect(response.redLights.pipelineBacklogAge.oldestPendingTargetDispatchAgeSeconds == 360)
+        #expect(abs((response.deliveryKPIs.apnsDeliverySuccessRate.successRate ?? 0) - 0.8) < 0.0001)
+        #expect(abs((response.deliveryKPIs.sendNoOpRateByReason.noOpRate ?? 0) - 0.25) < 0.0001)
+        #expect(abs((response.deliveryKPIs.zeroCandidateRevisionRate.zeroCandidateRate ?? 0) - 0.25) < 0.0001)
+        #expect(abs((response.audienceTargeting.freshTargetableInstallationCoverage.targetableRate ?? 0) - 0.61) < 0.0001)
+        #expect(abs((response.audienceTargeting.alertsWithGeographyAndH3Success.successRate ?? 0) - 0.8333333333) < 0.0001)
+    }
+
+    @Test("legacy stored snapshot decodes without ugcCodes")
+    func legacyStoredSnapshotDecodesWithoutUGCCodes() throws {
+        let json = #"""
+        {
+          "schemaVersion": 0,
+          "generatedAt": "2026-04-10T12:00:00Z",
+          "fastRefreshedAt": "2026-04-10T12:00:00Z",
+          "standardRefreshedAt": null,
+          "slowRefreshedAt": null,
+          "ingestFreshness": {
+            "recentAttemptLimit": 60,
+            "lastSuccessfulCompletedAt": null,
+            "lastAttemptCompletedAt": null,
+            "recentSuccessCount": 0,
+            "recentFailureCount": 0,
+            "lastFailureCompletedAt": null,
+            "lastFailureMessage": null
+          },
+          "pipelineBacklog": {
+            "pendingTargetDispatchCount": 0,
+            "oldestPendingTargetDispatchCreatedAt": null,
+            "pendingNotificationDispatchCount": 0,
+            "oldestPendingNotificationDispatchCreatedAt": null
+          },
+          "stuckClaimedRows": {
+            "thresholdSeconds": 300,
+            "count": 0,
+            "oldestClaimedCreatedAt": null
+          },
+          "staleActiveSeries": {
+            "graceSeconds": 900,
+            "count": 0
+          },
+          "endToEndLatency": {
+            "windowHours": 24,
+            "successfulRevisionCount": 0,
+            "p95Seconds": null
+          },
+          "apnsDelivery": {
+            "windowHours": 24,
+            "sentCount": 0,
+            "failedCount": 0,
+            "topFailureReasons": []
+          },
+          "sendNoOps": {
+            "windowHours": 24,
+            "totalAttemptCount": 0,
+            "noOpAttemptCount": 0,
+            "reasons": []
+          },
+          "zeroCandidateRate": {
+            "windowHours": 24,
+            "candidateResolutionAttemptCount": 0,
+            "zeroCandidateAttemptCount": 0
+          },
+          "targetableCoverage": {
+            "installationFreshnessSeconds": 86400,
+            "presenceFreshnessSeconds": 21600,
+            "activeSubscribedInstallationCount": 0,
+            "targetableInstallationCount": 0,
+            "lossBreakdown": {
+              "missingDeviceTokenCount": 0,
+              "staleInstallationHeartbeatCount": 0,
+              "stalePresenceCount": 0,
+              "missingTargetingDataCount": 0
+            }
+          },
+          "h3Derivation": {
+            "windowHours": 24,
+            "geometryBearingRevisionCount": 0,
+            "successfulConversionCount": 0,
+            "p95ConversionSeconds": null
+          },
+          "recentNotificationDebugEntries": [],
+          "touchedSeries": [
+            {
+              "seriesID": "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC",
+              "eventName": "Severe Thunderstorm Warning",
+              "state": "active",
+              "currentRevisionUrn": "urn:oid:series-1",
+              "touchedAt": "2026-04-10T11:59:30Z",
+              "latestRevisionReceivedAt": "2026-04-10T11:59:00Z",
+              "seriesUpdatedAt": "2026-04-10T11:59:30Z"
+            }
+          ]
+        }
+        """#
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let snapshot = try decoder.decode(OperatorDashboardStoredSnapshot.self, from: Data(json.utf8))
+        #expect(snapshot.schemaVersion == 0)
+        #expect(snapshot.touchedSeries.first?.ugcCodes == [])
+    }
+
+    @Test("legacy snapshot backfills touched-series fields")
+    func legacySnapshotBackfillsTouchedSeriesFields() {
+        var snapshot = makeSnapshot()
+        snapshot.schemaVersion = 1
+        snapshot.touchedSeries[0].ugcCodes = []
+        snapshot.touchedSeries[0].tornadoDetection = nil
+        snapshot.touchedSeries[0].tornadoDamageThreat = nil
+
+        let upgraded = backfillTouchedSeriesFields(
+            in: snapshot,
+            detailsBySeriesID: [
+                UUID(uuidString: "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC")!: .init(
+                    ugcCodes: ["COC005", "COC013"],
+                    tornadoDetection: "OBSERVED",
+                    tornadoDamageThreat: "CONSIDERABLE"
+                )
+            ]
+        )
+
+        #expect(upgraded.schemaVersion == OperatorDashboardStoredSnapshot.currentSchemaVersion)
+        #expect(upgraded.touchedSeries[0].ugcCodes == ["COC005", "COC013"])
+        #expect(upgraded.touchedSeries[0].tornadoDetection == "OBSERVED")
+        #expect(upgraded.touchedSeries[0].tornadoDamageThreat == "CONSIDERABLE")
+    }
+
+    @Test("metrics endpoint returns canonical dashboard snapshot")
+    func metricsEndpointReturnsSnapshot() async throws {
+        try await withApp { app in
+            app.operatorDashboardSnapshotStore = StubSnapshotStore(snapshot: makeSnapshot())
+
+            try await app.testing().test(.GET, "v1/metrics", afterResponse: { res async throws in
+                #expect(res.status == .ok)
+
+                let payload = try res.content.decode(OperatorDashboardSnapshotResponse.self)
+                #expect(payload.redLights.staleActiveSeriesCount.count == 5)
+                #expect(payload.operatorContext.recentNotificationDebugEntries.entries.count == 2)
+                #expect(payload.operatorContext.lastTouchedSeries.entries.first?.eventName == "Severe Thunderstorm Warning")
+                #expect(payload.operatorContext.lastTouchedSeries.entries.first?.ugcCodes == ["COC005", "COC013"])
+                #expect(payload.operatorContext.lastTouchedSeries.entries.first?.tornadoDetection == "OBSERVED")
+                #expect(payload.operatorContext.lastTouchedSeries.entries.first?.tornadoDamageThreat == "CONSIDERABLE")
+            })
+        }
+    }
+
+    @Test("dashboard page renders core sections from snapshot")
+    func dashboardPageRendersSnapshot() async throws {
+        try await withApp { app in
+            app.operatorDashboardSnapshotStore = StubSnapshotStore(snapshot: makeSnapshot())
+
+            try await app.testing().test(.GET, "dashboard", afterResponse: { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.contentType == .html)
+                #expect(res.body.string.contains("Red Lights"))
+                #expect(res.body.string.contains("Delivery KPIs"))
+                #expect(res.body.string.contains("Audience / Targeting"))
+                #expect(res.body.string.contains("Operator Context"))
+                #expect(res.body.string.contains("Arcus Signal"))
+                #expect(res.body.string.contains("Tornado Warning"))
+                #expect(res.body.string.contains("Tornado detection"))
+                #expect(res.body.string.contains("Tornado damage threat"))
+                #expect(res.body.string.contains("ugc_codes"))
+                #expect(res.body.string.contains("COC005, COC013"))
+                #expect(res.body.string.contains("OBSERVED"))
+                #expect(res.body.string.contains("CONSIDERABLE"))
+                #expect(res.body.string.contains("urn:oid:series-1"))
+                #expect(res.body.string.contains("fetch('/v1/metrics'"))
+                #expect(res.body.string.contains("window.setInterval(fetchSnapshot, pollIntervalMs)"))
+                #expect(res.body.string.contains("The page polls the canonical"))
+                #expect(res.body.string.contains("hero-rendered-at"))
+                #expect(res.body.string.contains("http-equiv=\"refresh\"") == false)
+            })
+        }
+    }
+
+    @Test("dashboard page returns unavailable shell without snapshot")
+    func dashboardPageUnavailableWithoutSnapshot() async throws {
+        try await withApp { app in
+            app.operatorDashboardSnapshotStore = StubSnapshotStore(snapshot: nil)
+
+            try await app.testing().test(.GET, "dashboard", afterResponse: { res async in
+                #expect(res.status == .serviceUnavailable)
+                #expect(res.body.string.contains("Dashboard Snapshot Unavailable"))
+                #expect(res.body.string.contains("window.location.replace('/dashboard')"))
+                #expect(res.body.string.contains("http-equiv=\"refresh\"") == false)
+            })
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- added an operator dashboard snapshot pipeline that computes and stores dashboard data off the request path
- added a canonical `GET /v1/metrics` API and a server-rendered `GET /dashboard` page backed by the same snapshot model
- added durable support tables and workflow instrumentation for ingest sweep health, send attempts, ledger completion timing, and H3 dispatch completion
- added dashboard-focused tests for snapshot calculations, API behavior, HTML rendering, smooth polling refresh, and legacy snapshot compatibility/backfill

## Why this changed

Operators needed a fast way to tell whether ingest, targeting, and delivery are healthy end to end without running expensive ad hoc queries on request paths.

## Impact

- exposes a stable metrics snapshot for operational tooling and manual inspection
- provides a dark-mode server-rendered dashboard for quick health checks
- keeps expensive aggregation work in the worker and serves precomputed snapshot data from the API
- updates the dashboard in place from `/v1/metrics` so the page refreshes smoothly without full-document jitter
- backfills legacy stored dashboard snapshots so newer touched-series fields render correctly without manual cleanup

## Root cause addressed

There was no single operational snapshot for the decoupled ingest, targeting, queue handoff, and delivery flows, which made it difficult to spot stalls, backlog growth, stale targeting, or silent delivery failures quickly.

## Validation

- `swift test --filter OperatorDashboardTests`
- `swift build`

## Notes

- the local worktree still has an unrelated unstaged change in `docs/Sql/_scratch.sql`; it is not part of this PR
