### PR TITLE
Include geolocation geometry in device alert payloads

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/console-kit.git",
       "state" : {
-        "revision" : "742f624a998cba2a9e653d9b1e91ad3f3a5dff6b",
-        "version" : "4.15.2"
+        "revision" : "32ad16dfc7677b927b225595ed18f3debb32f577",
+        "version" : "4.16.0"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/sql-kit.git",
       "state" : {
-        "revision" : "46d1a644846c6c42890a06988eb85cd975c3afc6",
-        "version" : "3.35.0"
+        "revision" : "3779cedb44b1f374f2cca261c6d28f206024a582",
+        "version" : "3.36.0"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
-        "version" : "1.6.0"
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
-        "version" : "1.18.0"
+        "revision" : "5aa1c0d1bc204908df47c2075bdbb39573d05e8d",
+        "version" : "1.19.0"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "fa308c07a6fa04a727212d793e761460e41049c3",
-        "version" : "4.3.0"
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
       }
     },
     {
@@ -240,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-structured-headers.git",
       "state" : {
-        "revision" : "76d7627bd88b47bf5a0f8497dd244885960dde0b",
-        "version" : "1.6.0"
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
       }
     },
     {
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
-        "version" : "1.10.1"
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
       }
     },
     {
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "f17c111cec972c2a4922cef38cf64f76f7e87886",
-        "version" : "2.8.0"
+        "revision" : "d51c8d13fa366eec807eedb4e37daa60ff5bfdd5",
+        "version" : "2.10.1"
       }
     },
     {
@@ -276,8 +276,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
-        "version" : "2.97.1"
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
       }
     },
     {
@@ -285,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "abcf5312eb8ed2fb11916078aef7c46b06f20813",
-        "version" : "1.33.0"
+        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
+        "version" : "1.34.0"
       }
     },
     {
@@ -294,8 +294,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "6d8d596f0a9bfebb925733003731fe2d749b7e02",
-        "version" : "1.42.0"
+        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
+        "version" : "1.43.0"
       }
     },
     {
@@ -303,8 +303,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "df9c3406028e3297246e6e7081977a167318b692",
-        "version" : "2.36.1"
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
       }
     },
     {
@@ -312,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "60c3e187154421171721c1a38e800b390680fb5d",
-        "version" : "1.26.0"
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
       }
     },
     {
@@ -339,8 +339,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
       "state" : {
-        "revision" : "89888196dd79c61c50bca9a103d8114f32e1e598",
-        "version" : "2.10.1"
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {
@@ -366,8 +366,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor.git",
       "state" : {
-        "revision" : "a8db2dbda8b3cdc8a61bd35128590bd296e85563",
-        "version" : "4.121.3"
+        "revision" : "cfd8f434843ac7850e2d97f46c1aa5ddb906cf1c",
+        "version" : "4.121.4"
       }
     },
     {
@@ -375,8 +375,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/websocket-kit.git",
       "state" : {
-        "revision" : "8666c92dbbb3c8eefc8008c9c8dcf50bfd302167",
-        "version" : "2.16.1"
+        "revision" : "90bbbdab3ede12c803cfbe91646f291c092517a3",
+        "version" : "2.16.2"
       }
     }
   ],

--- a/Sources/App/Models/API/AlertSeriesRow.swift
+++ b/Sources/App/Models/API/AlertSeriesRow.swift
@@ -36,6 +36,7 @@ struct AlertSeriesRow: Decodable, Sendable {
     let response: String?
     let ugcCodes: [String]
     let h3Cells: [Int64]
+    let geometry: GeoShape?
     let tornadoDetection: String?
     let tornadoDamageThreat: String?
     let maxWindGust: String?
@@ -73,6 +74,7 @@ struct AlertSeriesRow: Decodable, Sendable {
             response: response,
             ugc: ugcCodes,
             h3Cells: h3Cells,
+            geometry: geometry.flatMap(DeviceAlertGeometry.init(geoShape:)),
             tornadoDetection: tornadoDetection,
             tornadoDamageThreat: tornadoDamageThreat,
             maxWindGust: maxWindGust,
@@ -126,7 +128,8 @@ extension AlertSeriesRow {
             "\(ident: seriesAlias).\(ident: "thunderstorm_damage_threat") AS \(ident: "thunderstormDamageThreat")",
             "\(ident: seriesAlias).\(ident: "flash_flood_detection") AS \(ident: "flashFloodDetection")",
             "\(ident: seriesAlias).\(ident: "flash_flood_damage_threat") AS \(ident: "flashFloodDamageThreat")",
-            "COALESCE(\(ident: geolocationAlias).\(ident: "h3_cells"), '{}'::bigint[]) AS \(ident: "h3Cells")"
+            "COALESCE(\(ident: geolocationAlias).\(ident: "h3_cells"), '{}'::bigint[]) AS \(ident: "h3Cells")",
+            "\(ident: geolocationAlias).\(ident: "geometry") AS \(ident: "geometry")"
         ]
         .joined(separator: ",\n")
     }

--- a/Sources/App/Models/Device/DeviceAlertPayload.swift
+++ b/Sources/App/Models/Device/DeviceAlertPayload.swift
@@ -13,6 +13,95 @@ public enum DeviceAlertPayloadError: Error, Sendable {
     case invalidGeometryJSON
 }
 
+public enum DeviceAlertGeometry: Sendable, Codable, Equatable {
+    case polygon(rings: [[DeviceAlertCoordinate]])
+    case multiPolygon(polygons: [[[DeviceAlertCoordinate]]])
+
+    public init?(geoShape: GeoShape) {
+        switch geoShape {
+        case .point:
+            return nil
+        case .polygon(let rings):
+            self = .polygon(rings: rings.map { ring in
+                ring.map { DeviceAlertCoordinate(geoCoordinate: $0) }
+            })
+        case .multiPolygon(let polygons):
+            self = .multiPolygon(polygons: polygons.map { polygon in
+                polygon.map { ring in
+                    ring.map { DeviceAlertCoordinate(geoCoordinate: $0) }
+                }
+            })
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case coordinates
+    }
+
+    private enum GeometryType: String, Codable {
+        case polygon = "Polygon"
+        case multiPolygon = "MultiPolygon"
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(GeometryType.self, forKey: .type)
+
+        switch type {
+        case .polygon:
+            let rings = try container.decode([[DeviceAlertCoordinate]].self, forKey: .coordinates)
+            self = .polygon(rings: rings)
+        case .multiPolygon:
+            let polygons = try container.decode([[[DeviceAlertCoordinate]]].self, forKey: .coordinates)
+            self = .multiPolygon(polygons: polygons)
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .polygon(let rings):
+            try container.encode(GeometryType.polygon, forKey: .type)
+            try container.encode(rings, forKey: .coordinates)
+        case .multiPolygon(let polygons):
+            try container.encode(GeometryType.multiPolygon, forKey: .type)
+            try container.encode(polygons, forKey: .coordinates)
+        }
+    }
+}
+
+/// GeoJSON-like transport coordinate stored as `[longitude, latitude]`.
+/// Convert to map-native coordinate types only at the rendering edge.
+public struct DeviceAlertCoordinate: Sendable, Codable, Equatable {
+    public let longitude: Double
+    public let latitude: Double
+
+    public init(longitude: Double, latitude: Double) {
+        self.longitude = longitude
+        self.latitude = latitude
+    }
+
+    public init(from decoder: any Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        longitude = try container.decode(Double.self)
+        latitude = try container.decode(Double.self)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(longitude)
+        try container.encode(latitude)
+    }
+}
+
+private extension DeviceAlertCoordinate {
+    init(geoCoordinate: GeoShape.GeoCoordinate) {
+        self.init(longitude: geoCoordinate.lon, latitude: geoCoordinate.lat)
+    }
+}
+
 public struct DeviceAlertPayload: Sendable, Codable, Content {
     // MARK: Identity
     let id: UUID // Series Id
@@ -49,6 +138,7 @@ public struct DeviceAlertPayload: Sendable, Codable, Content {
     
     let ugc: [String]
     var h3Cells: [Int64]
+    let geometry: DeviceAlertGeometry?
     
     // CAP Params
     let tornadoDetection: String?
@@ -61,4 +151,3 @@ public struct DeviceAlertPayload: Sendable, Codable, Content {
     let flashFloodDetection: String?
     let flashFloodDamageThreat: String?
 }
-

--- a/Sources/App/Models/NWS/ArcusSeriesModel.swift
+++ b/Sources/App/Models/NWS/ArcusSeriesModel.swift
@@ -312,14 +312,17 @@ public extension ArcusSeriesModel {
         guard let cleanId = id else { throw DeviceAlertPayloadError.missingRequired(field: "id") }
         guard let cleanCreate = created else { throw DeviceAlertPayloadError.missingRequired(field: "created") }
         guard let cleanUpdate = updated else { throw DeviceAlertPayloadError.missingRequired(field: "updated") }
-        let h3Cells: [Int64]
+        let geolocation: ArcusGeolocationModel?
 
         switch $geolocation.value {
-        case .some(let geolocation):
-            h3Cells = geolocation?.h3Cells ?? []
+        case .some(let loadedGeolocation):
+            geolocation = loadedGeolocation
         case .none:
-            h3Cells = []
+            geolocation = nil
         }
+
+        let h3Cells = geolocation?.h3Cells ?? []
+        let geometry = geolocation.flatMap { DeviceAlertGeometry(geoShape: $0.geometry) }
         
         return .init(
             id: cleanId,
@@ -347,6 +350,7 @@ public extension ArcusSeriesModel {
             response: response,
             ugc: ugcCodes,
             h3Cells: h3Cells,
+            geometry: geometry,
             tornadoDetection: tornadoDetection,
             tornadoDamageThreat: tornadoDamageThreat,
             maxWindGust: maxWindGust,

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -1,4 +1,5 @@
 @testable import App
+import FluentSQL
 import Foundation
 #if canImport(Darwin)
 import Darwin
@@ -116,7 +117,8 @@ struct AppTests {
         id: UUID = UUID(),
         now: Date,
         ugcCodes: [String] = ["COC031"],
-        h3Cells: [Int64] = []
+        h3Cells: [Int64] = [],
+        geometry: GeoShape? = nil
     ) -> AlertSeriesRow {
         AlertSeriesRow(
             id: id,
@@ -145,6 +147,7 @@ struct AppTests {
             response: "Shelter",
             ugcCodes: ugcCodes,
             h3Cells: h3Cells,
+            geometry: geometry,
             tornadoDetection: nil,
             tornadoDamageThreat: nil,
             maxWindGust: nil,
@@ -311,6 +314,82 @@ struct AppTests {
         let payload = try series.asDeviceAlertPayload()
 
         #expect(payload.h3Cells == [617700169958293503])
+        #expect(payload.geometry == nil)
+    }
+
+    @Test("Device alert payload includes eager-loaded polygon geometry")
+    func deviceAlertPayloadIncludesGeolocationGeometry() throws {
+        let now = isoDate("2026-03-19T16:00:00Z")
+        let seriesID = UUID()
+        let series = ArcusSeriesModel(
+            id: seriesID,
+            source: EventSource.nws.rawValue,
+            event: "Tornado Warning",
+            sourceURL: "https://api.weather.gov/alerts/test-alert",
+            currentRevisionUrn: "urn:oid:test-alert",
+            currentRevisionSent: now,
+            messageType: NWSAlertMessageType.alert.rawValue,
+            contentFingerprint: "fingerprint",
+            state: EventState.active.rawValue,
+            created: now,
+            updated: now,
+            sent: now,
+            effective: now,
+            onset: nil,
+            expires: nil,
+            ends: nil,
+            lastSeenActive: now,
+            severity: EventSeverity.severe.rawValue,
+            urgency: EventUrgency.immediate.rawValue,
+            certainty: EventCertainty.observed.rawValue,
+            ugcCodes: ["COC031"],
+            areaDesc: "Denver County",
+            description: "Storm text"
+        )
+        series.$geolocation.value = .some(
+            ArcusGeolocationModel(
+                series: seriesID,
+                geometry: .polygon(
+                    rings: [[
+                        .init(lon: -104.0, lat: 39.0),
+                        .init(lon: -103.5, lat: 39.5),
+                        .init(lon: -104.0, lat: 39.0)
+                    ]]
+                ),
+                geometryHash: "geom-hash",
+                h3Cells: [617700169958293503],
+                h3Resolution: 8,
+                h3Hash: "h3-hash"
+            )
+        )
+
+        let payload = try series.asDeviceAlertPayload()
+
+        #expect(payload.h3Cells == [617700169958293503])
+        #expect(payload.geometry == .polygon(rings: [[
+            .init(longitude: -104.0, latitude: 39.0),
+            .init(longitude: -103.5, latitude: 39.5),
+            .init(longitude: -104.0, latitude: 39.0)
+        ]]))
+    }
+
+    @Test("Device alert geometry converts multipolygon server geometry")
+    func deviceAlertGeometryConvertsMultipolygonGeoShape() {
+        let geometry = DeviceAlertGeometry(
+            geoShape: .multiPolygon(
+                polygons: [[[
+                    .init(lon: -104.0, lat: 39.0),
+                    .init(lon: -103.5, lat: 39.5),
+                    .init(lon: -104.0, lat: 39.0)
+                ]]]
+            )
+        )
+
+        #expect(geometry == .multiPolygon(polygons: [[[
+            .init(longitude: -104.0, latitude: 39.0),
+            .init(longitude: -103.5, latitude: 39.5),
+            .init(longitude: -104.0, latitude: 39.0)
+        ]]]))
     }
 
     @Test("Alert series row maps UGC codes and empty H3 cells into device payload")
@@ -325,6 +404,7 @@ struct AppTests {
 
         #expect(payload.ugc == ["COC031", "COZ038"])
         #expect(payload.h3Cells == [])
+        #expect(payload.geometry == nil)
         #expect(payload.senderName == "NWS Boulder CO")
     }
 
@@ -340,6 +420,42 @@ struct AppTests {
 
         #expect(payload.ugc == ["COC031"])
         #expect(payload.h3Cells == [617700169958293503, 617700170495164415])
+    }
+
+    @Test("Alert series row carries joined polygon geometry into device payload")
+    func alertSeriesRowPayloadIncludesJoinedGeometry() {
+        let now = isoDate("2026-03-19T16:00:00Z")
+        let row = makeAlertSeriesRow(
+            now: now,
+            geometry: .polygon(rings: [[
+                .init(lon: -104.0, lat: 39.0),
+                .init(lon: -103.5, lat: 39.5),
+                .init(lon: -104.0, lat: 39.0)
+            ]])
+        )
+
+        let payload = row.asDeviceAlertPayload()
+
+        #expect(payload.geometry == .polygon(rings: [[
+            .init(longitude: -104.0, latitude: 39.0),
+            .init(longitude: -103.5, latitude: 39.5),
+            .init(longitude: -104.0, latitude: 39.0)
+        ]]))
+    }
+
+    @Test("Alert series row selects geolocation geometry instead of deprecated series geometry")
+    func alertSeriesRowSelectsJoinedGeolocationGeometry() async throws {
+        try await withApp(mode: .api) { app in
+            guard let sql = app.db as? any SQLDatabase else {
+                Issue.record("Expected configured app database to support SQL serialization.")
+                return
+            }
+
+            let columns = sql.serialize(AlertSeriesRow.sqlSelectColumns()).sql
+
+            #expect(columns.contains(#""g"."geometry" AS "geometry""#))
+            #expect(!columns.contains(#""s"."geometry" AS "geometry""#))
+        }
     }
 
     @Test("NWS event JSON decodes polygon geometry coordinates")

--- a/docs/Sql/Device.sql
+++ b/docs/Sql/Device.sql
@@ -3,3 +3,8 @@
 
 SELECT * FROM device_installations;
 SELECT * FROM device_presence;
+
+SELECT d.apns_environment,p.*
+FROM device_presence p
+LEFT JOIN device_installations d ON d.installation_id = p.installation_id
+WHERE d.apns_environment = 'prod'

--- a/docs/Sql/NotificationProcessing.sql
+++ b/docs/Sql/NotificationProcessing.sql
@@ -2,6 +2,7 @@
 -- build it out
 
 
-SElECT *
-FROM notification_ledger
+SElECT l.series_id, l.mode, l.reason, l.status, p.zone, p.h3_cell, l.created, l.completed_at
+FROM notification_ledger l
+left join device_presence p on l.installation_id = p.installation_id
 ORDER BY created desc nulls LAST

--- a/docs/Sql/_scratch.sql
+++ b/docs/Sql/_scratch.sql
@@ -1,9 +1,37 @@
 
 
-SELECT *
-FROM arcus_series
-ORDER BY ends DESC NULLS LAST
+SELECT s.* --s.id, s.event, r.id as RevId
+FROM arcus_series s
+--LEFT JOIN alert_revisions r ON r.series_id = s.id
+-- WHERE ends = '2026-03-15 04:00:00+00'
+ORDER BY created DESC NULLS LAST
 
+SELECT *
+FROM alert_revisions
+
+
+SELECT s.*, o.*
+FROM arcus_series s
+-- LEFT JOIN alert_revisions r on r.series_id = s.id
+-- LEFT JOIN arcus_geolocation g on g.series_id = s.id
+-- LEFT JOIN notification_ledger n ON n.series_id = s.id
+LEFT JOIN notification_outbox o ON o.series_id = s.id
+WHERE s.id = '6b2a670a-3b6e-4f63-8dff-c9c640381cb8'
+
+-- series
+-- revisions
+-- h3 cells
+-- notification ledger
+
+SelECT *
+FROM notification_ledger
+ORDER BY created desc nulls LAST
+
+SELECT * FROM device_installations;
+SELECT * FROM device_presence
+
+
+select * from target_dispatch_outbox
 
 SELECT *
 FROM arcus_series
@@ -59,3 +87,66 @@ LIMIT 1
 -- ALTER TABLE arcus_series
 -- ADD CONSTRAINT alert_series_state_check
 -- CHECK (state IN ('active', 'cancelled_in_error', 'cancelled', 'ended', 'expired'));
+
+SELECT *
+FROM notification_ledger
+WHERE series_id = 'b3c804ae-7707-4fd8-a280-f3a7ad5c2581'
+
+
+
+SELECT *--id, event, description, message_type
+FROM arcus_series
+-- WHERE event = 'Severe Thunderstorm Warning' AND message_type = 'alert' --AND description ~~* '%Tornado%'
+ORDER BY created desc
+WHERE description ~~* '%Tornado%' AND event <> 'Tornado Warning' AND event <> 'Tornado Watch'
+ORDER BY created DESC
+
+SELECT * from alert_revisions
+WHERE series_id = '32e7a79b-3599-4a39-a60e-ce7e961f3016'
+
+SELECT *
+FROM arcus_series
+WHERE id = '67DD1A5C-21E7-4BFB-8A3C-A7E40D7BDFB9'
+
+-- UPDATE arcus_series
+--     SET tornado_damage_threat = 'catastrophic', tornado_detection = 'possible',
+--     max_wind_gust = '60', max_hail_size = '1.25', wind_threat = 'yes', hail_threat = 'no',
+--     thunderstorm_damage_threat = 'significant', flash_flood_damage_threat = 'deep', flash_flood_detection = 'radar indicated'
+--     WHERE id = '67DD1A5C-21E7-4BFB-8A3C-A7E40D7BDFB9'
+
+
+
+
+SELECT s.id, s.event, s.geometry, g.*
+FROM arcus_series s
+LEFT JOIN arcus_geolocation g on s.id = g.series_id
+WHERE s.geometry IS NOT NULL AND g.id IS NULL
+ORDER BY s.created DESC
+
+
+SELECT *
+FROM target_dispatch_outbox
+WHERE created >= NOW() - INTERVAL '24 hours'
+
+WHERE geometry IS NOT NULL
+AND created >= NOW() - INTERVAL '24 hours';
+
+
+
+WITH base AS (
+    SELECT created, completed, result
+    FROM target_dispatch_outbox
+    WHERE created >= NOW() - INTERVAL '24 hours'
+),
+successful AS (
+    SELECT EXTRACT(EPOCH FROM (completed - created)) AS conversion_seconds
+    FROM base
+    WHERE result = 'succeeded'
+      AND completed IS NOT NULL
+)
+SELECT
+    (SELECT COUNT(*) FROM base) AS "geometryBearingRevisionCount",
+    (SELECT COUNT(*) FROM base WHERE result = 'succeeded') AS "successfulConversionCount",
+    (SELECT PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY conversion_seconds) FROM successful) AS "p95ConversionSeconds";
+
+


### PR DESCRIPTION
# Summary
This branch adds geolocation geometry to the device alert payload so downstream consumers can receive polygon and multipolygon alert shapes alongside the existing H3 targeting data. It also updates the joined alert query to source geometry from the geolocation record and adds coverage for the new payload shape.

# What Changed
- Added `DeviceAlertGeometry` and `DeviceAlertCoordinate` to model GeoJSON-like polygon and multipolygon payloads.
- Included optional geometry in `DeviceAlertPayload` and populate it from eager-loaded geolocation data.
- Updated `AlertSeriesRow` to select `geolocation.geometry` and map it into the payload.
- Added tests covering polygon and multipolygon geometry conversion and query selection.
- Refreshed `Package.resolved` and updated the SQL docs that mirror the alert query shape.

# User Impact
Device alerts can now carry the underlying alert area geometry, which enables downstream clients to render alert boundaries more precisely. Existing H3 targeting still remains in place.

# Testing
- `swift test --filter AppTests` passed.

# Notes
- Geometry is optional and remains `nil` when the geolocation relation is not loaded or the source shape is a point.
- The alert row now reads geometry from the joined geolocation record rather than the older series-level geometry path.

closes #48 
