### PR TITLE
Implement FB-019 freshness delivery boundary and migration hardening

### DIFF
--- a/Sources/App/Clients/APNsClient.swift
+++ b/Sources/App/Clients/APNsClient.swift
@@ -23,7 +23,16 @@ struct AlertDetails: Sendable, Codable {
     let body: String
 }
 
-struct APNsClient {
+protocol NotificationSender: Sendable {
+    func sendNotification(
+        app: Application,
+        with details: AlertDetails,
+        to device: String,
+        environment: APNsEnvironment
+    ) async throws
+}
+
+struct APNsClient: NotificationSender {
     func sendNotification(
         app: Application,
         with details: AlertDetails,

--- a/Sources/App/Infrastructure/Notifications/LocationFreshnessPolicy.swift
+++ b/Sources/App/Infrastructure/Notifications/LocationFreshnessPolicy.swift
@@ -1,0 +1,62 @@
+//
+//  LocationFreshnessPolicy.swift
+//  ArcusSignal
+//
+//  Created by Codex on 5/5/26.
+//
+
+import Foundation
+
+public enum LocationFreshnessState: String, Codable, Sendable {
+    case fresh
+    case degraded
+    case stale
+}
+
+public struct LocationFreshnessDecision: Sendable, Equatable {
+    public let state: LocationFreshnessState
+    public let age: TimeInterval
+
+    public init(state: LocationFreshnessState, age: TimeInterval) {
+        self.state = state
+        self.age = age
+    }
+}
+
+public struct LocationFreshnessPolicy: Sendable {
+    private static let hour: TimeInterval = 60 * 60
+    private static let staleThreshold: TimeInterval = 24 * hour
+    private static let whenInUseFreshThreshold: TimeInterval = 2 * hour
+    private static let alwaysFreshThreshold: TimeInterval = 6 * hour
+
+    public init() {}
+
+    public func decide(
+        capturedAt: Date,
+        locationAuth: LocationAuth,
+        now: Date
+    ) -> LocationFreshnessDecision {
+        let age = max(0, now.timeIntervalSince(capturedAt))
+
+        guard age <= Self.staleThreshold else {
+            return .init(state: .stale, age: age)
+        }
+
+        let freshThreshold: TimeInterval
+        switch locationAuth {
+        case .whenInUse:
+            freshThreshold = Self.whenInUseFreshThreshold
+        case .always:
+            freshThreshold = Self.alwaysFreshThreshold
+        case .denied, .restricted, .notDetermined, .unknown:
+            // Conservative fallback for non-granted authorization.
+            return .init(state: .stale, age: age)
+        }
+
+        if age <= freshThreshold {
+            return .init(state: .fresh, age: age)
+        }
+
+        return .init(state: .degraded, age: age)
+    }
+}

--- a/Sources/App/Infrastructure/Notifications/NotificationEngine.swift
+++ b/Sources/App/Infrastructure/Notifications/NotificationEngine.swift
@@ -70,9 +70,15 @@ struct NotificationEngine: Sendable {
     func buildNotification(
         for series: ArcusSeriesModel,
         with payload: NotificationSendJobPayload,
-        on device: NotificationCandidate
+        on device: NotificationCandidate,
+        freshnessState: LocationFreshnessState? = nil
     ) -> AlertDetails {
-        buildAlertDetails(for: series, with: payload, on: device)
+        buildAlertDetails(
+            for: series,
+            with: payload,
+            on: device,
+            freshnessState: freshnessState
+        )
     }
 
     func buildPreviewNotification(
@@ -85,7 +91,8 @@ struct NotificationEngine: Sendable {
     private func buildAlertDetails(
         for series: ArcusSeriesModel,
         with payload: NotificationSendJobPayload,
-        on device: NotificationCandidate?
+        on device: NotificationCandidate?,
+        freshnessState: LocationFreshnessState? = nil
     ) -> AlertDetails {
         let eventName = deriveEventName(for: series)
         let tone = deriveTone(for: series)
@@ -93,7 +100,12 @@ struct NotificationEngine: Sendable {
         let severeTags = deriveSevereTags(for: series, of: eventKind)
 
         let title = deriveTitle(for: eventName, reason: payload.reason)
-        let subTitle = deriveSubtitle(with: payload, on: device)
+        let subTitle = deriveSubtitle(
+            with: payload,
+            eventKind: eventKind,
+            on: device,
+            freshnessState: freshnessState
+        )
         let body = deriveBody(
             for: eventKind,
             tone: tone,
@@ -219,12 +231,24 @@ struct NotificationEngine: Sendable {
 
     private func deriveSubtitle(
         with payload: NotificationSendJobPayload,
-        on device: NotificationCandidate?
+        eventKind: NotificationEventKind,
+        on device: NotificationCandidate?,
+        freshnessState: LocationFreshnessState?
     ) -> String {
         _ = device
 
         switch payload.reason {
         case .new:
+            if eventKind.isWarningOrWatch, let freshnessState {
+                switch freshnessState {
+                case .fresh:
+                    return "Includes your location"
+                case .degraded:
+                    return "For your last known area"
+                case .stale:
+                    preconditionFailure("Stale candidates should never reach notification composition")
+                }
+            }
             return payload.mode == .h3 ? "Includes your location" : "For your area"
         case .update:
             return "Updated for your area"
@@ -650,5 +674,27 @@ struct NotificationEngine: Sendable {
         }
 
         return "Hail up to \(trimmed) in"
+    }
+}
+
+private extension NotificationEventKind {
+    var isWarningOrWatch: Bool {
+        switch self {
+        case .tornadoWarning,
+             .tornadoWatch,
+             .severeThunderstormWarning,
+             .severeThunderstormWatch,
+             .flashFloodWarning,
+             .blizzardWarning,
+             .winterStormWarning,
+             .fireWarning,
+             .fireWeatherWatch,
+             .redFlagWarning,
+             .genericWarning,
+             .genericWatch:
+            return true
+        case .extremeFireDanger, .generic:
+            return false
+        }
     }
 }

--- a/Sources/App/Jobs/NotificationSendJob.swift
+++ b/Sources/App/Jobs/NotificationSendJob.swift
@@ -16,10 +16,15 @@ struct NotificationCandidate: Decodable {
     let id: UUID
     let apnsToken: String
     let apnsEnvironment: String
+    let locationAuthRaw: String
+    let capturedAt: Date
+    let receivedAt: Date
     let countyLabel: String?
     let fireZoneLabel: String?
-//    let matchReason: String
-//    let locality: String?
+
+    var locationAuth: LocationAuth {
+        LocationAuth(rawValue: locationAuthRaw) ?? .unknown
+    }
 }
 
 struct LedgerClaimResult {
@@ -34,6 +39,11 @@ struct DispatchNotificationsResult {
     let sentCount: Int
     let failedCount: Int
     let noOpReason: NotificationSendNoOpReason?
+}
+
+enum NotificationCandidateDeliveryDisposition: Sendable, Equatable {
+    case deliver(LocationFreshnessDecision)
+    case skipStale(LocationFreshnessDecision)
 }
 
 public enum NotificationTargetMode: String, Codable, Sendable {
@@ -71,8 +81,27 @@ public struct NotificationSendJob: AsyncJob {
     public typealias Payload = NotificationSendJobPayload
     private let sender: APNsClient = APNsClient()
     private let engine: NotificationEngine = NotificationEngine()
+    private let freshnessPolicy: LocationFreshnessPolicy = LocationFreshnessPolicy()
+    private let missedDecisionStore: NotificationMissedDecisionStore = NotificationMissedDecisionStore()
     
     public init () {}
+
+    func deliveryDisposition(
+        for candidate: NotificationCandidate,
+        evaluatedAt: Date
+    ) -> NotificationCandidateDeliveryDisposition {
+        let freshness = freshnessPolicy.decide(
+            capturedAt: candidate.capturedAt,
+            locationAuth: candidate.locationAuth,
+            now: evaluatedAt
+        )
+        switch freshness.state {
+        case .stale:
+            return .skipStale(freshness)
+        case .fresh, .degraded:
+            return .deliver(freshness)
+        }
+    }
     
     public func dequeue(_ context: QueueContext, _ payload: Payload) async throws {
         context.logger.info(
@@ -152,7 +181,6 @@ public struct NotificationSendJob: AsyncJob {
             // Get our list of candidates
             let h3Candidates = try await loadH3Candidates(
                 cells: geo.h3Cells,
-                freshnessCutoff: nil,
                 on: context.application.db
             )
             
@@ -172,7 +200,6 @@ public struct NotificationSendJob: AsyncJob {
             // we only have 2 modes right now, so its ugc
             let ugcCandidates = try await loadUGCCandidates(
                 ugcCodes: series.ugcCodes,
-                freshnessCutoff: nil,
                 on: context.application.db
             )
 
@@ -214,60 +241,38 @@ public struct NotificationSendJob: AsyncJob {
 private extension NotificationSendJob {
     func loadUGCCandidates(
         ugcCodes: [String],
-        freshnessCutoff: Date?,
         on db: any Database
     ) async throws -> [NotificationCandidate] {
         guard let sql = db as? any SQLDatabase else {
             throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
         }
 
-        if let freshnessCutoff {
-            return try await sql.raw("""
-                SELECT
-                    i.installation_id AS "id",
-                    i.apns_device_token AS "apnsToken",
-                    i.apns_environment AS "apnsEnvironment",
-                    p.county_label as countyLabel,
-                    p.fire_zone_label as fireZoneLabel
-                FROM device_installations i
-                JOIN device_presence p on i.installation_id = p.installation_id
-                WHERE i.is_active = TRUE
-                  AND i.is_subscribed = TRUE
-                  AND i.apns_device_token <> ''
-                  AND i.last_seen_at >= \(bind: freshnessCutoff)
-                  AND (
-                      p.county  = ANY(\(bind: ugcCodes)::text[])
-                    OR p.zone  = ANY(\(bind: ugcCodes)::text[])
-                    OR p.fire_zone = ANY(\(bind: ugcCodes)::text[])
-                  )
-                """)
-                .all(decoding: NotificationCandidate.self)
-        } else {
-            return try await sql.raw("""
-                SELECT
-                    i.installation_id AS "id",
-                    i.apns_device_token AS "apnsToken",
-                    i.apns_environment AS "apnsEnvironment",
-                    p.county_label as countyLabel,
-                    p.fire_zone_label as fireZoneLabel
-                FROM device_installations i
-                JOIN device_presence p on i.installation_id = p.installation_id
-                WHERE i.is_active = TRUE
-                  AND i.is_subscribed = TRUE
-                  AND i.apns_device_token <> ''
-                  AND (
-                      p.county  = ANY(\(bind: ugcCodes)::text[])
-                    OR p.zone  = ANY(\(bind: ugcCodes)::text[])
-                    OR p.fire_zone = ANY(\(bind: ugcCodes)::text[])
-                  )
-                """)
-                .all(decoding: NotificationCandidate.self)
-        }
+        return try await sql.raw("""
+            SELECT
+                i.installation_id AS "id",
+                i.apns_device_token AS "apnsToken",
+                i.apns_environment AS "apnsEnvironment",
+                i.location_auth AS "locationAuthRaw",
+                p.captured_at AS "capturedAt",
+                p.received_at AS "receivedAt",
+                p.county_label as countyLabel,
+                p.fire_zone_label as fireZoneLabel
+            FROM device_installations i
+            JOIN device_presence p on i.installation_id = p.installation_id
+            WHERE i.is_active = TRUE
+              AND i.is_subscribed = TRUE
+              AND i.apns_device_token <> ''
+              AND (
+                  p.county  = ANY(\(bind: ugcCodes)::text[])
+                OR p.zone  = ANY(\(bind: ugcCodes)::text[])
+                OR p.fire_zone = ANY(\(bind: ugcCodes)::text[])
+              )
+            """)
+            .all(decoding: NotificationCandidate.self)
     }
     
     func loadH3Candidates(
         cells: [Int64],
-        freshnessCutoff: Date?,
         on db: any Database
     ) async throws -> [NotificationCandidate] {
         guard let sql = db as? any SQLDatabase else {
@@ -275,44 +280,26 @@ private extension NotificationSendJob {
         }
         guard cells.count > 0 else { return [] }
 
-        if let freshnessCutoff {
-            return try await sql.raw("""
-                SELECT
-                    i.installation_id AS "id",
-                    i.apns_device_token AS "apnsToken",
-                    i.apns_environment AS "apnsEnvironment",
-                    p.county_label as countyLabel,
-                    p.fire_zone_label as fireZoneLabel
-                FROM device_installations i
-                JOIN device_presence p
-                  ON i.installation_id = p.installation_id
-                WHERE i.is_active = TRUE
-                  AND i.is_subscribed = TRUE
-                  AND i.apns_device_token <> ''
-                  AND p.h3_cell IS NOT NULL
-                  AND p.h3_cell = ANY(\(bind: cells)::bigint[])
-                  AND i.last_seen_at >= \(bind: freshnessCutoff)
-                """)
-                .all(decoding: NotificationCandidate.self)
-        } else {
-            return try await sql.raw("""
-                SELECT
-                    i.installation_id AS "id",
-                    i.apns_device_token AS "apnsToken",
-                    i.apns_environment AS "apnsEnvironment",
-                    p.county_label as countyLabel,
-                    p.fire_zone_label as fireZoneLabel
-                FROM device_installations i
-                JOIN device_presence p
-                  ON i.installation_id = p.installation_id
-                WHERE i.is_active = TRUE
-                  AND i.is_subscribed = TRUE
-                  AND i.apns_device_token <> ''
-                  AND p.h3_cell IS NOT NULL
-                  AND p.h3_cell = ANY(\(bind: cells)::bigint[])
-                """)
-                .all(decoding: NotificationCandidate.self)
-        }
+        return try await sql.raw("""
+            SELECT
+                i.installation_id AS "id",
+                i.apns_device_token AS "apnsToken",
+                i.apns_environment AS "apnsEnvironment",
+                i.location_auth AS "locationAuthRaw",
+                p.captured_at AS "capturedAt",
+                p.received_at AS "receivedAt",
+                p.county_label as countyLabel,
+                p.fire_zone_label as fireZoneLabel
+            FROM device_installations i
+            JOIN device_presence p
+              ON i.installation_id = p.installation_id
+            WHERE i.is_active = TRUE
+              AND i.is_subscribed = TRUE
+              AND i.apns_device_token <> ''
+              AND p.h3_cell IS NOT NULL
+              AND p.h3_cell = ANY(\(bind: cells)::bigint[])
+            """)
+            .all(decoding: NotificationCandidate.self)
     }
     
     func claimNotificationLedger(
@@ -398,7 +385,33 @@ private extension NotificationSendJob {
         var sentCount = 0
         var failedCount = 0
 
+        let evaluatedAt = Date()
         for candidate in candidates {
+            let disposition = deliveryDisposition(
+                for: candidate,
+                evaluatedAt: evaluatedAt
+            )
+
+            if case let .skipStale(freshnessDecision) = disposition {
+                _ = try await missedDecisionStore.insertStaleMissDecision(
+                    .init(
+                        installationID: candidate.id,
+                        seriesID: payload.seriesId,
+                        revisionUrn: payload.revisionUrn,
+                        mode: payload.mode,
+                        reason: payload.reason,
+                        freshnessState: freshnessDecision.state,
+                        missReason: .staleLocation,
+                        permissionMode: candidate.locationAuth,
+                        capturedAt: candidate.capturedAt,
+                        receivedAt: candidate.receivedAt,
+                        evaluatedAt: evaluatedAt
+                    ),
+                    on: context.application.db
+                )
+                continue
+            }
+
             let claim = try await claimNotificationLedger(
                 installationID: candidate.id,
                 seriesID: payload.seriesId,

--- a/Sources/App/Jobs/NotificationSendJob.swift
+++ b/Sources/App/Jobs/NotificationSendJob.swift
@@ -80,12 +80,29 @@ public struct NotificationSendJobPayload: Codable, Sendable {
 
 public struct NotificationSendJob: AsyncJob {
     public typealias Payload = NotificationSendJobPayload
-    private let sender: APNsClient = APNsClient()
-    private let engine: NotificationEngine = NotificationEngine()
-    private let freshnessPolicy: LocationFreshnessPolicy = LocationFreshnessPolicy()
-    private let missedDecisionStore: NotificationMissedDecisionStore = NotificationMissedDecisionStore()
-    
-    public init () {}
+    private let sender: any NotificationSender
+    private let engine: NotificationEngine
+    private let freshnessPolicy: LocationFreshnessPolicy
+    private let missedDecisionStore: NotificationMissedDecisionStore
+
+    public init() {
+        self.sender = APNsClient()
+        self.engine = NotificationEngine()
+        self.freshnessPolicy = LocationFreshnessPolicy()
+        self.missedDecisionStore = NotificationMissedDecisionStore()
+    }
+
+    init(
+        sender: any NotificationSender,
+        engine: NotificationEngine = NotificationEngine(),
+        freshnessPolicy: LocationFreshnessPolicy = LocationFreshnessPolicy(),
+        missedDecisionStore: NotificationMissedDecisionStore = NotificationMissedDecisionStore()
+    ) {
+        self.sender = sender
+        self.engine = engine
+        self.freshnessPolicy = freshnessPolicy
+        self.missedDecisionStore = missedDecisionStore
+    }
 
     func deliveryDisposition(
         for candidate: NotificationCandidate,

--- a/Sources/App/Jobs/NotificationSendJob.swift
+++ b/Sources/App/Jobs/NotificationSendJob.swift
@@ -241,7 +241,7 @@ public struct NotificationSendJob: AsyncJob {
 }
 
 
-private extension NotificationSendJob {
+extension NotificationSendJob {
     func loadUGCCandidates(
         ugcCodes: [String],
         on db: any Database
@@ -311,6 +311,7 @@ private extension NotificationSendJob {
         revisionUrn: String,
         mode: NotificationTargetMode,
         reason: NotificationReason,
+        freshnessState: LocationFreshnessState,
         on db: any Database
     ) async throws -> LedgerClaimResult {
         guard let sql = db as? any SQLDatabase else {
@@ -321,7 +322,7 @@ private extension NotificationSendJob {
 
         let row = try await sql.raw("""
             INSERT INTO notification_ledger
-                (id, installation_id, series_id, revision_urn, mode, reason, created, status)
+                (id, installation_id, series_id, revision_urn, mode, reason, freshness_state, created, status)
             VALUES
                 (\(bind: newID),
                  \(bind: installationID),
@@ -329,6 +330,7 @@ private extension NotificationSendJob {
                  \(bind: revisionUrn),
                  \(bind: mode),
                  \(bind: reason),
+                 \(bind: freshnessState),
                  NOW(),
                 'claimed')
             ON CONFLICT (installation_id, series_id, revision_urn)
@@ -444,6 +446,7 @@ private extension NotificationSendJob {
                 revisionUrn: payload.revisionUrn,
                 mode: payload.mode,
                 reason: payload.reason,
+                freshnessState: freshnessDecision.state,
                 on: context.application.db
             )
             

--- a/Sources/App/Jobs/NotificationSendJob.swift
+++ b/Sources/App/Jobs/NotificationSendJob.swift
@@ -392,7 +392,9 @@ private extension NotificationSendJob {
                 evaluatedAt: evaluatedAt
             )
 
-            if case let .skipStale(freshnessDecision) = disposition {
+            let freshnessDecision: LocationFreshnessDecision
+            switch disposition {
+            case let .skipStale(staleDecision):
                 _ = try await missedDecisionStore.insertStaleMissDecision(
                     .init(
                         installationID: candidate.id,
@@ -400,7 +402,7 @@ private extension NotificationSendJob {
                         revisionUrn: payload.revisionUrn,
                         mode: payload.mode,
                         reason: payload.reason,
-                        freshnessState: freshnessDecision.state,
+                        freshnessState: staleDecision.state,
                         missReason: .staleLocation,
                         permissionMode: candidate.locationAuth,
                         capturedAt: candidate.capturedAt,
@@ -410,6 +412,8 @@ private extension NotificationSendJob {
                     on: context.application.db
                 )
                 continue
+            case let .deliver(deliveryDecision):
+                freshnessDecision = deliveryDecision
             }
 
             let claim = try await claimNotificationLedger(
@@ -427,7 +431,12 @@ private extension NotificationSendJob {
 
             claimedCount += 1
             
-            let alert = engine.buildNotification(for: series, with: payload, on: candidate)
+            let alert = engine.buildNotification(
+                for: series,
+                with: payload,
+                on: candidate,
+                freshnessState: freshnessDecision.state
+            )
             await saveNotificationDebugSnapshot(
                 seriesID: payload.seriesId,
                 installationID: candidate.id,

--- a/Sources/App/Jobs/NotificationSendJob.swift
+++ b/Sources/App/Jobs/NotificationSendJob.swift
@@ -35,6 +35,7 @@ struct LedgerClaimResult {
 struct DispatchNotificationsResult {
     let candidateResolutionReached: Bool
     let candidateCount: Int
+    let staleMissedCount: Int
     let claimedCount: Int
     let sentCount: Int
     let failedCount: Int
@@ -143,6 +144,7 @@ public struct NotificationSendJob: AsyncJob {
                 summary: .init(
                     candidateResolutionReached: false,
                     candidateCount: 0,
+                    staleMissedCount: 0,
                     claimedCount: 0,
                     sentCount: 0,
                     failedCount: 0,
@@ -169,6 +171,7 @@ public struct NotificationSendJob: AsyncJob {
                     summary: .init(
                         candidateResolutionReached: false,
                         candidateCount: 0,
+                        staleMissedCount: 0,
                         claimedCount: 0,
                         sentCount: 0,
                         failedCount: 0,
@@ -374,6 +377,7 @@ private extension NotificationSendJob {
             return .init(
                 candidateResolutionReached: true,
                 candidateCount: 0,
+                staleMissedCount: 0,
                 claimedCount: 0,
                 sentCount: 0,
                 failedCount: 0,
@@ -381,6 +385,7 @@ private extension NotificationSendJob {
             )
         }
 
+        var staleMissedCount = 0
         var claimedCount = 0
         var sentCount = 0
         var failedCount = 0
@@ -395,7 +400,7 @@ private extension NotificationSendJob {
             let freshnessDecision: LocationFreshnessDecision
             switch disposition {
             case let .skipStale(staleDecision):
-                _ = try await missedDecisionStore.insertStaleMissDecision(
+                let insertResult = try await missedDecisionStore.insertStaleMissDecision(
                     .init(
                         installationID: candidate.id,
                         seriesID: payload.seriesId,
@@ -410,6 +415,23 @@ private extension NotificationSendJob {
                         evaluatedAt: evaluatedAt
                     ),
                     on: context.application.db
+                )
+                staleMissedCount += 1
+                context.logger.info(
+                    "Notification candidate skipped due to stale location",
+                    metadata: [
+                        "installation_id": .string(candidate.id.uuidString),
+                        "series_id": .string(payload.seriesId.uuidString),
+                        "revision_urn": .string(payload.revisionUrn),
+                        "event_type": .string(series.event),
+                        "mode": .string(payload.mode.rawValue),
+                        "reason": .string(payload.reason.rawValue),
+                        "freshness_state": .string(staleDecision.state.rawValue),
+                        "permission_mode": .string(candidate.locationAuth.rawValue),
+                        "decision_outcome": .string("missed_stale_location"),
+                        "miss_reason": .string(NotificationMissReason.staleLocation.rawValue),
+                        "decision_persisted": .string(insertResult.inserted ? "inserted" : "already_recorded")
+                    ]
                 )
                 continue
             case let .deliver(deliveryDecision):
@@ -556,7 +578,11 @@ private extension NotificationSendJob {
 
         let noOpReason: NotificationSendNoOpReason?
         if sentCount == 0 && failedCount == 0 {
-            noOpReason = .allCandidatesPreviouslyClaimed
+            if staleMissedCount > 0 && claimedCount == 0 {
+                noOpReason = .allCandidatesStaleLocation
+            } else {
+                noOpReason = .allCandidatesPreviouslyClaimed
+            }
         } else {
             noOpReason = nil
         }
@@ -564,6 +590,7 @@ private extension NotificationSendJob {
         return .init(
             candidateResolutionReached: true,
             candidateCount: candidates.count,
+            staleMissedCount: staleMissedCount,
             claimedCount: claimedCount,
             sentCount: sentCount,
             failedCount: failedCount,

--- a/Sources/App/Migrations/AddFreshnessStateToNotificationLedger.swift
+++ b/Sources/App/Migrations/AddFreshnessStateToNotificationLedger.swift
@@ -3,9 +3,17 @@ import SQLKit
 
 struct AddFreshnessStateToNotificationLedger: AsyncMigration {
     func prepare(on db: any Database) async throws {
-        try await db.schema(NotificationLedgerModel.schema)
-            .field("freshness_state", .string)
-            .update()
+        guard let sql = db as? any SQLDatabase else {
+            try await db.schema(NotificationLedgerModel.schema)
+                .field("freshness_state", .string)
+                .update()
+            return
+        }
+
+        try await sql.raw("""
+            ALTER TABLE notification_ledger
+            ADD COLUMN IF NOT EXISTS freshness_state TEXT;
+            """).run()
     }
 
     func revert(on db: any Database) async throws {

--- a/Sources/App/Migrations/AddFreshnessStateToNotificationLedger.swift
+++ b/Sources/App/Migrations/AddFreshnessStateToNotificationLedger.swift
@@ -1,0 +1,16 @@
+import Fluent
+import SQLKit
+
+struct AddFreshnessStateToNotificationLedger: AsyncMigration {
+    func prepare(on db: any Database) async throws {
+        try await db.schema(NotificationLedgerModel.schema)
+            .field("freshness_state", .string, .required, .sql(.default("'fresh'")))
+            .update()
+    }
+
+    func revert(on db: any Database) async throws {
+        try await db.schema(NotificationLedgerModel.schema)
+            .deleteField("freshness_state")
+            .update()
+    }
+}

--- a/Sources/App/Migrations/AddFreshnessStateToNotificationLedger.swift
+++ b/Sources/App/Migrations/AddFreshnessStateToNotificationLedger.swift
@@ -4,7 +4,7 @@ import SQLKit
 struct AddFreshnessStateToNotificationLedger: AsyncMigration {
     func prepare(on db: any Database) async throws {
         try await db.schema(NotificationLedgerModel.schema)
-            .field("freshness_state", .string, .required, .sql(.default("'fresh'")))
+            .field("freshness_state", .string)
             .update()
     }
 

--- a/Sources/App/Migrations/CreateAlertSeries.swift
+++ b/Sources/App/Migrations/CreateAlertSeries.swift
@@ -3,15 +3,29 @@ import SQLKit
 
 public struct AddRemainingArcusSeriesFields: AsyncMigration {
     public func prepare(on db: any Database) async throws {
-        try await db.schema(ArcusSeriesModel.schema)
-            .field("category", .string)
-            .field("senderName", .string)
-            .field("headline", .string)
-            .field("description", .string)
-            .field("instructions", .string)
-            .field("response", .string)
-            .field("status", .string)
-            .update()
+        guard let sql = db as? any SQLDatabase else {
+            try await db.schema(ArcusSeriesModel.schema)
+                .field("category", .string)
+                .field("senderName", .string)
+                .field("headline", .string)
+                .field("description", .string)
+                .field("instructions", .string)
+                .field("response", .string)
+                .field("status", .string)
+                .update()
+            return
+        }
+
+        try await sql.raw("""
+            ALTER TABLE arcus_series
+              ADD COLUMN IF NOT EXISTS category TEXT,
+              ADD COLUMN IF NOT EXISTS "senderName" TEXT,
+              ADD COLUMN IF NOT EXISTS headline TEXT,
+              ADD COLUMN IF NOT EXISTS description TEXT,
+              ADD COLUMN IF NOT EXISTS instructions TEXT,
+              ADD COLUMN IF NOT EXISTS response TEXT,
+              ADD COLUMN IF NOT EXISTS status TEXT;
+            """).run()
     }
 
     public func revert(on db: any Database) async throws {
@@ -29,9 +43,17 @@ public struct AddRemainingArcusSeriesFields: AsyncMigration {
 
 public struct FixArcusSeriesSenderNameField: AsyncMigration {
     public func prepare(on db: any Database) async throws {
-        try await db.schema(ArcusSeriesModel.schema)
-            .field("sender_name", .string)
-            .update()
+        guard let sql = db as? any SQLDatabase else {
+            try await db.schema(ArcusSeriesModel.schema)
+                .field("sender_name", .string)
+                .update()
+            return
+        }
+
+        try await sql.raw("""
+            ALTER TABLE arcus_series
+            ADD COLUMN IF NOT EXISTS sender_name TEXT;
+            """).run()
     }
 
     public func revert(on db: any Database) async throws {
@@ -43,9 +65,19 @@ public struct FixArcusSeriesSenderNameField: AsyncMigration {
 
 public struct RemoveArcusSeriesSenderNameField: AsyncMigration {
     public func prepare(on db: any Database) async throws {
-        try await db.schema(ArcusSeriesModel.schema)
-            .deleteField("senderName")
-            .update()
+        guard let sql = db as? any SQLDatabase else {
+            try await db.schema(ArcusSeriesModel.schema)
+                .deleteField("senderName")
+                .update()
+            return
+        }
+
+        // Some environments never created the legacy camelCase column.
+        // Use IF EXISTS so the migration is idempotent across schema histories.
+        try await sql.raw("""
+            ALTER TABLE arcus_series
+            DROP COLUMN IF EXISTS "senderName";
+            """).run()
     }
 
     public func revert(on db: any Database) async throws {
@@ -119,17 +151,33 @@ public struct CreateAlertSeriesModel: AsyncMigration {
 
 public struct AddCAPParamFields: AsyncMigration {
     public func prepare(on db: any Database) async throws {
-        try await db.schema(ArcusSeriesModel.schema)
-            .field("tornado_detection", .string)
-            .field("tornado_damage_threat", .string)
-            .field("max_wind_gust", .string)
-            .field("max_hail_size", .string)
-            .field("wind_threat", .string)
-            .field("hail_threat", .string)
-            .field("thunderstorm_damage_threat", .string)
-            .field("flash_flood_detection", .string)
-            .field("flash_flood_damage_threat", .string)
-            .update()
+        guard let sql = db as? any SQLDatabase else {
+            try await db.schema(ArcusSeriesModel.schema)
+                .field("tornado_detection", .string)
+                .field("tornado_damage_threat", .string)
+                .field("max_wind_gust", .string)
+                .field("max_hail_size", .string)
+                .field("wind_threat", .string)
+                .field("hail_threat", .string)
+                .field("thunderstorm_damage_threat", .string)
+                .field("flash_flood_detection", .string)
+                .field("flash_flood_damage_threat", .string)
+                .update()
+            return
+        }
+
+        try await sql.raw("""
+            ALTER TABLE arcus_series
+              ADD COLUMN IF NOT EXISTS tornado_detection TEXT,
+              ADD COLUMN IF NOT EXISTS tornado_damage_threat TEXT,
+              ADD COLUMN IF NOT EXISTS max_wind_gust TEXT,
+              ADD COLUMN IF NOT EXISTS max_hail_size TEXT,
+              ADD COLUMN IF NOT EXISTS wind_threat TEXT,
+              ADD COLUMN IF NOT EXISTS hail_threat TEXT,
+              ADD COLUMN IF NOT EXISTS thunderstorm_damage_threat TEXT,
+              ADD COLUMN IF NOT EXISTS flash_flood_detection TEXT,
+              ADD COLUMN IF NOT EXISTS flash_flood_damage_threat TEXT;
+            """).run()
     }
 
     public func revert(on db: any Database) async throws {

--- a/Sources/App/Migrations/CreateDeviceInstallations.swift
+++ b/Sources/App/Migrations/CreateDeviceInstallations.swift
@@ -60,9 +60,17 @@ struct CreateDeviceInstallations: AsyncMigration {
 
 struct AddIsSubscribedToDeviceInstallation: AsyncMigration {
     func prepare(on db: any Database) async throws {
-        try await db.schema(DeviceInstallationModel.schema)
-            .field("is_subscribed", .bool)
-            .update()
+        guard let sql = db as? any SQLDatabase else {
+            try await db.schema(DeviceInstallationModel.schema)
+                .field("is_subscribed", .bool)
+                .update()
+            return
+        }
+
+        try await sql.raw("""
+            ALTER TABLE device_installations
+            ADD COLUMN IF NOT EXISTS is_subscribed BOOLEAN;
+            """).run()
     }
 
     func revert(on db: any Database) async throws {

--- a/Sources/App/Migrations/CreateDevicePresence.swift
+++ b/Sources/App/Migrations/CreateDevicePresence.swift
@@ -3,10 +3,19 @@ import SQLKit
 
 struct AddCountyLabelFieldsToDevicePresence: AsyncMigration {
     func prepare(on db: any Database) async throws {
-        try await db.schema(DevicePresenceModel.schema)
-            .field("county_label", .string)
-            .field("fire_zone_label", .string)
-            .update()
+        guard let sql = db as? any SQLDatabase else {
+            try await db.schema(DevicePresenceModel.schema)
+                .field("county_label", .string)
+                .field("fire_zone_label", .string)
+                .update()
+            return
+        }
+
+        try await sql.raw("""
+            ALTER TABLE device_presence
+              ADD COLUMN IF NOT EXISTS county_label TEXT,
+              ADD COLUMN IF NOT EXISTS fire_zone_label TEXT;
+            """).run()
     }
 
     func revert(on db: any Database) async throws {

--- a/Sources/App/Migrations/CreateNotificationDebug.swift
+++ b/Sources/App/Migrations/CreateNotificationDebug.swift
@@ -10,26 +10,48 @@ import SQLKit
 
 struct CreateNotificationDebug: AsyncMigration {
     func prepare(on db: any Database) async throws {
-        try await db.schema(NotificationDebugModel.schema)
-            .field("id", .uuid, .identifier(auto: false))
-            .field("series_id", .uuid, .required,
-                   .references(ArcusSeriesModel.schema, "id", onDelete: .cascade))
-            .field("installation_id", .uuid,
-                   .references(DeviceInstallationModel.schema, "installation_id", onDelete: .setNull))
-            .field("notification_ledger_id", .uuid,
-                   .references(NotificationLedgerModel.schema, "id", onDelete: .setNull))
-            .field("revision_urn", .string, .required)
-            .field("mode", .string, .required)
-            .field("reason", .string, .required)
-            .field("record_kind", .string, .required)
-            .field("title", .string, .required)
-            .field("subtitle", .string, .required)
-            .field("body", .string, .required)
-            .field("created", .datetime)
-            .unique(on: "notification_ledger_id")
-            .create()
+        guard let sql = db as? any SQLDatabase else {
+            try await db.schema(NotificationDebugModel.schema)
+                .field("id", .uuid, .identifier(auto: false))
+                .field("series_id", .uuid, .required,
+                       .references(ArcusSeriesModel.schema, "id", onDelete: .cascade))
+                .field("installation_id", .uuid,
+                       .references(DeviceInstallationModel.schema, "installation_id", onDelete: .setNull))
+                .field("notification_ledger_id", .uuid,
+                       .references(NotificationLedgerModel.schema, "id", onDelete: .setNull))
+                .field("revision_urn", .string, .required)
+                .field("mode", .string, .required)
+                .field("reason", .string, .required)
+                .field("record_kind", .string, .required)
+                .field("title", .string, .required)
+                .field("subtitle", .string, .required)
+                .field("body", .string, .required)
+                .field("created", .datetime)
+                .unique(on: "notification_ledger_id")
+                .create()
+            return
+        }
 
-        guard let sql = db as? any SQLDatabase else { return }
+        if try await !tableExists(sql: sql, table: NotificationDebugModel.schema) {
+            try await db.schema(NotificationDebugModel.schema)
+                .field("id", .uuid, .identifier(auto: false))
+                .field("series_id", .uuid, .required,
+                       .references(ArcusSeriesModel.schema, "id", onDelete: .cascade))
+                .field("installation_id", .uuid,
+                       .references(DeviceInstallationModel.schema, "installation_id", onDelete: .setNull))
+                .field("notification_ledger_id", .uuid,
+                       .references(NotificationLedgerModel.schema, "id", onDelete: .setNull))
+                .field("revision_urn", .string, .required)
+                .field("mode", .string, .required)
+                .field("reason", .string, .required)
+                .field("record_kind", .string, .required)
+                .field("title", .string, .required)
+                .field("subtitle", .string, .required)
+                .field("body", .string, .required)
+                .field("created", .datetime)
+                .unique(on: "notification_ledger_id")
+                .create()
+        }
 
         try await sql.raw("""
             CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_debug_preview_unique
@@ -51,4 +73,15 @@ struct CreateNotificationDebug: AsyncMigration {
 
         try await db.schema(NotificationDebugModel.schema).delete()
     }
+}
+
+private func tableExists(sql: any SQLDatabase, table: String) async throws -> Bool {
+    let row = try await sql.raw("""
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = 'public' AND table_name = \(bind: table)
+        ) AS exists;
+        """).first()
+    return try row?.decode(column: "exists", as: Bool.self) ?? false
 }

--- a/Sources/App/Migrations/CreateNotificationLedger.swift
+++ b/Sources/App/Migrations/CreateNotificationLedger.swift
@@ -37,9 +37,17 @@ struct CreateNotificationLedger: AsyncMigration {
 
 struct AddCreatedToNotificationLedger: AsyncMigration {
     func prepare(on db: any Database) async throws {
-        try await db.schema(NotificationLedgerModel.schema)
-            .field("created", .datetime, .required)     // consider enum later
-            .update()
+        guard let sql = db as? any SQLDatabase else {
+            try await db.schema(NotificationLedgerModel.schema)
+                .field("created", .datetime, .required)
+                .update()
+            return
+        }
+
+        try await sql.raw("""
+            ALTER TABLE notification_ledger
+            ADD COLUMN IF NOT EXISTS created TIMESTAMPTZ;
+            """).run()
     }
 
     func revert(on db: any Database) async throws {
@@ -49,9 +57,17 @@ struct AddCreatedToNotificationLedger: AsyncMigration {
 
 struct AddStatusToNotificationLedger: AsyncMigration {
     func prepare(on db: any Database) async throws {
-        try await db.schema(NotificationLedgerModel.schema)
-            .field("status", .string)     // consider enum later
-            .update()
+        guard let sql = db as? any SQLDatabase else {
+            try await db.schema(NotificationLedgerModel.schema)
+                .field("status", .string)
+                .update()
+            return
+        }
+
+        try await sql.raw("""
+            ALTER TABLE notification_ledger
+            ADD COLUMN IF NOT EXISTS status TEXT;
+            """).run()
     }
 
     func revert(on db: any Database) async throws {
@@ -61,9 +77,17 @@ struct AddStatusToNotificationLedger: AsyncMigration {
 
 struct AddApnsErrorCodeToNotificationLedger: AsyncMigration {
     func prepare(on db: any Database) async throws {
-        try await db.schema(NotificationLedgerModel.schema)
-            .field("apns_error_code", .string)     // consider enum later
-            .update()
+        guard let sql = db as? any SQLDatabase else {
+            try await db.schema(NotificationLedgerModel.schema)
+                .field("apns_error_code", .string)
+                .update()
+            return
+        }
+
+        try await sql.raw("""
+            ALTER TABLE notification_ledger
+            ADD COLUMN IF NOT EXISTS apns_error_code TEXT;
+            """).run()
     }
 
     func revert(on db: any Database) async throws {

--- a/Sources/App/Migrations/CreateNotificationMissedDecisions.swift
+++ b/Sources/App/Migrations/CreateNotificationMissedDecisions.swift
@@ -1,0 +1,28 @@
+import Fluent
+
+struct CreateNotificationMissedDecisions: AsyncMigration {
+    func prepare(on db: any Database) async throws {
+        try await db.schema(NotificationMissedDecisionModel.schema)
+            .field("id", .uuid, .identifier(auto: false))
+            .field("installation_id", .uuid, .required,
+                   .references(DeviceInstallationModel.schema, "installation_id", onDelete: .cascade))
+            .field("series_id", .uuid, .required,
+                   .references(ArcusSeriesModel.schema, "id", onDelete: .cascade))
+            .field("revision_urn", .string, .required)
+            .field("mode", .string, .required)
+            .field("reason", .string, .required)
+            .field("freshness_state", .string, .required)
+            .field("miss_reason", .string, .required)
+            .field("permission_mode", .string, .required)
+            .field("captured_at", .datetime, .required)
+            .field("received_at", .datetime, .required)
+            .field("evaluated_at", .datetime, .required)
+            .field("created", .datetime, .required)
+            .unique(on: "installation_id", "series_id", "revision_urn", "mode", "reason", "miss_reason")
+            .create()
+    }
+
+    func revert(on db: any Database) async throws {
+        try await db.schema(NotificationMissedDecisionModel.schema).delete()
+    }
+}

--- a/Sources/App/Migrations/CreateNotificationOutbox.swift
+++ b/Sources/App/Migrations/CreateNotificationOutbox.swift
@@ -58,11 +58,17 @@ struct CreateNotificationOutbox: AsyncMigration {
 
 struct AddReasonToNotificationOutbox: AsyncMigration {
     func prepare(on db: any Database) async throws {
-        try await db.schema(ArcusNotificationOutboxModel.schema)
-            .field("reason", .string)
-            .update()
+        guard let sql = db as? any SQLDatabase else {
+            try await db.schema(ArcusNotificationOutboxModel.schema)
+                .field("reason", .string)
+                .update()
+            return
+        }
 
-        guard let sql = db as? any SQLDatabase else { return }
+        try await sql.raw("""
+            ALTER TABLE notification_outbox
+            ADD COLUMN IF NOT EXISTS reason TEXT;
+            """).run()
 
         try await sql.raw("""
             UPDATE notification_outbox

--- a/Sources/App/Migrations/CreateOperatorDashboardSupport.swift
+++ b/Sources/App/Migrations/CreateOperatorDashboardSupport.swift
@@ -3,23 +3,42 @@ import SQLKit
 
 struct CreateIngestSweepRuns: AsyncMigration {
     func prepare(on database: any Database) async throws {
-        try await database.schema(IngestSweepRunModel.schema)
-            .id()
-            .field("source", .string, .required)
-            .field("fixture_name", .string)
-            .field("run_label", .string)
-            .field("status", .string, .required)
-            .field("started_at", .datetime, .required)
-            .field("completed_at", .datetime, .required)
-            .field("event_count", .int)
-            .field("new_series_count", .int)
-            .field("new_revision_count", .int)
-            .field("target_outbox_queued_count", .int)
-            .field("notification_outbox_queued_count", .int)
-            .field("error_message", .string)
-            .create()
+        guard let sql = database as? any SQLDatabase else {
+            try await database.schema(IngestSweepRunModel.schema)
+                .id()
+                .field("source", .string, .required)
+                .field("fixture_name", .string)
+                .field("run_label", .string)
+                .field("status", .string, .required)
+                .field("started_at", .datetime, .required)
+                .field("completed_at", .datetime, .required)
+                .field("event_count", .int)
+                .field("new_series_count", .int)
+                .field("new_revision_count", .int)
+                .field("target_outbox_queued_count", .int)
+                .field("notification_outbox_queued_count", .int)
+                .field("error_message", .string)
+                .create()
+            return
+        }
 
-        guard let sql = database as? any SQLDatabase else { return }
+        if try await !tableExists(sql: sql, table: IngestSweepRunModel.schema) {
+            try await database.schema(IngestSweepRunModel.schema)
+                .id()
+                .field("source", .string, .required)
+                .field("fixture_name", .string)
+                .field("run_label", .string)
+                .field("status", .string, .required)
+                .field("started_at", .datetime, .required)
+                .field("completed_at", .datetime, .required)
+                .field("event_count", .int)
+                .field("new_series_count", .int)
+                .field("new_revision_count", .int)
+                .field("target_outbox_queued_count", .int)
+                .field("notification_outbox_queued_count", .int)
+                .field("error_message", .string)
+                .create()
+        }
 
         try await sql.raw("""
             CREATE INDEX IF NOT EXISTS idx_ingest_sweep_runs_completed_at
@@ -43,11 +62,17 @@ struct CreateIngestSweepRuns: AsyncMigration {
 
 struct AddCompletedAtToNotificationLedger: AsyncMigration {
     func prepare(on db: any Database) async throws {
-        try await db.schema(NotificationLedgerModel.schema)
-            .field("completed_at", .datetime)
-            .update()
+        guard let sql = db as? any SQLDatabase else {
+            try await db.schema(NotificationLedgerModel.schema)
+                .field("completed_at", .datetime)
+                .update()
+            return
+        }
 
-        guard let sql = db as? any SQLDatabase else { return }
+        try await sql.raw("""
+            ALTER TABLE notification_ledger
+            ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ;
+            """).run()
 
         try await sql.raw("""
             CREATE INDEX IF NOT EXISTS idx_notification_ledger_status_completed_at
@@ -67,12 +92,19 @@ struct AddCompletedAtToNotificationLedger: AsyncMigration {
 
 struct AddCompletionFieldsToTargetDispatchOutbox: AsyncMigration {
     func prepare(on db: any Database) async throws {
-        try await db.schema(ArcusTargetDispatchOutboxModel.schema)
-            .field("completed", .datetime)
-            .field("result", .string)
-            .update()
+        guard let sql = db as? any SQLDatabase else {
+            try await db.schema(ArcusTargetDispatchOutboxModel.schema)
+                .field("completed", .datetime)
+                .field("result", .string)
+                .update()
+            return
+        }
 
-        guard let sql = db as? any SQLDatabase else { return }
+        try await sql.raw("""
+            ALTER TABLE target_dispatch_outbox
+              ADD COLUMN IF NOT EXISTS completed TIMESTAMPTZ,
+              ADD COLUMN IF NOT EXISTS result TEXT;
+            """).run()
 
         try await sql.raw("""
             CREATE INDEX IF NOT EXISTS idx_target_dispatch_outbox_result_completed
@@ -93,24 +125,44 @@ struct AddCompletionFieldsToTargetDispatchOutbox: AsyncMigration {
 
 struct CreateNotificationSendAttempts: AsyncMigration {
     func prepare(on database: any Database) async throws {
-        try await database.schema(NotificationSendAttemptModel.schema)
-            .id()
-            .field("series_id", .uuid, .required,
-                   .references(ArcusSeriesModel.schema, "id", onDelete: .cascade))
-            .field("revision_urn", .string, .required)
-            .field("mode", .string, .required)
-            .field("reason", .string, .required)
-            .field("outcome", .string, .required)
-            .field("no_op_reason", .string)
-            .field("candidate_resolution_reached", .bool, .required)
-            .field("candidate_count", .int, .required)
-            .field("claimed_count", .int, .required)
-            .field("sent_count", .int, .required)
-            .field("failed_count", .int, .required)
-            .field("attempted_at", .datetime, .required)
-            .create()
+        guard let sql = database as? any SQLDatabase else {
+            try await database.schema(NotificationSendAttemptModel.schema)
+                .id()
+                .field("series_id", .uuid, .required,
+                       .references(ArcusSeriesModel.schema, "id", onDelete: .cascade))
+                .field("revision_urn", .string, .required)
+                .field("mode", .string, .required)
+                .field("reason", .string, .required)
+                .field("outcome", .string, .required)
+                .field("no_op_reason", .string)
+                .field("candidate_resolution_reached", .bool, .required)
+                .field("candidate_count", .int, .required)
+                .field("claimed_count", .int, .required)
+                .field("sent_count", .int, .required)
+                .field("failed_count", .int, .required)
+                .field("attempted_at", .datetime, .required)
+                .create()
+            return
+        }
 
-        guard let sql = database as? any SQLDatabase else { return }
+        if try await !tableExists(sql: sql, table: NotificationSendAttemptModel.schema) {
+            try await database.schema(NotificationSendAttemptModel.schema)
+                .id()
+                .field("series_id", .uuid, .required,
+                       .references(ArcusSeriesModel.schema, "id", onDelete: .cascade))
+                .field("revision_urn", .string, .required)
+                .field("mode", .string, .required)
+                .field("reason", .string, .required)
+                .field("outcome", .string, .required)
+                .field("no_op_reason", .string)
+                .field("candidate_resolution_reached", .bool, .required)
+                .field("candidate_count", .int, .required)
+                .field("claimed_count", .int, .required)
+                .field("sent_count", .int, .required)
+                .field("failed_count", .int, .required)
+                .field("attempted_at", .datetime, .required)
+                .create()
+        }
 
         try await sql.raw("""
             CREATE INDEX IF NOT EXISTS idx_notification_send_attempts_attempted_at
@@ -140,15 +192,38 @@ struct CreateNotificationSendAttempts: AsyncMigration {
 
 struct CreateOperatorDashboardSnapshots: AsyncMigration {
     func prepare(on database: any Database) async throws {
-        try await database.schema(OperatorDashboardSnapshotModel.schema)
-            .field("id", .string, .identifier(auto: false))
-            .field("snapshot", .dictionary, .required)
-            .field("created_at", .datetime)
-            .field("updated_at", .datetime)
-            .create()
+        guard let sql = database as? any SQLDatabase else {
+            try await database.schema(OperatorDashboardSnapshotModel.schema)
+                .field("id", .string, .identifier(auto: false))
+                .field("snapshot", .dictionary, .required)
+                .field("created_at", .datetime)
+                .field("updated_at", .datetime)
+                .create()
+            return
+        }
+
+        if try await !tableExists(sql: sql, table: OperatorDashboardSnapshotModel.schema) {
+            try await database.schema(OperatorDashboardSnapshotModel.schema)
+                .field("id", .string, .identifier(auto: false))
+                .field("snapshot", .dictionary, .required)
+                .field("created_at", .datetime)
+                .field("updated_at", .datetime)
+                .create()
+        }
     }
 
     func revert(on database: any Database) async throws {
         try await database.schema(OperatorDashboardSnapshotModel.schema).delete()
     }
+}
+
+private func tableExists(sql: any SQLDatabase, table: String) async throws -> Bool {
+    let row = try await sql.raw("""
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = 'public' AND table_name = \(bind: table)
+        ) AS exists;
+        """).first()
+    return try row?.decode(column: "exists", as: Bool.self) ?? false
 }

--- a/Sources/App/Migrations/EnforceContentFingerprintIntegrityOnAlertSeries.swift
+++ b/Sources/App/Migrations/EnforceContentFingerprintIntegrityOnAlertSeries.swift
@@ -13,9 +13,19 @@ public struct EnforceContentFingerprintIntegrityOnAlertSeries: AsyncMigration {
             """).run()
 
         try await sql.raw("""
-            ALTER TABLE arcus_series
-              ADD CONSTRAINT arcus_series_content_fingerprint_hex_check
-              CHECK (content_fingerprint ~ '^[0-9a-f]{64}$') NOT VALID;
+            DO $$
+            BEGIN
+              IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conname = 'arcus_series_content_fingerprint_hex_check'
+              ) THEN
+                ALTER TABLE arcus_series
+                  ADD CONSTRAINT arcus_series_content_fingerprint_hex_check
+                  CHECK (content_fingerprint ~ '^[0-9a-f]{64}$') NOT VALID;
+              END IF;
+            END
+            $$;
             """).run()
 
         try await sql.raw("""

--- a/Sources/App/Migrations/UpdateArcusSeriesConstraints.swift
+++ b/Sources/App/Migrations/UpdateArcusSeriesConstraints.swift
@@ -17,13 +17,23 @@ public struct UpdateArcusSeriesConstraints: AsyncMigration {
         
         try await sql.raw("""
                     ALTER TABLE arcus_series
-                      DROP CONSTRAINT alert_series_state_check;
+                      DROP CONSTRAINT IF EXISTS alert_series_state_check;
                     """).run()
         
         try await sql.raw("""
-                    ALTER TABLE arcus_series
-                      ADD CONSTRAINT alert_series_state_check
-                      CHECK (state IN ('active', 'cancelled_in_error', 'cancelled', 'ended', 'expired'));
+                    DO $$
+                    BEGIN
+                      IF NOT EXISTS (
+                        SELECT 1
+                        FROM pg_constraint
+                        WHERE conname = 'alert_series_state_check'
+                      ) THEN
+                        ALTER TABLE arcus_series
+                          ADD CONSTRAINT alert_series_state_check
+                          CHECK (state IN ('active', 'cancelled_in_error', 'cancelled', 'ended', 'expired'));
+                      END IF;
+                    END
+                    $$;
                     """).run()
     }
     

--- a/Sources/App/Models/Notification/NotificationLedgerModel.swift
+++ b/Sources/App/Models/Notification/NotificationLedgerModel.swift
@@ -30,8 +30,8 @@ public final class NotificationLedgerModel: Model, @unchecked Sendable, Content 
     @Field(key: "reason")
     public var reason: String
 
-    @Field(key: "freshness_state")
-    public var freshnessStateRaw: String
+    @OptionalField(key: "freshness_state")
+    public var freshnessStateRaw: String?
     
     @OptionalField(key: "status")
     public var status: String?
@@ -70,8 +70,11 @@ public final class NotificationLedgerModel: Model, @unchecked Sendable, Content 
         self.completedAt = completedAt
     }
 
-    public var freshnessState: LocationFreshnessState {
-        get { LocationFreshnessState(rawValue: freshnessStateRaw) ?? .stale }
-        set { freshnessStateRaw = newValue.rawValue }
+    public var freshnessState: LocationFreshnessState? {
+        get {
+            guard let freshnessStateRaw else { return nil }
+            return LocationFreshnessState(rawValue: freshnessStateRaw)
+        }
+        set { freshnessStateRaw = newValue?.rawValue }
     }
 }

--- a/Sources/App/Models/Notification/NotificationLedgerModel.swift
+++ b/Sources/App/Models/Notification/NotificationLedgerModel.swift
@@ -29,6 +29,9 @@ public final class NotificationLedgerModel: Model, @unchecked Sendable, Content 
     
     @Field(key: "reason")
     public var reason: String
+
+    @Field(key: "freshness_state")
+    public var freshnessStateRaw: String
     
     @OptionalField(key: "status")
     public var status: String?
@@ -52,6 +55,7 @@ public final class NotificationLedgerModel: Model, @unchecked Sendable, Content 
         revisionUrn: String,
         mode: String,
         reason: String,
+        freshnessState: LocationFreshnessState,
         status: String?,
         completedAt: Date? = nil
     ) {
@@ -61,7 +65,13 @@ public final class NotificationLedgerModel: Model, @unchecked Sendable, Content 
         self.revisionUrn = revisionUrn
         self.mode = mode
         self.reason = reason
+        self.freshnessStateRaw = freshnessState.rawValue
         self.status = status
         self.completedAt = completedAt
+    }
+
+    public var freshnessState: LocationFreshnessState {
+        get { LocationFreshnessState(rawValue: freshnessStateRaw) ?? .stale }
+        set { freshnessStateRaw = newValue.rawValue }
     }
 }

--- a/Sources/App/Models/Notification/NotificationMissedDecisionModel.swift
+++ b/Sources/App/Models/Notification/NotificationMissedDecisionModel.swift
@@ -1,0 +1,168 @@
+import Fluent
+import FluentSQL
+import Foundation
+import Vapor
+
+public enum NotificationMissReason: String, Codable, Sendable {
+    case staleLocation = "stale_location"
+}
+
+public final class NotificationMissedDecisionModel: Model, @unchecked Sendable {
+    public static let schema = "notification_missed_decisions"
+
+    @ID(key: .id)
+    public var id: UUID?
+
+    @Parent(key: "installation_id")
+    public var deviceInstallation: DeviceInstallationModel
+
+    @Parent(key: "series_id")
+    public var series: ArcusSeriesModel
+
+    @Field(key: "revision_urn")
+    public var revisionUrn: String
+
+    @Field(key: "mode")
+    public var modeRaw: String
+
+    @Field(key: "reason")
+    public var reasonRaw: String
+
+    @Field(key: "freshness_state")
+    public var freshnessStateRaw: String
+
+    @Field(key: "miss_reason")
+    public var missReasonRaw: String
+
+    @Field(key: "permission_mode")
+    public var permissionModeRaw: String
+
+    @Field(key: "captured_at")
+    public var capturedAt: Date
+
+    @Field(key: "received_at")
+    public var receivedAt: Date
+
+    @Field(key: "evaluated_at")
+    public var evaluatedAt: Date
+
+    @Timestamp(key: "created", on: .create)
+    public var created: Date?
+
+    public init() {}
+
+    public init(
+        id: UUID? = nil,
+        installationID: UUID,
+        seriesID: UUID,
+        revisionUrn: String,
+        mode: NotificationTargetMode,
+        reason: NotificationReason,
+        freshnessState: LocationFreshnessState,
+        missReason: NotificationMissReason,
+        permissionMode: LocationAuth,
+        capturedAt: Date,
+        receivedAt: Date,
+        evaluatedAt: Date
+    ) {
+        self.id = id
+        self.$deviceInstallation.id = installationID
+        self.$series.id = seriesID
+        self.revisionUrn = revisionUrn
+        self.modeRaw = mode.rawValue
+        self.reasonRaw = reason.rawValue
+        self.freshnessStateRaw = freshnessState.rawValue
+        self.missReasonRaw = missReason.rawValue
+        self.permissionModeRaw = permissionMode.rawValue
+        self.capturedAt = capturedAt
+        self.receivedAt = receivedAt
+        self.evaluatedAt = evaluatedAt
+    }
+
+    public var mode: NotificationTargetMode {
+        get { NotificationTargetMode(rawValue: modeRaw) ?? .ugc }
+        set { modeRaw = newValue.rawValue }
+    }
+
+    public var reason: NotificationReason {
+        get { NotificationReason(rawValue: reasonRaw) ?? .new }
+        set { reasonRaw = newValue.rawValue }
+    }
+
+    public var freshnessState: LocationFreshnessState {
+        get { LocationFreshnessState(rawValue: freshnessStateRaw) ?? .stale }
+        set { freshnessStateRaw = newValue.rawValue }
+    }
+
+    public var missReason: NotificationMissReason {
+        get { NotificationMissReason(rawValue: missReasonRaw) ?? .staleLocation }
+        set { missReasonRaw = newValue.rawValue }
+    }
+
+    public var permissionMode: LocationAuth {
+        get { LocationAuth(rawValue: permissionModeRaw) ?? .unknown }
+        set { permissionModeRaw = newValue.rawValue }
+    }
+}
+
+struct NotificationMissedDecisionInsertResult {
+    let inserted: Bool
+    let id: UUID?
+}
+
+struct NotificationMissedDecisionInsertInput {
+    let installationID: UUID
+    let seriesID: UUID
+    let revisionUrn: String
+    let mode: NotificationTargetMode
+    let reason: NotificationReason
+    let freshnessState: LocationFreshnessState
+    let missReason: NotificationMissReason
+    let permissionMode: LocationAuth
+    let capturedAt: Date
+    let receivedAt: Date
+    let evaluatedAt: Date
+}
+
+struct NotificationMissedDecisionStore {
+    func insertStaleMissDecision(
+        _ input: NotificationMissedDecisionInsertInput,
+        on db: any Database
+    ) async throws -> NotificationMissedDecisionInsertResult {
+        guard let sql = db as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        let newID = UUID()
+        let row = try await sql.raw("""
+            INSERT INTO notification_missed_decisions
+                (id, installation_id, series_id, revision_urn, mode, reason, freshness_state, miss_reason,
+                 permission_mode, captured_at, received_at, evaluated_at, created)
+            VALUES
+                (\(bind: newID),
+                 \(bind: input.installationID),
+                 \(bind: input.seriesID),
+                 \(bind: input.revisionUrn),
+                 \(bind: input.mode),
+                 \(bind: input.reason),
+                 \(bind: input.freshnessState),
+                 \(bind: input.missReason),
+                 \(bind: input.permissionMode),
+                 \(bind: input.capturedAt),
+                 \(bind: input.receivedAt),
+                 \(bind: input.evaluatedAt),
+                 NOW())
+            ON CONFLICT (installation_id, series_id, revision_urn, mode, reason, miss_reason)
+            DO NOTHING
+            RETURNING id
+            """)
+            .first()
+
+        if let row {
+            let insertedID = try row.decode(column: "id", as: UUID.self)
+            return .init(inserted: true, id: insertedID)
+        }
+
+        return .init(inserted: false, id: nil)
+    }
+}

--- a/Sources/App/Models/Notification/NotificationSendAttemptModel.swift
+++ b/Sources/App/Models/Notification/NotificationSendAttemptModel.swift
@@ -11,6 +11,7 @@ public enum NotificationSendNoOpReason: String, Codable, Sendable {
     case staleRevisionMismatch = "stale_revision_mismatch"
     case missingGeolocation = "missing_geolocation"
     case zeroCandidates = "zero_candidates"
+    case allCandidatesStaleLocation = "all_candidates_stale_location"
     case allCandidatesPreviouslyClaimed = "all_candidates_previously_claimed"
 }
 

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -60,6 +60,7 @@ private func configureMigrations(on app: Application) {
     app.migrations.add(CreateDevicePresence())
     app.migrations.add(ConvertInstallationIDsToUUID())
     app.migrations.add(CreateNotificationLedger())
+    app.migrations.add(CreateNotificationMissedDecisions())
     app.migrations.add(AddCreatedToNotificationLedger())
     app.migrations.add(AddReasonToNotificationOutbox())
     app.migrations.add(AddRemainingArcusSeriesFields())

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -68,6 +68,7 @@ private func configureMigrations(on app: Application) {
     app.migrations.add(RemoveArcusSeriesSenderNameField())
     app.migrations.add(AddCountyLabelFieldsToDevicePresence())
     app.migrations.add(AddStatusToNotificationLedger())
+    app.migrations.add(AddFreshnessStateToNotificationLedger())
     app.migrations.add(AddIsSubscribedToDeviceInstallation())
     app.migrations.add(FixIsSubscribedToDeviceInstallation())
     app.migrations.add(UpdateArcusSeriesConstraints())

--- a/Tests/AppTests/LocationFreshnessPolicyTests.swift
+++ b/Tests/AppTests/LocationFreshnessPolicyTests.swift
@@ -23,6 +23,18 @@ struct LocationFreshnessPolicyTests {
         #expect(decision.age == 0)
     }
 
+    @Test("Always: now is fresh")
+    func alwaysNowFresh() {
+        let decision = policy.decide(
+            capturedAt: now,
+            locationAuth: .always,
+            now: now
+        )
+
+        #expect(decision.state == .fresh)
+        #expect(decision.age == 0)
+    }
+
     @Test("When In Use: exactly 2 hours is fresh")
     func whenInUseAtTwoHoursFresh() {
         let decision = policy.decide(
@@ -77,6 +89,26 @@ struct LocationFreshnessPolicyTests {
             )
             #expect(decision.state == .degraded)
         }
+    }
+
+    @Test("When In Use: exactly 24 hours is degraded")
+    func whenInUseAtTwentyFourHoursDegraded() {
+        let decision = policy.decide(
+            capturedAt: capturedAt(hoursAgo: 24),
+            locationAuth: .whenInUse,
+            now: now
+        )
+        #expect(decision.state == .degraded)
+    }
+
+    @Test("Always: exactly 24 hours is degraded")
+    func alwaysAtTwentyFourHoursDegraded() {
+        let decision = policy.decide(
+            capturedAt: capturedAt(hoursAgo: 24),
+            locationAuth: .always,
+            now: now
+        )
+        #expect(decision.state == .degraded)
     }
 
     @Test("Both modes: just over 24 hours is stale")

--- a/Tests/AppTests/LocationFreshnessPolicyTests.swift
+++ b/Tests/AppTests/LocationFreshnessPolicyTests.swift
@@ -1,0 +1,123 @@
+@testable import App
+import Foundation
+import Testing
+
+@Suite("Location freshness policy tests")
+struct LocationFreshnessPolicyTests {
+    private let policy = LocationFreshnessPolicy()
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func capturedAt(hoursAgo: Double, secondsAgo: Double = 0) -> Date {
+        now.addingTimeInterval(-(hoursAgo * 60 * 60) - secondsAgo)
+    }
+
+    @Test("When In Use: now is fresh")
+    func whenInUseNowFresh() {
+        let decision = policy.decide(
+            capturedAt: now,
+            locationAuth: .whenInUse,
+            now: now
+        )
+
+        #expect(decision.state == .fresh)
+        #expect(decision.age == 0)
+    }
+
+    @Test("When In Use: exactly 2 hours is fresh")
+    func whenInUseAtTwoHoursFresh() {
+        let decision = policy.decide(
+            capturedAt: capturedAt(hoursAgo: 2),
+            locationAuth: .whenInUse,
+            now: now
+        )
+
+        #expect(decision.state == .fresh)
+    }
+
+    @Test("When In Use: just over 2 hours is degraded")
+    func whenInUseJustOverTwoHoursDegraded() {
+        let decision = policy.decide(
+            capturedAt: capturedAt(hoursAgo: 2, secondsAgo: 1),
+            locationAuth: .whenInUse,
+            now: now
+        )
+
+        #expect(decision.state == .degraded)
+    }
+
+    @Test("Always: exactly 6 hours is fresh")
+    func alwaysAtSixHoursFresh() {
+        let decision = policy.decide(
+            capturedAt: capturedAt(hoursAgo: 6),
+            locationAuth: .always,
+            now: now
+        )
+
+        #expect(decision.state == .fresh)
+    }
+
+    @Test("Always: just over 6 hours is degraded")
+    func alwaysJustOverSixHoursDegraded() {
+        let decision = policy.decide(
+            capturedAt: capturedAt(hoursAgo: 6, secondsAgo: 1),
+            locationAuth: .always,
+            now: now
+        )
+
+        #expect(decision.state == .degraded)
+    }
+
+    @Test("Both modes: exactly 24 hours is degraded")
+    func exactlyTwentyFourHoursDegraded() {
+        for auth in [LocationAuth.whenInUse, .always] {
+            let decision = policy.decide(
+                capturedAt: capturedAt(hoursAgo: 24),
+                locationAuth: auth,
+                now: now
+            )
+            #expect(decision.state == .degraded)
+        }
+    }
+
+    @Test("Both modes: just over 24 hours is stale")
+    func justOverTwentyFourHoursStale() {
+        for auth in [LocationAuth.whenInUse, .always] {
+            let decision = policy.decide(
+                capturedAt: capturedAt(hoursAgo: 24, secondsAgo: 1),
+                locationAuth: auth,
+                now: now
+            )
+            #expect(decision.state == .stale)
+        }
+    }
+
+    @Test("Non-granted auth modes are conservatively stale")
+    func nonGrantedModesAreStale() {
+        let nonGrantedModes: [LocationAuth] = [
+            .denied,
+            .restricted,
+            .notDetermined,
+            .unknown
+        ]
+
+        for auth in nonGrantedModes {
+            let decision = policy.decide(
+                capturedAt: capturedAt(hoursAgo: 1),
+                locationAuth: auth,
+                now: now
+            )
+            #expect(decision.state == .stale)
+        }
+    }
+
+    @Test("API is capturedAt based and does not accept receivedAt")
+    func apiIsCapturedAtOnly() {
+        let decision = policy.decide(
+            capturedAt: capturedAt(hoursAgo: 1),
+            locationAuth: .always,
+            now: now
+        )
+
+        #expect(decision.state == .fresh)
+    }
+}

--- a/Tests/AppTests/NotificationEngineTests.swift
+++ b/Tests/AppTests/NotificationEngineTests.swift
@@ -53,6 +53,9 @@ struct NotificationEngineTests {
             id: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
             apnsToken: "token",
             apnsEnvironment: "sandbox",
+            locationAuthRaw: LocationAuth.whenInUse.rawValue,
+            capturedAt: Date(timeIntervalSince1970: 1_710_000_000),
+            receivedAt: Date(timeIntervalSince1970: 1_710_000_001),
             countyLabel: countyLabel,
             fireZoneLabel: fireZoneLabel
         )

--- a/Tests/AppTests/NotificationEngineTests.swift
+++ b/Tests/AppTests/NotificationEngineTests.swift
@@ -66,7 +66,8 @@ struct NotificationEngineTests {
         let details = engine.buildNotification(
             for: makeSeries(event: "Tornado Warning", severity: "extreme"),
             with: makePayload(mode: .h3, reason: .new),
-            on: makeCandidate()
+            on: makeCandidate(),
+            freshnessState: .fresh
         )
 
         #expect(details.title == "Tornado Warning")
@@ -98,6 +99,34 @@ struct NotificationEngineTests {
         #expect(details.title == "Fire Warning")
         #expect(details.subTitle == "For your area")
         #expect(details.body == "Critical fire weather conditions in your area.")
+    }
+
+    @Test("Degraded warning notifications use last-known-area subtitle")
+    func degradedWarningUsesLastKnownAreaSubtitle() {
+        let details = engine.buildNotification(
+            for: makeSeries(event: "Severe Thunderstorm Warning"),
+            with: makePayload(mode: .h3, reason: .new),
+            on: makeCandidate(),
+            freshnessState: .degraded
+        )
+
+        #expect(details.title == "Severe Thunderstorm Warning")
+        #expect(details.subTitle == "For your last known area")
+        #expect(details.body == "Damaging winds or large hail possible in your area.")
+    }
+
+    @Test("Non-new copy remains unchanged even when degraded")
+    func degradedUpdatePreservesExistingSubtitleCopy() {
+        let details = engine.buildNotification(
+            for: makeSeries(event: "Tornado Watch"),
+            with: makePayload(mode: .ugc, reason: .update),
+            on: makeCandidate(),
+            freshnessState: .degraded
+        )
+
+        #expect(details.title == "Tornado Watch - Update")
+        #expect(details.subTitle == "Updated for your area")
+        #expect(details.body == "Tornado risk continues for your area.")
     }
 
     @Test("Cancellation messaging is explicit")

--- a/Tests/AppTests/NotificationLedgerFreshnessPersistenceTests.swift
+++ b/Tests/AppTests/NotificationLedgerFreshnessPersistenceTests.swift
@@ -6,8 +6,8 @@ import FluentSQL
 import Testing
 import Vapor
 
-@Suite("Notification missed decision persistence", .serialized)
-struct NotificationMissedDecisionPersistenceTests {
+@Suite("Notification ledger freshness persistence", .serialized)
+struct NotificationLedgerFreshnessPersistenceTests {
     private func withApp(test: (Application) async throws -> Void) async throws {
         let app = try await Application.make(.testing)
         do {
@@ -68,30 +68,6 @@ struct NotificationMissedDecisionPersistenceTests {
             """).run()
 
         try await sql.raw("""
-            CREATE TABLE IF NOT EXISTS notification_missed_decisions (
-                id UUID PRIMARY KEY,
-                installation_id UUID NOT NULL REFERENCES device_installations(installation_id) ON DELETE CASCADE,
-                series_id UUID NOT NULL REFERENCES arcus_series(id) ON DELETE CASCADE,
-                revision_urn TEXT NOT NULL,
-                mode TEXT NOT NULL,
-                reason TEXT NOT NULL,
-                freshness_state TEXT NOT NULL,
-                miss_reason TEXT NOT NULL,
-                permission_mode TEXT NOT NULL,
-                captured_at TIMESTAMP NOT NULL,
-                received_at TIMESTAMP NOT NULL,
-                evaluated_at TIMESTAMP NOT NULL,
-                created TIMESTAMP NOT NULL
-            );
-            """).run()
-
-        try await sql.raw("""
-            CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_missed_decisions_identity
-            ON notification_missed_decisions
-            (installation_id, series_id, revision_urn, mode, reason, miss_reason);
-            """).run()
-
-        try await sql.raw("""
             CREATE TABLE IF NOT EXISTS notification_ledger (
                 id UUID PRIMARY KEY,
                 installation_id UUID NOT NULL REFERENCES device_installations(installation_id) ON DELETE CASCADE,
@@ -101,8 +77,30 @@ struct NotificationMissedDecisionPersistenceTests {
                 reason TEXT NOT NULL,
                 freshness_state TEXT NOT NULL,
                 status TEXT,
+                apns_error_code TEXT,
+                completed_at TIMESTAMP,
                 created TIMESTAMP NOT NULL
             );
+            """).run()
+
+        try await sql.raw("""
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_ledger_identity
+            ON notification_ledger (installation_id, series_id, revision_urn);
+            """).run()
+
+        try await sql.raw("""
+            ALTER TABLE notification_ledger
+            ADD COLUMN IF NOT EXISTS status TEXT;
+            """).run()
+
+        try await sql.raw("""
+            ALTER TABLE notification_ledger
+            ADD COLUMN IF NOT EXISTS apns_error_code TEXT;
+            """).run()
+
+        try await sql.raw("""
+            ALTER TABLE notification_ledger
+            ADD COLUMN IF NOT EXISTS completed_at TIMESTAMP;
             """).run()
 
         try await sql.raw("""
@@ -126,7 +124,7 @@ struct NotificationMissedDecisionPersistenceTests {
             """).run()
     }
 
-    private func seedSeries(id: UUID, revisionUrn _: String, on db: any Database) async throws {
+    private func seedSeries(id: UUID, on db: any Database) async throws {
         guard let sql = db as? any SQLDatabase else {
             throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
         }
@@ -143,98 +141,96 @@ struct NotificationMissedDecisionPersistenceTests {
             """).run()
     }
 
-    @Test("stale missed decision can be inserted")
-    func insertsStaleMissDecision() async throws {
+    @Test("fresh candidate claim persists fresh freshness_state")
+    func freshClaimPersistsFreshness() async throws {
         try await withApp { app in
+            let job = NotificationSendJob()
             let installationID = UUID()
             let seriesID = UUID()
-            let revisionUrn = "urn:oid:test-revision"
-            let now = Date()
-            let capturedAt = now.addingTimeInterval(-3_600)
-            let receivedAt = now.addingTimeInterval(-3_500)
+            let revisionUrn = "urn:oid:fresh-claim"
 
             try await seedInstallation(id: installationID, on: app.db)
-            try await seedSeries(id: seriesID, revisionUrn: revisionUrn, on: app.db)
+            try await seedSeries(id: seriesID, on: app.db)
 
-            let store = NotificationMissedDecisionStore()
-            let result = try await store.insertStaleMissDecision(
-                .init(
-                    installationID: installationID,
-                    seriesID: seriesID,
-                    revisionUrn: revisionUrn,
-                    mode: .h3,
-                    reason: .new,
-                    freshnessState: .stale,
-                    missReason: .staleLocation,
-                    permissionMode: .whenInUse,
-                    capturedAt: capturedAt,
-                    receivedAt: receivedAt,
-                    evaluatedAt: now
-                ),
+            let claim = try await job.claimNotificationLedger(
+                installationID: installationID,
+                seriesID: seriesID,
+                revisionUrn: revisionUrn,
+                mode: .h3,
+                reason: .new,
+                freshnessState: .fresh,
                 on: app.db
             )
 
-            #expect(result.inserted)
-            #expect(result.id != nil)
-
-            let row = try await NotificationMissedDecisionModel.query(on: app.db)
-                .filter(\.$revisionUrn == revisionUrn)
-                .first()
-            #expect(row != nil)
-            #expect(row?.freshnessState == .stale)
-            #expect(row?.permissionMode == .whenInUse)
-            #expect(row?.missReason == .staleLocation)
-
-            let ledgerCount = try await NotificationLedgerModel.query(on: app.db)
-                .filter(\.$deviceInstallation.$id == installationID)
-                .filter(\.$series.$id == seriesID)
-                .filter(\.$revisionUrn == revisionUrn)
-                .count()
-            #expect(ledgerCount == 0)
+            #expect(claim.inserted)
+            let ledger = try await NotificationLedgerModel.find(claim.id, on: app.db)
+            #expect(ledger?.freshnessState == .fresh)
+            #expect(ledger?.status == "claimed")
         }
     }
 
-    @Test("duplicate logical stale misses are ignored")
-    func ignoresDuplicateLogicalMiss() async throws {
+    @Test("degraded candidate claim persists degraded freshness_state")
+    func degradedClaimPersistsFreshness() async throws {
         try await withApp { app in
+            let job = NotificationSendJob()
             let installationID = UUID()
             let seriesID = UUID()
-            let revisionUrn = "urn:oid:test-revision"
-            let now = Date()
-            let capturedAt = now.addingTimeInterval(-3_600)
-            let receivedAt = now.addingTimeInterval(-3_500)
+            let revisionUrn = "urn:oid:degraded-claim"
 
             try await seedInstallation(id: installationID, on: app.db)
-            try await seedSeries(id: seriesID, revisionUrn: revisionUrn, on: app.db)
+            try await seedSeries(id: seriesID, on: app.db)
 
-            let store = NotificationMissedDecisionStore()
-            let input = NotificationMissedDecisionInsertInput(
+            let claim = try await job.claimNotificationLedger(
                 installationID: installationID,
                 seriesID: seriesID,
                 revisionUrn: revisionUrn,
                 mode: .ugc,
                 reason: .update,
-                freshnessState: .stale,
-                missReason: .staleLocation,
-                permissionMode: .always,
-                capturedAt: capturedAt,
-                receivedAt: receivedAt,
-                evaluatedAt: now
+                freshnessState: .degraded,
+                on: app.db
             )
 
-            let first = try await store.insertStaleMissDecision(input, on: app.db)
-            let second = try await store.insertStaleMissDecision(input, on: app.db)
+            #expect(claim.inserted)
+            let ledger = try await NotificationLedgerModel.find(claim.id, on: app.db)
+            #expect(ledger?.freshnessState == .degraded)
+            #expect(ledger?.status == "claimed")
+        }
+    }
 
-            #expect(first.inserted)
-            #expect(second.inserted == false)
+    @Test("failed claimed send keeps original persisted freshness_state")
+    func failedClaimKeepsOriginalFreshness() async throws {
+        try await withApp { app in
+            let job = NotificationSendJob()
+            let installationID = UUID()
+            let seriesID = UUID()
+            let revisionUrn = "urn:oid:failed-claim"
 
-            let count = try await NotificationMissedDecisionModel.query(on: app.db)
-                .filter(\.$deviceInstallation.$id == installationID)
-                .filter(\.$series.$id == seriesID)
-                .filter(\.$revisionUrn == revisionUrn)
-                .count()
+            try await seedInstallation(id: installationID, on: app.db)
+            try await seedSeries(id: seriesID, on: app.db)
 
-            #expect(count == 1)
+            let claim = try await job.claimNotificationLedger(
+                installationID: installationID,
+                seriesID: seriesID,
+                revisionUrn: revisionUrn,
+                mode: .h3,
+                reason: .new,
+                freshnessState: .degraded,
+                on: app.db
+            )
+
+            #expect(claim.inserted)
+
+            guard let existing = try await NotificationLedgerModel.find(claim.id, on: app.db) else {
+                Issue.record("Missing claimed ledger row")
+                return
+            }
+            existing.status = "failed"
+            existing.completedAt = Date()
+            try await existing.save(on: app.db)
+
+            let refreshed = try await NotificationLedgerModel.find(claim.id, on: app.db)
+            #expect(refreshed?.status == "failed")
+            #expect(refreshed?.freshnessState == .degraded)
         }
     }
 }

--- a/Tests/AppTests/NotificationMissedDecisionPersistenceTests.swift
+++ b/Tests/AppTests/NotificationMissedDecisionPersistenceTests.swift
@@ -1,0 +1,214 @@
+@testable import App
+import Foundation
+import Fluent
+import FluentPostgresDriver
+import FluentSQL
+import Testing
+import Vapor
+
+@Suite("Notification missed decision persistence", .serialized)
+struct NotificationMissedDecisionPersistenceTests {
+    private func withApp(test: (Application) async throws -> Void) async throws {
+        let app = try await Application.make(.testing)
+        do {
+            let databaseURL = Environment.get("DATABASE_URL")
+                ?? "postgres://arcus:arcus@127.0.0.1:5432/arcus_signal?tlsmode=disable"
+            app.databases.use(try .postgres(url: databaseURL), as: .psql)
+            try await bootstrapTables(on: app.db)
+            try await test(app)
+        } catch {
+            Issue.record("Test DB error: \(String(reflecting: error))")
+            try? await app.asyncShutdown()
+            throw error
+        }
+        try await app.asyncShutdown()
+    }
+
+    private func bootstrapTables(on db: any Database) async throws {
+        guard let sql = db as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        try await sql.raw("""
+            CREATE TABLE IF NOT EXISTS device_installations (
+                installation_id UUID PRIMARY KEY,
+                apns_device_token TEXT NOT NULL,
+                apns_environment TEXT NOT NULL,
+                platform TEXT NOT NULL,
+                os_version TEXT NOT NULL,
+                app_version TEXT NOT NULL,
+                build_number TEXT NOT NULL,
+                location_auth TEXT NOT NULL,
+                is_active BOOLEAN NOT NULL,
+                created_at TIMESTAMP NOT NULL,
+                updated_at TIMESTAMP NOT NULL,
+                last_seen_at TIMESTAMP NOT NULL
+            );
+            """).run()
+
+        try await sql.raw("""
+            CREATE TABLE IF NOT EXISTS arcus_series (
+                id UUID PRIMARY KEY,
+                source TEXT NOT NULL,
+                event TEXT NOT NULL,
+                source_url TEXT NOT NULL,
+                current_revision_urn TEXT NOT NULL,
+                current_revision_sent TIMESTAMP NOT NULL,
+                message_type TEXT NOT NULL,
+                content_fingerprint TEXT NOT NULL,
+                state TEXT NOT NULL,
+                severity TEXT NOT NULL,
+                urgency TEXT NOT NULL,
+                certainty TEXT NOT NULL,
+                ugc_codes TEXT[] NOT NULL,
+                created TIMESTAMP NOT NULL,
+                updated TIMESTAMP NOT NULL,
+                last_seen_active TIMESTAMP NOT NULL
+            );
+            """).run()
+
+        try await sql.raw("""
+            CREATE TABLE IF NOT EXISTS notification_missed_decisions (
+                id UUID PRIMARY KEY,
+                installation_id UUID NOT NULL REFERENCES device_installations(installation_id) ON DELETE CASCADE,
+                series_id UUID NOT NULL REFERENCES arcus_series(id) ON DELETE CASCADE,
+                revision_urn TEXT NOT NULL,
+                mode TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                freshness_state TEXT NOT NULL,
+                miss_reason TEXT NOT NULL,
+                permission_mode TEXT NOT NULL,
+                captured_at TIMESTAMP NOT NULL,
+                received_at TIMESTAMP NOT NULL,
+                evaluated_at TIMESTAMP NOT NULL,
+                created TIMESTAMP NOT NULL
+            );
+            """).run()
+
+        try await sql.raw("""
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_missed_decisions_identity
+            ON notification_missed_decisions
+            (installation_id, series_id, revision_urn, mode, reason, miss_reason);
+            """).run()
+    }
+
+    private func seedInstallation(id: UUID, on db: any Database) async throws {
+        guard let sql = db as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+        try await sql.raw("""
+            INSERT INTO device_installations
+                (installation_id, apns_device_token, apns_environment, platform, os_version, app_version,
+                 build_number, location_auth, is_active, created_at, updated_at, last_seen_at)
+            VALUES
+                (\(bind: id), 'token', 'sandbox', 'iOS', '26.0', '1.0.0', '100', 'whenInUse',
+                 TRUE, NOW(), NOW(), NOW())
+            ON CONFLICT (installation_id) DO NOTHING
+            """).run()
+    }
+
+    private func seedSeries(id: UUID, revisionUrn _: String, on db: any Database) async throws {
+        guard let sql = db as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+        try await sql.raw("""
+            INSERT INTO arcus_series
+                (id, source, event, source_url, current_revision_urn, current_revision_sent, message_type,
+                 content_fingerprint, state, severity, urgency, certainty, ugc_codes, created, updated, last_seen_active)
+            VALUES
+                (\(bind: id), 'nws', 'Tornado Warning', 'https://api.weather.gov/alerts/test', 'urn:oid:series',
+                 NOW(), 'alert', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                 'active', 'severe', 'immediate', 'observed', ARRAY[]::text[],
+                 NOW(), NOW(), NOW())
+            ON CONFLICT (id) DO NOTHING
+            """).run()
+    }
+
+    @Test("stale missed decision can be inserted")
+    func insertsStaleMissDecision() async throws {
+        try await withApp { app in
+            let installationID = UUID()
+            let seriesID = UUID()
+            let revisionUrn = "urn:oid:test-revision"
+            let now = Date()
+            let capturedAt = now.addingTimeInterval(-3_600)
+            let receivedAt = now.addingTimeInterval(-3_500)
+
+            try await seedInstallation(id: installationID, on: app.db)
+            try await seedSeries(id: seriesID, revisionUrn: revisionUrn, on: app.db)
+
+            let store = NotificationMissedDecisionStore()
+            let result = try await store.insertStaleMissDecision(
+                .init(
+                    installationID: installationID,
+                    seriesID: seriesID,
+                    revisionUrn: revisionUrn,
+                    mode: .h3,
+                    reason: .new,
+                    freshnessState: .stale,
+                    missReason: .staleLocation,
+                    permissionMode: .whenInUse,
+                    capturedAt: capturedAt,
+                    receivedAt: receivedAt,
+                    evaluatedAt: now
+                ),
+                on: app.db
+            )
+
+            #expect(result.inserted)
+            #expect(result.id != nil)
+
+            let row = try await NotificationMissedDecisionModel.query(on: app.db)
+                .filter(\.$revisionUrn == revisionUrn)
+                .first()
+            #expect(row != nil)
+            #expect(row?.freshnessState == .stale)
+            #expect(row?.permissionMode == .whenInUse)
+            #expect(row?.missReason == .staleLocation)
+        }
+    }
+
+    @Test("duplicate logical stale misses are ignored")
+    func ignoresDuplicateLogicalMiss() async throws {
+        try await withApp { app in
+            let installationID = UUID()
+            let seriesID = UUID()
+            let revisionUrn = "urn:oid:test-revision"
+            let now = Date()
+            let capturedAt = now.addingTimeInterval(-3_600)
+            let receivedAt = now.addingTimeInterval(-3_500)
+
+            try await seedInstallation(id: installationID, on: app.db)
+            try await seedSeries(id: seriesID, revisionUrn: revisionUrn, on: app.db)
+
+            let store = NotificationMissedDecisionStore()
+            let input = NotificationMissedDecisionInsertInput(
+                installationID: installationID,
+                seriesID: seriesID,
+                revisionUrn: revisionUrn,
+                mode: .ugc,
+                reason: .update,
+                freshnessState: .stale,
+                missReason: .staleLocation,
+                permissionMode: .always,
+                capturedAt: capturedAt,
+                receivedAt: receivedAt,
+                evaluatedAt: now
+            )
+
+            let first = try await store.insertStaleMissDecision(input, on: app.db)
+            let second = try await store.insertStaleMissDecision(input, on: app.db)
+
+            #expect(first.inserted)
+            #expect(second.inserted == false)
+
+            let count = try await NotificationMissedDecisionModel.query(on: app.db)
+                .filter(\.$deviceInstallation.$id == installationID)
+                .filter(\.$series.$id == seriesID)
+                .filter(\.$revisionUrn == revisionUrn)
+                .count()
+
+            #expect(count == 1)
+        }
+    }
+}

--- a/Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift
+++ b/Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift
@@ -1,0 +1,371 @@
+@testable import App
+import Fluent
+import FluentPostgresDriver
+import FluentSQL
+import Foundation
+import Queues
+import Testing
+import Vapor
+
+@Suite("Notification send job delivery boundary", .serialized)
+struct NotificationSendJobDeliveryBoundaryTests {
+    private func withApp(test: (Application) async throws -> Void) async throws {
+        let app = try await Application.make(.testing)
+        do {
+            let databaseURL = Environment.get("DATABASE_URL")
+                ?? "postgres://arcus:arcus@127.0.0.1:5432/arcus_signal?tlsmode=disable"
+            app.databases.use(try .postgres(url: databaseURL), as: .psql)
+            try await bootstrapTables(on: app.db)
+            try await test(app)
+        } catch {
+            Issue.record("Test DB error: \(String(reflecting: error))")
+            try? await app.asyncShutdown()
+            throw error
+        }
+        try await app.asyncShutdown()
+    }
+
+    private func bootstrapTables(on db: any Database) async throws {
+        guard let sql = db as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        try await sql.raw("""
+            CREATE TABLE IF NOT EXISTS device_installations (
+                installation_id UUID PRIMARY KEY,
+                apns_device_token TEXT NOT NULL,
+                apns_environment TEXT NOT NULL,
+                platform TEXT NOT NULL,
+                os_version TEXT NOT NULL,
+                app_version TEXT NOT NULL,
+                build_number TEXT NOT NULL,
+                location_auth TEXT NOT NULL,
+                is_active BOOLEAN NOT NULL,
+                is_subscribed BOOLEAN NOT NULL DEFAULT TRUE,
+                created_at TIMESTAMP NOT NULL,
+                updated_at TIMESTAMP NOT NULL,
+                last_seen_at TIMESTAMP NOT NULL
+            );
+            """).run()
+
+        try await sql.raw("""
+            ALTER TABLE device_installations
+            ADD COLUMN IF NOT EXISTS is_subscribed BOOLEAN NOT NULL DEFAULT TRUE;
+            """).run()
+
+        try await sql.raw("""
+            CREATE TABLE IF NOT EXISTS arcus_series (
+                id UUID PRIMARY KEY,
+                source TEXT NOT NULL,
+                event TEXT NOT NULL,
+                source_url TEXT NOT NULL,
+                current_revision_urn TEXT NOT NULL,
+                current_revision_sent TIMESTAMP NOT NULL,
+                message_type TEXT NOT NULL,
+                content_fingerprint TEXT NOT NULL,
+                state TEXT NOT NULL,
+                severity TEXT NOT NULL,
+                urgency TEXT NOT NULL,
+                certainty TEXT NOT NULL,
+                ugc_codes TEXT[] NOT NULL,
+                created TIMESTAMP NOT NULL,
+                updated TIMESTAMP NOT NULL,
+                last_seen_active TIMESTAMP NOT NULL
+            );
+            """).run()
+
+        try await sql.raw("""
+            CREATE TABLE IF NOT EXISTS notification_ledger (
+                id UUID PRIMARY KEY,
+                installation_id UUID NOT NULL REFERENCES device_installations(installation_id) ON DELETE CASCADE,
+                series_id UUID NOT NULL REFERENCES arcus_series(id) ON DELETE CASCADE,
+                revision_urn TEXT NOT NULL,
+                mode TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                freshness_state TEXT NOT NULL,
+                status TEXT,
+                apns_error_code TEXT,
+                completed_at TIMESTAMP,
+                created TIMESTAMP NOT NULL
+            );
+            """).run()
+
+        try await sql.raw("""
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_ledger_identity
+            ON notification_ledger (installation_id, series_id, revision_urn);
+            """).run()
+
+        try await sql.raw("""
+            CREATE TABLE IF NOT EXISTS notification_missed_decisions (
+                id UUID PRIMARY KEY,
+                installation_id UUID NOT NULL REFERENCES device_installations(installation_id) ON DELETE CASCADE,
+                series_id UUID NOT NULL REFERENCES arcus_series(id) ON DELETE CASCADE,
+                revision_urn TEXT NOT NULL,
+                mode TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                freshness_state TEXT NOT NULL,
+                miss_reason TEXT NOT NULL,
+                permission_mode TEXT NOT NULL,
+                captured_at TIMESTAMP NOT NULL,
+                received_at TIMESTAMP NOT NULL,
+                evaluated_at TIMESTAMP NOT NULL,
+                created TIMESTAMP NOT NULL
+            );
+            """).run()
+
+        try await sql.raw("""
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_missed_decisions_identity
+            ON notification_missed_decisions
+            (installation_id, series_id, revision_urn, mode, reason, miss_reason);
+            """).run()
+
+        try await sql.raw("""
+            CREATE TABLE IF NOT EXISTS notification_debug (
+                id UUID PRIMARY KEY,
+                series_id UUID NOT NULL,
+                installation_id UUID NULL,
+                notification_ledger_id UUID NULL,
+                revision_urn TEXT NOT NULL,
+                mode TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                record_kind TEXT NOT NULL,
+                title TEXT NOT NULL,
+                subtitle TEXT NOT NULL,
+                body TEXT NOT NULL,
+                created TIMESTAMP NOT NULL
+            );
+            """).run()
+    }
+
+    private func makeQueueContext(app: Application) -> QueueContext {
+        QueueContext(
+            queueName: QueueName(string: "test-send"),
+            configuration: app.queues.configuration,
+            application: app,
+            logger: app.logger,
+            on: app.eventLoopGroup.any()
+        )
+    }
+
+    private func seedInstallation(id: UUID, locationAuth: LocationAuth, on db: any Database) async throws {
+        guard let sql = db as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        try await sql.raw("""
+            INSERT INTO device_installations
+                (installation_id, apns_device_token, apns_environment, platform, os_version, app_version,
+                 build_number, location_auth, is_active, is_subscribed, created_at, updated_at, last_seen_at)
+            VALUES
+                (\(bind: id), 'token', 'sandbox', 'iOS', '26.0', '1.0.0', '100',
+                 \(bind: locationAuth.rawValue), TRUE, TRUE, NOW(), NOW(), NOW())
+            ON CONFLICT (installation_id) DO UPDATE
+            SET location_auth = EXCLUDED.location_auth
+            """).run()
+    }
+
+    private func seedSeries(id: UUID, revisionUrn: String, on db: any Database) async throws {
+        guard let sql = db as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        try await sql.raw("""
+            INSERT INTO arcus_series
+                (id, source, event, source_url, current_revision_urn, current_revision_sent, message_type,
+                 content_fingerprint, state, severity, urgency, certainty, ugc_codes, created, updated, last_seen_active)
+            VALUES
+                (\(bind: id), 'nws', 'Tornado Warning', 'https://api.weather.gov/alerts/test', \(bind: revisionUrn),
+                 NOW(), 'alert', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                 'active', 'severe', 'immediate', 'observed', ARRAY[]::text[], NOW(), NOW(), NOW())
+            ON CONFLICT (id) DO UPDATE
+            SET current_revision_urn = EXCLUDED.current_revision_urn
+            """).run()
+    }
+
+    private func makeSeries(id: UUID, revisionUrn: String, now: Date) -> ArcusSeriesModel {
+        ArcusSeriesModel(
+            id: id,
+            source: "nws",
+            event: "Tornado Warning",
+            sourceURL: "https://api.weather.gov/alerts/test",
+            currentRevisionUrn: revisionUrn,
+            currentRevisionSent: now,
+            messageType: "alert",
+            contentFingerprint: String(repeating: "a", count: 64),
+            state: "active",
+            lastSeenActive: now,
+            severity: "severe",
+            urgency: "immediate",
+            certainty: "observed",
+            ugcCodes: []
+        )
+    }
+
+    private func makeCandidate(
+        id: UUID,
+        auth: LocationAuth,
+        capturedAt: Date
+    ) -> NotificationCandidate {
+        NotificationCandidate(
+            id: id,
+            apnsToken: "token",
+            apnsEnvironment: "sandbox",
+            locationAuthRaw: auth.rawValue,
+            capturedAt: capturedAt,
+            receivedAt: capturedAt.addingTimeInterval(30),
+            countyLabel: "Test County",
+            fireZoneLabel: nil
+        )
+    }
+
+    @Test("stale candidates are blocked before ledger and persist one stale miss across retries")
+    func staleCandidatesBlockedBeforeLedgerAndIdempotent() async throws {
+        try await withApp { app in
+            let sender = RecordingNotificationSender()
+            let job = NotificationSendJob(sender: sender)
+            let context = makeQueueContext(app: app)
+
+            let installationID = UUID()
+            let seriesID = UUID()
+            let revisionUrn = "urn:oid:stale-boundary"
+            let now = Date()
+            let series = makeSeries(id: seriesID, revisionUrn: revisionUrn, now: now)
+            let candidate = makeCandidate(
+                id: installationID,
+                auth: .whenInUse,
+                capturedAt: now.addingTimeInterval(-(25 * 60 * 60))
+            )
+
+            try await seedInstallation(id: installationID, locationAuth: .whenInUse, on: app.db)
+            try await seedSeries(id: seriesID, revisionUrn: revisionUrn, on: app.db)
+
+            _ = try await job.dispatchNotifications(
+                to: [candidate],
+                with: .init(seriesId: seriesID, revisionUrn: revisionUrn, mode: .h3, reason: .new),
+                and: series,
+                using: context
+            )
+            _ = try await job.dispatchNotifications(
+                to: [candidate],
+                with: .init(seriesId: seriesID, revisionUrn: revisionUrn, mode: .h3, reason: .new),
+                and: series,
+                using: context
+            )
+
+            let ledgerCount = try await NotificationLedgerModel.query(on: app.db)
+                .filter(\.$deviceInstallation.$id == installationID)
+                .filter(\.$series.$id == seriesID)
+                .filter(\.$revisionUrn == revisionUrn)
+                .count()
+            #expect(ledgerCount == 0)
+
+            let missedRows = try await NotificationMissedDecisionModel.query(on: app.db)
+                .filter(\.$deviceInstallation.$id == installationID)
+                .filter(\.$series.$id == seriesID)
+                .filter(\.$revisionUrn == revisionUrn)
+                .all()
+            #expect(missedRows.count == 1)
+            #expect(missedRows.first?.freshnessState == .stale)
+
+            let sends = await sender.sendCount
+            #expect(sends == 0)
+        }
+    }
+
+    @Test("degraded candidates remain eligible and persist degraded ledger freshness")
+    func degradedCandidatesRemainEligibleAndPersistLedgerFreshness() async throws {
+        try await withApp { app in
+            let sender = RecordingNotificationSender()
+            let job = NotificationSendJob(sender: sender)
+            let context = makeQueueContext(app: app)
+
+            let installationID = UUID()
+            let seriesID = UUID()
+            let revisionUrn = "urn:oid:degraded-boundary"
+            let now = Date()
+            let series = makeSeries(id: seriesID, revisionUrn: revisionUrn, now: now)
+            let candidate = makeCandidate(
+                id: installationID,
+                auth: .whenInUse,
+                capturedAt: now.addingTimeInterval(-(3 * 60 * 60))
+            )
+
+            try await seedInstallation(id: installationID, locationAuth: .whenInUse, on: app.db)
+            try await seedSeries(id: seriesID, revisionUrn: revisionUrn, on: app.db)
+
+            let summary = try await job.dispatchNotifications(
+                to: [candidate],
+                with: .init(seriesId: seriesID, revisionUrn: revisionUrn, mode: .h3, reason: .new),
+                and: series,
+                using: context
+            )
+
+            #expect(summary.claimedCount == 1)
+            #expect(summary.sentCount == 1)
+            #expect(summary.staleMissedCount == 0)
+
+            let ledger = try await NotificationLedgerModel.query(on: app.db)
+                .filter(\.$deviceInstallation.$id == installationID)
+                .filter(\.$series.$id == seriesID)
+                .filter(\.$revisionUrn == revisionUrn)
+                .first()
+            #expect(ledger != nil)
+            #expect(ledger?.freshnessState == .degraded)
+        }
+    }
+
+    @Test("fresh candidates persist fresh ledger freshness")
+    func freshCandidatesPersistFreshLedgerFreshness() async throws {
+        try await withApp { app in
+            let sender = RecordingNotificationSender()
+            let job = NotificationSendJob(sender: sender)
+            let context = makeQueueContext(app: app)
+
+            let installationID = UUID()
+            let seriesID = UUID()
+            let revisionUrn = "urn:oid:fresh-boundary"
+            let now = Date()
+            let series = makeSeries(id: seriesID, revisionUrn: revisionUrn, now: now)
+            let candidate = makeCandidate(
+                id: installationID,
+                auth: .always,
+                capturedAt: now.addingTimeInterval(-(60 * 60))
+            )
+
+            try await seedInstallation(id: installationID, locationAuth: .always, on: app.db)
+            try await seedSeries(id: seriesID, revisionUrn: revisionUrn, on: app.db)
+
+            let summary = try await job.dispatchNotifications(
+                to: [candidate],
+                with: .init(seriesId: seriesID, revisionUrn: revisionUrn, mode: .ugc, reason: .new),
+                and: series,
+                using: context
+            )
+
+            #expect(summary.claimedCount == 1)
+            #expect(summary.sentCount == 1)
+            #expect(summary.staleMissedCount == 0)
+
+            let ledger = try await NotificationLedgerModel.query(on: app.db)
+                .filter(\.$deviceInstallation.$id == installationID)
+                .filter(\.$series.$id == seriesID)
+                .filter(\.$revisionUrn == revisionUrn)
+                .first()
+            #expect(ledger != nil)
+            #expect(ledger?.freshnessState == .fresh)
+        }
+    }
+}
+
+private actor RecordingNotificationSender: NotificationSender {
+    private(set) var sendCount = 0
+
+    func sendNotification(
+        app _: Application,
+        with _: AlertDetails,
+        to _: String,
+        environment _: APNsEnvironment
+    ) async throws {
+        sendCount += 1
+    }
+}

--- a/Tests/AppTests/NotificationSendJobFreshnessDecisionTests.swift
+++ b/Tests/AppTests/NotificationSendJobFreshnessDecisionTests.swift
@@ -38,6 +38,21 @@ struct NotificationSendJobFreshnessDecisionTests {
         }
     }
 
+    @Test("stale always-mode candidates are skipped")
+    func staleAlwaysCandidatesAreSkipped() {
+        let candidate = makeCandidate(
+            auth: .always,
+            capturedAt: now.addingTimeInterval(-(24 * 60 * 60) - 1)
+        )
+
+        let disposition = job.deliveryDisposition(for: candidate, evaluatedAt: now)
+        if case .skipStale = disposition {
+            #expect(Bool(true))
+        } else {
+            Issue.record("Expected stale always candidate to be skipped")
+        }
+    }
+
     @Test("fresh candidates continue")
     func freshCandidatesContinue() {
         let candidate = makeCandidate(
@@ -65,6 +80,21 @@ struct NotificationSendJobFreshnessDecisionTests {
             #expect(freshness.state == .degraded)
         } else {
             Issue.record("Expected degraded candidate to continue")
+        }
+    }
+
+    @Test("degraded always-mode candidates continue")
+    func degradedAlwaysCandidatesContinue() {
+        let candidate = makeCandidate(
+            auth: .always,
+            capturedAt: now.addingTimeInterval(-(8 * 60 * 60))
+        )
+
+        let disposition = job.deliveryDisposition(for: candidate, evaluatedAt: now)
+        if case let .deliver(freshness) = disposition {
+            #expect(freshness.state == .degraded)
+        } else {
+            Issue.record("Expected degraded always candidate to continue")
         }
     }
 }

--- a/Tests/AppTests/NotificationSendJobFreshnessDecisionTests.swift
+++ b/Tests/AppTests/NotificationSendJobFreshnessDecisionTests.swift
@@ -1,0 +1,70 @@
+@testable import App
+import Foundation
+import Testing
+
+@Suite("Notification send job freshness decision")
+struct NotificationSendJobFreshnessDecisionTests {
+    private let job = NotificationSendJob()
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func makeCandidate(
+        auth: LocationAuth,
+        capturedAt: Date
+    ) -> NotificationCandidate {
+        .init(
+            id: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!,
+            apnsToken: "token",
+            apnsEnvironment: "sandbox",
+            locationAuthRaw: auth.rawValue,
+            capturedAt: capturedAt,
+            receivedAt: capturedAt.addingTimeInterval(5),
+            countyLabel: nil,
+            fireZoneLabel: nil
+        )
+    }
+
+    @Test("stale candidates are skipped")
+    func staleCandidatesAreSkipped() {
+        let candidate = makeCandidate(
+            auth: .whenInUse,
+            capturedAt: now.addingTimeInterval(-(24 * 60 * 60) - 1)
+        )
+
+        let disposition = job.deliveryDisposition(for: candidate, evaluatedAt: now)
+        if case .skipStale = disposition {
+            #expect(Bool(true))
+        } else {
+            Issue.record("Expected stale candidate to be skipped")
+        }
+    }
+
+    @Test("fresh candidates continue")
+    func freshCandidatesContinue() {
+        let candidate = makeCandidate(
+            auth: .always,
+            capturedAt: now.addingTimeInterval(-(60 * 60))
+        )
+
+        let disposition = job.deliveryDisposition(for: candidate, evaluatedAt: now)
+        if case .deliver = disposition {
+            #expect(Bool(true))
+        } else {
+            Issue.record("Expected fresh candidate to continue")
+        }
+    }
+
+    @Test("degraded candidates continue")
+    func degradedCandidatesContinue() {
+        let candidate = makeCandidate(
+            auth: .whenInUse,
+            capturedAt: now.addingTimeInterval(-(3 * 60 * 60))
+        )
+
+        let disposition = job.deliveryDisposition(for: candidate, evaluatedAt: now)
+        if case let .deliver(freshness) = disposition {
+            #expect(freshness.state == .degraded)
+        } else {
+            Issue.record("Expected degraded candidate to continue")
+        }
+    }
+}

--- a/docs/Sql/NotificationProcessing.sql
+++ b/docs/Sql/NotificationProcessing.sql
@@ -7,14 +7,14 @@ SELECT
     l.mode,
     l.reason,
     COALESCE(s.event, 'unknown') AS event_type,
-    l.freshness_state,
+    COALESCE(l.freshness_state, 'legacy_unknown') AS freshness_state,
     l.status AS decision_outcome,
     COUNT(*) AS count
 FROM notification_ledger l
 LEFT JOIN arcus_series s ON s.id = l.series_id
 WHERE l.status IN ('sent', 'failed')
-GROUP BY l.mode, l.reason, COALESCE(s.event, 'unknown'), l.freshness_state, l.status
-ORDER BY count DESC, l.mode, l.reason, event_type, l.freshness_state, decision_outcome;
+GROUP BY l.mode, l.reason, COALESCE(s.event, 'unknown'), COALESCE(l.freshness_state, 'legacy_unknown'), l.status
+ORDER BY count DESC, l.mode, l.reason, event_type, freshness_state, decision_outcome;
 
 -- 2) Stale-location misses (candidate-level) from notification_missed_decisions.
 -- This answers: how many candidate pushes were skipped because location was stale?
@@ -39,7 +39,7 @@ WITH delivered AS (
         l.mode,
         l.reason,
         COALESCE(s.event, 'unknown') AS event_type,
-        l.freshness_state,
+        COALESCE(l.freshness_state, 'legacy_unknown') AS freshness_state,
         NULL::text AS permission_mode,
         NULL::text AS miss_reason,
         CASE
@@ -51,7 +51,7 @@ WITH delivered AS (
     FROM notification_ledger l
     LEFT JOIN arcus_series s ON s.id = l.series_id
     WHERE l.status IN ('sent', 'failed')
-    GROUP BY l.mode, l.reason, COALESCE(s.event, 'unknown'), l.freshness_state, l.status
+    GROUP BY l.mode, l.reason, COALESCE(s.event, 'unknown'), COALESCE(l.freshness_state, 'legacy_unknown'), l.status
 ), stale_missed AS (
     SELECT
         m.mode,

--- a/docs/Sql/NotificationProcessing.sql
+++ b/docs/Sql/NotificationProcessing.sql
@@ -1,8 +1,81 @@
--- Checks the notification ledger
--- build it out
+-- Notification processing diagnostics
+-- FB-019 location freshness observability
 
-
-SElECT l.series_id, l.mode, l.reason, l.status, p.zone, p.h3_cell, l.created, l.completed_at
+-- 1) Delivered outcomes (delivery-level) from notification_ledger.
+-- Counts successful/failed sends by mode/reason and optional event.
+SELECT
+    l.mode,
+    l.reason,
+    COALESCE(s.event, 'unknown') AS event_type,
+    l.status AS decision_outcome,
+    COUNT(*) AS count
 FROM notification_ledger l
-left join device_presence p on l.installation_id = p.installation_id
-ORDER BY created desc nulls LAST
+LEFT JOIN arcus_series s ON s.id = l.series_id
+WHERE l.status IN ('sent', 'failed')
+GROUP BY l.mode, l.reason, COALESCE(s.event, 'unknown'), l.status
+ORDER BY count DESC, l.mode, l.reason, event_type, decision_outcome;
+
+-- 2) Stale-location misses (candidate-level) from notification_missed_decisions.
+-- This answers: how many candidate pushes were skipped because location was stale?
+SELECT
+    m.mode,
+    m.reason,
+    COALESCE(s.event, 'unknown') AS event_type,
+    m.freshness_state,
+    m.permission_mode,
+    m.miss_reason,
+    'missed_stale_location'::text AS decision_outcome,
+    COUNT(*) AS count
+FROM notification_missed_decisions m
+LEFT JOIN arcus_series s ON s.id = m.series_id
+WHERE m.miss_reason = 'stale_location'
+GROUP BY m.mode, m.reason, COALESCE(s.event, 'unknown'), m.freshness_state, m.permission_mode, m.miss_reason
+ORDER BY count DESC, m.mode, m.reason, event_type, m.permission_mode;
+
+-- 3) Unified decision-outcome view (candidate + delivery) for quick reporting.
+WITH delivered AS (
+    SELECT
+        l.mode,
+        l.reason,
+        COALESCE(s.event, 'unknown') AS event_type,
+        NULL::text AS freshness_state,
+        NULL::text AS permission_mode,
+        NULL::text AS miss_reason,
+        CASE
+            WHEN l.status = 'sent' THEN 'delivered'
+            WHEN l.status = 'failed' THEN 'delivery_failed'
+            ELSE l.status
+        END AS decision_outcome,
+        COUNT(*) AS count
+    FROM notification_ledger l
+    LEFT JOIN arcus_series s ON s.id = l.series_id
+    WHERE l.status IN ('sent', 'failed')
+    GROUP BY l.mode, l.reason, COALESCE(s.event, 'unknown'), l.status
+), stale_missed AS (
+    SELECT
+        m.mode,
+        m.reason,
+        COALESCE(s.event, 'unknown') AS event_type,
+        m.freshness_state,
+        m.permission_mode,
+        m.miss_reason,
+        'missed_stale_location'::text AS decision_outcome,
+        COUNT(*) AS count
+    FROM notification_missed_decisions m
+    LEFT JOIN arcus_series s ON s.id = m.series_id
+    WHERE m.miss_reason = 'stale_location'
+    GROUP BY m.mode, m.reason, COALESCE(s.event, 'unknown'), m.freshness_state, m.permission_mode, m.miss_reason
+)
+SELECT * FROM delivered
+UNION ALL
+SELECT * FROM stale_missed
+ORDER BY count DESC, mode, reason, event_type, decision_outcome;
+
+-- 4) Send-attempt no-op reasons (attempt-level) including stale-only runs.
+SELECT
+    outcome,
+    no_op_reason,
+    COUNT(*) AS count
+FROM notification_send_attempts
+GROUP BY outcome, no_op_reason
+ORDER BY count DESC, outcome, no_op_reason;

--- a/docs/Sql/NotificationProcessing.sql
+++ b/docs/Sql/NotificationProcessing.sql
@@ -7,13 +7,14 @@ SELECT
     l.mode,
     l.reason,
     COALESCE(s.event, 'unknown') AS event_type,
+    l.freshness_state,
     l.status AS decision_outcome,
     COUNT(*) AS count
 FROM notification_ledger l
 LEFT JOIN arcus_series s ON s.id = l.series_id
 WHERE l.status IN ('sent', 'failed')
-GROUP BY l.mode, l.reason, COALESCE(s.event, 'unknown'), l.status
-ORDER BY count DESC, l.mode, l.reason, event_type, decision_outcome;
+GROUP BY l.mode, l.reason, COALESCE(s.event, 'unknown'), l.freshness_state, l.status
+ORDER BY count DESC, l.mode, l.reason, event_type, l.freshness_state, decision_outcome;
 
 -- 2) Stale-location misses (candidate-level) from notification_missed_decisions.
 -- This answers: how many candidate pushes were skipped because location was stale?
@@ -38,7 +39,7 @@ WITH delivered AS (
         l.mode,
         l.reason,
         COALESCE(s.event, 'unknown') AS event_type,
-        NULL::text AS freshness_state,
+        l.freshness_state,
         NULL::text AS permission_mode,
         NULL::text AS miss_reason,
         CASE
@@ -50,7 +51,7 @@ WITH delivered AS (
     FROM notification_ledger l
     LEFT JOIN arcus_series s ON s.id = l.series_id
     WHERE l.status IN ('sent', 'failed')
-    GROUP BY l.mode, l.reason, COALESCE(s.event, 'unknown'), l.status
+    GROUP BY l.mode, l.reason, COALESCE(s.event, 'unknown'), l.freshness_state, l.status
 ), stale_missed AS (
     SELECT
         m.mode,

--- a/docs/plans/FB-019-issue-runbook.md
+++ b/docs/plans/FB-019-issue-runbook.md
@@ -1,0 +1,326 @@
+# FB-019 Issue Runbook
+
+**Status:** Active  
+**Applies To:** FB-019 Location Freshness & Presence Policy  
+**Project:** Arcus Signal  
+**Related Docs:**
+- `AGENTS.md`
+- `docs/architecture.md`
+- `docs/epics-stories.md`
+- `docs/event-cleanup-strategy.md`
+- `docs/plans/FB-019-progress.md`
+- `/Users/justin/Library/Mobile Documents/iCloud~md~obsidian/Documents/Second Brain/Efforts/Notes/FB-019 Location Freshness Policy.md`
+
+This document defines how to execute one issue at a time for FB-019.
+
+---
+
+## Purpose
+
+Implement one incremental issue for FB-019 Location Freshness & Presence Policy in a way that aligns with the feature brief, Arcus Signal's existing notification pipeline, and the backend's idempotency and exactly-once constraints.
+
+This runbook exists to keep implementation:
+- issue-scoped
+- sequential
+- testable
+- verifiable
+- traceable across product intent, persistence, notification delivery, and operator diagnostics
+
+> Do not treat a single issue as permission to rebuild notification targeting.  
+> Implement the current slice cleanly, leave a durable handoff, and move to the next issue only after verification.
+
+---
+
+## Source of Truth
+
+Treat these inputs with the following authority:
+
+1. The relevant repo `AGENTS.md`  
+   Repo-wide and server standing rules.
+
+2. `docs/architecture.md` and `docs/epics-stories.md`  
+   Arcus Signal pipeline, persistence, idempotency, and delivery invariants.
+
+3. `docs/plans/FB-019-issue-runbook.md`  
+   The execution contract for how FB-019 issues should be worked.
+
+4. `FB-019 Location Freshness Policy.md`  
+   The product, behavior, thresholds, copy, and acceptance criteria source of truth.
+
+5. `docs/plans/FB-019-progress.md`  
+   The durable implementation ledger and issue-to-issue handoff record.
+
+6. The current GitHub issue or implementation slice for FB-019  
+   The implementation boundary for the current run.
+
+7. Current source, migrations, tests, SQL diagnostics, and operator dashboard code touched by that issue.
+
+---
+
+## Required Read Order
+
+Read in this order before doing any implementation work:
+
+1. `AGENTS.md`
+2. `docs/architecture.md`
+3. `docs/epics-stories.md`
+4. `docs/plans/FB-019-issue-runbook.md`
+5. `/Users/justin/Library/Mobile Documents/iCloud~md~obsidian/Documents/Second Brain/Efforts/Notes/FB-019 Location Freshness Policy.md`
+6. `docs/plans/FB-019-progress.md`
+7. `docs/event-cleanup-strategy.md`, especially the stale presence notes, when the issue touches retention, suppression, or cleanup
+8. The current GitHub issue or implementation slice
+9. Relevant source, migrations, tests, SQL diagnostics, and dashboard paths touched by that issue
+
+FB-019 is server-side unless a future issue explicitly says otherwise. Do not inspect or modify app repositories for this feature.
+
+---
+
+## Scope Rules
+
+Implement **only** the current issue's scope.
+
+### Required
+
+- Stay aligned with `FB-019 Location Freshness Policy.md`.
+- Treat the current GitHub issue or slice as the implementation boundary for this run.
+- Keep changes incremental and reviewable.
+- Leave the codebase in a clean state for the next issue.
+- Update `docs/plans/FB-019-progress.md` before finishing.
+- Keep freshness state names exactly:
+  - `fresh`
+  - `degraded`
+  - `stale`
+- Compute freshness from `device_presence.captured_at`, not `received_at`, `updated_at`, or `device_installations.last_seen_at`.
+- Use the recorded permission mode from `device_installations.location_auth`.
+- Keep the global hard-stale threshold at 24 hours after `captured_at`.
+- Apply v1 thresholds:
+  - When In Use: fresh `0-2 hr`, degraded `2-24 hr`, stale `>24 hr`
+  - Always: fresh `0-6 hr`, degraded `6-24 hr`, stale `>24 hr`
+- Exclude stale presence from push targeting.
+- Log stale exclusions as missed notification decisions with idempotent persistence.
+- Allow degraded warning and watch candidates to remain eligible.
+- Use conservative subtitle copy for degraded candidates: `For your last known area`.
+- Preserve fresh current-location subtitle copy: `Includes your location`.
+- Keep stale candidates unsent; do not create stale notification copy because no push should be delivered.
+- Integrate policy into the existing notification decision flow.
+- Keep `NotificationEngine` in place.
+- Keep idempotency enforced by database constraints where effects matter.
+- Add focused tests for fresh, degraded, and stale behavior across When In Use and Always modes.
+- Record freshness state used at decision time for delivered notification decisions.
+- Add observability sufficient to answer: "How many candidate pushes were skipped because location was stale?"
+- Evaluate whether `swift-concurrency-expert` applies before implementation and before final verification.
+
+### Forbidden
+
+- Do not introduce a new notification architecture or parallel targeting pipeline.
+- Do not target using stale presence.
+- Do not compute freshness from `received_at`, `updated_at`, or `last_seen_at`.
+- Do not silently drop stale candidates without durable missed-decision accounting.
+- Do not send user-facing copy that implies current-location precision for degraded presence.
+- Do not use `Near your last known area` in v1.
+- Do not change in-app UI freshness state or Summary screen behavior.
+- Do not build real-time continuous location tracking.
+- Do not redesign the full notification policy matrix for every alert type.
+- Do not move mesoscale discussion notification handling from device-side logic to server-side targeting in FB-019.
+- Do not implement route-aware or travel-mode alerting.
+- Do not solve multi-device account sync semantics unless a future issue explicitly scopes it.
+- Do not introduce server-side raw lat/lon storage.
+- Do not refactor unrelated app, ingestion, APNs, or dashboard areas unless a small local change is strictly required.
+
+If a future-facing seam is required, keep it:
+- minimal
+- local
+- easy to extend later
+
+Document the deferred remainder clearly in `docs/plans/FB-019-progress.md`.
+
+---
+
+## Working Style
+
+Prefer:
+- simple policy value types
+- pure freshness computation
+- database-backed idempotency for missed decisions
+- narrow changes to candidate resolution, delivery ledger, and notification copy
+- explicit SQL over clever query indirection when it matches the surrounding code
+- focused model/migration tests where practical
+- deterministic unit tests for threshold boundaries
+- clear operator diagnostics over noisy logs
+
+Avoid:
+- global notification rewrites
+- ambiguous freshness terminology
+- hidden fallback thresholds
+- wall-clock assumptions that make tests flaky
+- per-alert-type branching unless the current issue requires it
+- broad dashboard redesigns
+- stale-location deletion masquerading as targeting policy
+
+The policy should become a small, testable decision point in the existing delivery path, not a second notification system wearing a serious expression.
+
+---
+
+## Sequential Execution Model
+
+Work **one issue at a time**, sequentially.
+
+Do not attempt to execute multiple issues in parallel under a parent coordinator.
+
+Parallelism is allowed **only inside the current issue** and only for narrow investigation or isolated subtasks.
+
+---
+
+## Delegated Agent Rules
+
+If delegated agents or subtasks are available, use them only when they reduce context sprawl and improve quality for the **current issue**.
+
+### Good delegated tasks
+
+- tracing candidate query paths for H3 and UGC modes
+- mapping current ledger, outbox, debug snapshot, and attempt persistence
+- reviewing migration and constraint patterns
+- checking dashboard metric queries and SQL diagnostics
+- validating a small proposed policy seam against surrounding code
+
+### Do not delegate
+
+- overall architecture
+- final issue planning
+- final policy thresholds or copy decisions
+- final database identity design
+- cross-issue sequencing decisions
+- final integration decisions
+
+Delegated work should stay scoped and concise.
+
+The primary executor remains responsible for:
+- reconciling findings
+- resolving conflicts
+- producing one coherent implementation for the current issue
+
+---
+
+## Execution Sequence
+
+Before making code changes for the current issue:
+
+### 1. Inspect inputs
+
+Inspect the relevant sections of:
+- `FB-019 Location Freshness Policy.md`
+- `docs/plans/FB-019-progress.md`
+- the current issue or implementation slice
+- existing presence, installation, candidate query, notification engine, ledger, outbox, debug, metrics, migration, and test code touched by that issue
+
+### 2. Identify what matters now
+
+Identify:
+- which parts of the feature brief are relevant to the current issue
+- which parts are already partially implemented, if any
+- what existing seams, models, SQL queries, migrations, tests, and diagnostics are most relevant
+- what must change now versus what should remain deferred to later issues
+
+### 3. Produce a pre-implementation plan
+
+Before coding, produce:
+- a concise findings summary
+- an issue-scoped implementation plan
+- a short ambiguity/risk list
+- any assumptions to be made
+- a progress-verification plan explaining how the issue will be checked against both the brief and the issue once implemented
+
+### 4. Evaluate the plan before coding
+
+Evaluate the plan and:
+- remove anything that reaches beyond the current issue without strong justification
+- remove speculative abstractions or premature architecture
+- check for conflicts with the feature brief, prior progress log entries, or existing code conventions
+- verify that the plan leaves a clean handoff for the next issue
+- simplify the design if it is becoming broader than the issue requires
+
+### 4.5 Skill evaluation gate
+
+Before coding, decide whether `swift-concurrency-expert` applies.
+
+Use `swift-concurrency-expert` when the issue touches:
+- async/await flows
+- `Sendable` or `Codable` models crossing concurrency boundaries
+- Vapor queue jobs
+- APNs delivery paths
+- Fluent models or repository helpers used from async contexts
+- shared policy types used across jobs, tests, and services
+
+For applicable skill use:
+- read the skill before implementation
+- use it to evaluate the issue-scoped plan
+- apply only guidance relevant to the current issue
+- record any important skill-driven decisions in `docs/plans/FB-019-progress.md`
+
+Do not use the skill as permission to broaden scope.
+
+### 5. Implement
+
+Implement in small, reviewable steps.
+
+Prefer extending existing patterns over inventing new ones.
+
+### 6. Ask questions only when necessary
+
+Stop to ask questions only if a missing decision would materially affect:
+- the current issue's scope
+- a durable model or persistence shape
+- a public or cross-cutting API contract
+- a user-visible notification behavior that would be costly to reverse later
+- the missed-decision table identity or uniqueness rule
+
+### 7. Verify
+
+Run the smallest meaningful verification for the issue:
+- focused unit tests for freshness policy thresholds
+- focused tests for candidate eligibility and subtitle selection
+- migration tests or database-level checks for missed-decision persistence when applicable
+- notification job tests for stale suppression and degraded delivery when practical
+- dashboard or SQL checks when observability changes
+- `swift test` or narrower SwiftPM test filters when the issue touches shared behavior
+
+Do not claim tests passed unless they were actually run.
+
+### 8. Update progress
+
+Before finishing the issue:
+- update `docs/plans/FB-019-progress.md`
+- record files changed
+- record tests run and results
+- record deferred scope
+- record handoff notes for the next issue
+
+---
+
+## Suggested Implementation Sequence
+
+Work these slices in order unless the epic owner explicitly changes the order:
+
+1. `FB-019: Add location freshness policy model`
+2. `FB-019: Add missed notification decision persistence`
+3. `FB-019: Integrate freshness into notification candidate decisions`
+4. `FB-019: Select push subtitle by freshness state`
+5. `FB-019: Record freshness state on delivered decisions`
+6. `FB-019: Add freshness observability and validation`
+
+---
+
+## Expected End State
+
+FB-019 is done when:
+- Arcus Signal computes `fresh`, `degraded`, or `stale` from `device_presence.captured_at` and `device_installations.location_auth`.
+- When In Use presence is fresh through 2 hours, degraded through 24 hours, and stale after 24 hours.
+- Always presence is fresh through 6 hours, degraded through 24 hours, and stale after 24 hours.
+- Fresh warning and watch notifications use `Includes your location`.
+- Degraded warning and watch notifications remain eligible and use `For your last known area`.
+- Stale notification candidates are excluded from push delivery.
+- Stale exclusions are written once to a durable missed-decision table.
+- Delivered notification decisions record the freshness state used at decision time.
+- Observability reports candidate counts by freshness state, permission mode, delivery outcome, and stale-miss reason.
+- Tests prove fresh, degraded, and stale behavior for both permission modes.
+- No app UI behavior, real-time tracking, or parallel notification architecture is introduced.

--- a/docs/plans/FB-019-progress.md
+++ b/docs/plans/FB-019-progress.md
@@ -227,7 +227,7 @@ Related GitHub issues:
 ## Issue 3 - Integrate freshness into notification candidate decisions
 
 ### Status
-- Not started
+- Completed (2026-05-05)
 
 ### Scope
 - Load candidate presence `captured_at` and installation `location_auth` for H3 and UGC candidates.
@@ -243,10 +243,36 @@ Related GitHub issues:
 - `Done means`
 
 ### Handoff notes
-- The current `freshnessCutoff` parameter in candidate loaders filters `i.last_seen_at`; it should not be used as-is for FB-019 freshness.
-- Prefer one clear candidate shape that carries freshness inputs into the decision point.
-- Preserve idempotent behavior on job retry.
-- Ensure zero-candidate/no-op metrics distinguish no matching candidates from stale-suppressed candidates when practical.
+- Integrated freshness evaluation in `NotificationSendJob.dispatchNotifications(...)` immediately after candidate selection and before `claimNotificationLedger(...)`.
+- Enriched `NotificationCandidate` to carry freshness inputs:
+  - `locationAuthRaw` (`device_installations.location_auth`)
+  - `capturedAt` (`device_presence.captured_at`)
+  - `receivedAt` (`device_presence.received_at`)
+- Updated both candidate loaders (`loadH3Candidates`, `loadUGCCandidates`) to select these columns.
+- Removed the legacy `freshnessCutoff` argument/branches that filtered on `device_installations.last_seen_at` so FB-019 freshness is exclusively `captured_at` policy-driven.
+- Added a small decision seam `deliveryDisposition(for:evaluatedAt:)` in `NotificationSendJob`:
+  - `.skipStale` -> persist stale/missed via `NotificationMissedDecisionStore.insertStaleMissDecision(...)`, then skip send path.
+  - `.deliver` (fresh/degraded) -> continue unchanged through ledger claim and APNs send.
+- Stale/missed writes are idempotent through #53 uniqueness and `ON CONFLICT DO NOTHING`; retries do not duplicate stale rows.
+- Existing notification ledger dedupe/idempotency remains intact; stale candidates are evaluated before ledger claim so no stale claims/sends are created.
+- Delivered-decision freshness state is currently carried in local decision flow only and not persisted to `notification_ledger` in this slice to avoid widening schema/scope; follow-up remains for downstream usage (#55/#56).
+
+### Files changed
+- `Sources/App/Jobs/NotificationSendJob.swift`
+- `Tests/AppTests/NotificationSendJobFreshnessDecisionTests.swift`
+- `Tests/AppTests/NotificationEngineTests.swift`
+- `docs/plans/FB-019-progress.md`
+
+### Tests run
+- `swift test --filter LocationFreshness`
+- `swift test --filter Notification`
+- `swift test --filter Missed`
+- `swift test`
+
+### Deferred
+- Subtitle wording changes are still deferred (no push copy changes introduced in this issue).
+- Delivered freshness-state persistence is deferred to later FB-019 slices (#55/#56) to keep this issue narrow.
+- Additional stale-suppression observability/dashboard expansion is deferred.
 
 ---
 

--- a/docs/plans/FB-019-progress.md
+++ b/docs/plans/FB-019-progress.md
@@ -325,7 +325,7 @@ Related GitHub issues:
 ## Issue 5 - Record freshness state on delivered decisions
 
 ### Status
-- Not started
+- Deferred
 
 ### Scope
 - Persist freshness state used at decision time for delivered or attempted notification decisions.
@@ -339,13 +339,14 @@ Related GitHub issues:
 ### Handoff notes
 - The likely target is `notification_ledger`, but verify against the missed-decision design before committing.
 - Avoid recomputing freshness later from mutable presence for historical reporting.
+- Deferred from this issue scope because #56 final slice targeted observability/tests only and did not require schema expansion.
 
 ---
 
 ## Issue 6 - Add freshness observability and validation
 
 ### Status
-- Not started
+- Completed (2026-05-05)
 
 ### Scope
 - Add metrics/logging/reporting for:
@@ -356,6 +357,47 @@ Related GitHub issues:
 - Update operator dashboard queries only as much as needed.
 - Add or update SQL diagnostic docs.
 - Run end-to-end validation where practical.
+
+### Handoff notes
+- Added structured stale-skip observability logs in `NotificationSendJob` with:
+  - `installation_id`
+  - `series_id`
+  - `revision_urn`
+  - `event_type`
+  - `mode`
+  - `reason`
+  - `freshness_state`
+  - `permission_mode`
+  - `decision_outcome=missed_stale_location`
+  - `miss_reason=stale_location`
+  - `decision_persisted` (`inserted` or `already_recorded`)
+- Updated no-op attempt classification so stale-only candidate runs are distinguishable:
+  - new `notification_send_attempts.no_op_reason` value: `all_candidates_stale_location`
+  - existing `all_candidates_previously_claimed` preserved for dedupe-only no-op runs.
+- Expanded SQL diagnostics in `docs/Sql/NotificationProcessing.sql`:
+  - delivered/failed counts from `notification_ledger`
+  - stale-miss counts from `notification_missed_decisions`
+  - unified decision-outcome query with dimensions (`freshness_state`, `permission_mode`, `event_type`, `mode`, `reason`, `decision_outcome`, `miss_reason`)
+  - attempt-level no-op reason rollup from `notification_send_attempts`
+- Dashboard/API changes intentionally deferred: existing dashboard model would require non-trivial schema/section additions for this slice, and SQL/log diagnostics provide immediate production answerability with minimal risk.
+
+### Files changed
+- `Sources/App/Jobs/NotificationSendJob.swift`
+- `Sources/App/Models/Notification/NotificationSendAttemptModel.swift`
+- `Tests/AppTests/LocationFreshnessPolicyTests.swift`
+- `Tests/AppTests/NotificationSendJobFreshnessDecisionTests.swift`
+- `docs/Sql/NotificationProcessing.sql`
+- `docs/plans/FB-019-progress.md`
+
+### Tests run
+- `swift test --filter LocationFreshness`
+- `swift test --filter NotificationEngine`
+- `swift test --filter Missed`
+- `swift test --filter OperatorDashboard`
+- `swift test`
+
+### Remaining risks / open questions
+- Delivered rows still do not persist decision-time freshness state in `notification_ledger`; reporting freshness for delivered outcomes currently relies on stale-miss table + delivery outcomes, not a single per-candidate unified persistence row.
 
 ### Relevant feature brief sections
 - `Goals`

--- a/docs/plans/FB-019-progress.md
+++ b/docs/plans/FB-019-progress.md
@@ -167,7 +167,7 @@ Related GitHub issues:
 ## Issue 2 - Add missed notification decision persistence
 
 ### Status
-- Not started
+- Completed (2026-05-05)
 
 ### Scope
 - Add a dedicated table/model/migration for stale or missed notification decisions.
@@ -182,10 +182,45 @@ Related GitHub issues:
 - `Open questions`
 
 ### Handoff notes
-- Open design question: exact schema and unique constraint.
-- Candidate identity should likely include installation, series, revision, mode, reason, and missed reason.
-- Keep this separate from sent-delivery ledger unless the current implementation proves a unified ledger is cleaner without weakening semantics.
-- Do not delete stale presence records in this slice.
+- Added a dedicated stale/missed table: `notification_missed_decisions`.
+- Kept delivery ledger semantics unchanged; stale misses persist separately from `notification_ledger`.
+- Identity decision finalized as:
+  - `UNIQUE (installation_id, series_id, revision_urn, mode, reason, miss_reason)`
+  - This mirrors delivery identity (`installation_id`, `series_id`, `revision_urn`) and extends with decision context (`mode`, `reason`, `miss_reason`) to keep stale-miss inserts idempotent across retries/re-evaluation.
+- Column set implemented:
+  - `id`
+  - `installation_id` FK -> `device_installations.installation_id` (`ON DELETE CASCADE`)
+  - `series_id` FK -> `arcus_series.id` (`ON DELETE CASCADE`)
+  - `revision_urn`
+  - `mode`
+  - `reason`
+  - `freshness_state`
+  - `miss_reason`
+  - `permission_mode`
+  - `captured_at`
+  - `received_at`
+  - `evaluated_at`
+  - `created`
+- Added `NotificationMissedDecisionModel` and `NotificationMissedDecisionStore.insertStaleMissDecision(...)` using SQL `INSERT ... ON CONFLICT DO NOTHING RETURNING id`.
+- Helper returns inserted-vs-existing via `NotificationMissedDecisionInsertResult`.
+- Freshness typing uses existing `LocationFreshnessState` from Issue 1 / dependency #52 (no reimplementation).
+- No integration into `NotificationSendJob` decision flow yet (deferred to Issue 3 by design).
+
+### Files changed
+- `Sources/App/Migrations/CreateNotificationMissedDecisions.swift`
+- `Sources/App/Models/Notification/NotificationMissedDecisionModel.swift`
+- `Sources/App/configure.swift`
+- `Tests/AppTests/NotificationMissedDecisionPersistenceTests.swift`
+- `docs/plans/FB-019-progress.md`
+
+### Tests run
+- `swift test --filter Missed`
+- `swift test`
+
+### Deferred
+- NotificationEngine / send-job integration remains deferred to Issue 3.
+- No subtitle/candidate SQL/push-delivery behavior changes in this slice.
+- No retention/cleanup/metrics changes in this slice.
 
 ---
 

--- a/docs/plans/FB-019-progress.md
+++ b/docs/plans/FB-019-progress.md
@@ -317,7 +317,6 @@ Related GitHub issues:
 - `swift test`
 
 ### Deferred
-- Delivered freshness-state persistence remains deferred to Issue 5.
 - Freshness observability/dashboard additions remain deferred to Issue 6 / GitHub #56.
 
 ---
@@ -325,7 +324,7 @@ Related GitHub issues:
 ## Issue 5 - Record freshness state on delivered decisions
 
 ### Status
-- Deferred
+- Completed (2026-05-06)
 
 ### Scope
 - Persist freshness state used at decision time for delivered or attempted notification decisions.
@@ -337,9 +336,34 @@ Related GitHub issues:
 - `Done means`
 
 ### Handoff notes
-- The likely target is `notification_ledger`, but verify against the missed-decision design before committing.
-- Avoid recomputing freshness later from mutable presence for historical reporting.
-- Deferred from this issue scope because #56 final slice targeted observability/tests only and did not require schema expansion.
+- Added a dedicated ledger migration to persist decision-time freshness on delivery rows:
+  - `AddFreshnessStateToNotificationLedger` adds required `notification_ledger.freshness_state`.
+- Updated `NotificationLedgerModel` with typed freshness access:
+  - `freshnessStateRaw` (stored raw string)
+  - computed `freshnessState: LocationFreshnessState`
+- Updated `NotificationSendJob.claimNotificationLedger(...)` to accept `freshnessState: LocationFreshnessState` and write it during claim insert.
+- Freshness is captured once at decision/claim time and no longer depends on mutable `device_presence` for delivered/failed reporting.
+- Stale behavior remains unchanged:
+  - stale candidates are still skipped before claim/send
+  - stale candidates persist only in `notification_missed_decisions`
+  - stale candidates still do not create ledger rows.
+- Updated `docs/Sql/NotificationProcessing.sql` to include/group on `notification_ledger.freshness_state` for delivered and failed outcomes.
+- Added DB-backed persistence tests for fresh/degraded claim rows and failure-state freshness retention.
+
+### Files changed
+- `Sources/App/Migrations/AddFreshnessStateToNotificationLedger.swift`
+- `Sources/App/configure.swift`
+- `Sources/App/Models/Notification/NotificationLedgerModel.swift`
+- `Sources/App/Jobs/NotificationSendJob.swift`
+- `Tests/AppTests/NotificationLedgerFreshnessPersistenceTests.swift`
+- `Tests/AppTests/NotificationMissedDecisionPersistenceTests.swift`
+- `docs/Sql/NotificationProcessing.sql`
+- `docs/plans/FB-019-progress.md`
+
+### Tests run
+- `swift test --filter NotificationLedgerFreshnessPersistenceTests`
+- `swift test --filter NotificationMissedDecisionPersistenceTests`
+- `swift test`
 
 ---
 
@@ -397,7 +421,7 @@ Related GitHub issues:
 - `swift test`
 
 ### Remaining risks / open questions
-- Delivered rows still do not persist decision-time freshness state in `notification_ledger`; reporting freshness for delivered outcomes currently relies on stale-miss table + delivery outcomes, not a single per-candidate unified persistence row.
+- Dashboard stale-presence slices still use their existing thresholding surface; this issue only closes delivered/failed ledger freshness persistence and SQL diagnostics grouping.
 
 ### Relevant feature brief sections
 - `Goals`

--- a/docs/plans/FB-019-progress.md
+++ b/docs/plans/FB-019-progress.md
@@ -337,17 +337,17 @@ Related GitHub issues:
 
 ### Handoff notes
 - Added a dedicated ledger migration to persist decision-time freshness on delivery rows:
-  - `AddFreshnessStateToNotificationLedger` adds required `notification_ledger.freshness_state`.
+  - `AddFreshnessStateToNotificationLedger` adds nullable `notification_ledger.freshness_state` so pre-FB-019 rows are not backfilled with synthetic values.
 - Updated `NotificationLedgerModel` with typed freshness access:
   - `freshnessStateRaw` (stored raw string)
-  - computed `freshnessState: LocationFreshnessState`
+  - computed `freshnessState: LocationFreshnessState?`
 - Updated `NotificationSendJob.claimNotificationLedger(...)` to accept `freshnessState: LocationFreshnessState` and write it during claim insert.
 - Freshness is captured once at decision/claim time and no longer depends on mutable `device_presence` for delivered/failed reporting.
 - Stale behavior remains unchanged:
   - stale candidates are still skipped before claim/send
   - stale candidates persist only in `notification_missed_decisions`
   - stale candidates still do not create ledger rows.
-- Updated `docs/Sql/NotificationProcessing.sql` to include/group on `notification_ledger.freshness_state` for delivered and failed outcomes.
+- Updated `docs/Sql/NotificationProcessing.sql` to include/group on `notification_ledger.freshness_state` for delivered and failed outcomes, with `NULL` mapped to `legacy_unknown` for historical rows.
 - Added DB-backed persistence tests for fresh/degraded claim rows and failure-state freshness retention.
 
 ### Files changed

--- a/docs/plans/FB-019-progress.md
+++ b/docs/plans/FB-019-progress.md
@@ -1,0 +1,302 @@
+# FB-019 Progress Log
+
+## Overview
+
+FB-019 adds a server-owned Location Freshness & Presence Policy for Arcus Signal notification targeting.
+
+Implementation should proceed one issue at a time, following `docs/plans/FB-019-issue-runbook.md`.
+
+Primary source of truth:
+- `/Users/justin/Library/Mobile Documents/iCloud~md~obsidian/Documents/Second Brain/Efforts/Notes/FB-019 Location Freshness Policy.md`
+
+Related local docs:
+- `AGENTS.md`
+- `docs/architecture.md`
+- `docs/epics-stories.md`
+- `docs/event-cleanup-strategy.md`
+
+Related GitHub issues:
+- Not created yet.
+
+---
+
+## Global Decisions
+
+- Feature name: Location Freshness & Presence Policy.
+- Freshness states are locked as:
+  - `fresh`
+  - `degraded`
+  - `stale`
+- Freshness must be computed from `device_presence.captured_at`.
+- Freshness must not be computed from `device_presence.received_at`, `device_presence.updated_at`, or `device_installations.last_seen_at`.
+- Permission mode comes from `device_installations.location_auth`.
+- Global hard-stale threshold is 24 hours after `captured_at`.
+- When In Use thresholds:
+  - fresh: `0-2 hr`
+  - degraded: `2-24 hr`
+  - stale: `>24 hr`
+- Always thresholds:
+  - fresh: `0-6 hr`
+  - degraded: `6-24 hr`
+  - stale: `>24 hr`
+- Degraded presence remains eligible for warning and watch pushes.
+- Stale presence is ineligible for push targeting.
+- Stale does not mean delete immediately; it means not trustworthy enough for current-location targeting.
+- Fresh warning and watch pushes use subtitle copy `Includes your location`.
+- Degraded warning and watch pushes use subtitle copy `For your last known area`.
+- Do not use `Near your last known area` in v1.
+- Stale candidates are suppressed rather than sent.
+- Stale suppressions must be recorded once in a dedicated missed-decision table.
+- Delivered notification decisions should record the freshness state used at decision time.
+- Observability should answer: "How many candidate pushes were skipped because location was stale?"
+- Keep the existing `NotificationEngine` and notification delivery flow in place.
+- Do not introduce a parallel targeting pipeline.
+- Morning summaries remain out of scope because they are handled on-device.
+
+---
+
+## Current Status
+
+- FB-019 runbook and progress documents have been created.
+- No FB-019 GitHub epic or sub-issues have been identified in this repository yet.
+- No implementation changes have been made for FB-019.
+- Initial codebase investigation confirms the server has the core data needed for the policy:
+  - `device_presence.captured_at`
+  - `device_presence.received_at`
+  - `device_installations.location_auth`
+  - H3 and UGC candidate queries in `NotificationSendJob`
+  - push copy composition in `NotificationEngine`
+  - exactly-once sent-delivery accounting in `notification_ledger`
+  - operator metrics that already reference stale presence conceptually
+
+---
+
+## Codebase Investigation Notes
+
+- Relevant existing paths:
+  - `Sources/App/Controllers/DeviceController.swift`
+  - `Sources/App/Models/Device/DevicePresenceModel.swift`
+  - `Sources/App/Models/Device/DeviceInstallationModel.swift`
+  - `Sources/App/Migrations/CreateDevicePresence.swift`
+  - `Sources/App/Migrations/CreateDeviceInstallations.swift`
+  - `Sources/App/Jobs/NotificationSendJob.swift`
+  - `Sources/App/Infrastructure/Notifications/NotificationEngine.swift`
+  - `Sources/App/Models/Notification/NotificationLedgerModel.swift`
+  - `Sources/App/Models/Data/ArcusNotificationOutboxModel.swift`
+  - `Sources/App/lib/OperatorDashboardSnapshotRefresher.swift`
+  - `Sources/App/lib/OperatorDashboardConfig.swift`
+  - `Tests/AppTests/NotificationEngineTests.swift`
+  - `Tests/AppTests/OperatorDashboardTests.swift`
+  - `docs/event-cleanup-strategy.md`
+  - `docs/Sql/NotificationProcessing.sql`
+  - `docs/Sql/NotificationDebug.sql`
+  - `docs/Sql/Device.sql`
+- `DeviceController` already rejects future `capturedAt` values more than five minutes ahead of server receive time.
+- `DeviceController` ignores older presence updates by comparing incoming `capturedAt` against the stored `capturedAt`.
+- `DevicePresenceModel` stores `capturedAt`, `receivedAt`, location age, accuracy, cell scheme, H3 cell, UGC codes, and location source.
+- `DeviceInstallationModel` stores `locationAuthRaw`, with typed `LocationAuth` values:
+  - `always`
+  - `whenInUse`
+  - `denied`
+  - `restricted`
+  - `notDetermined`
+  - `unknown`
+- `NotificationSendJob.loadH3Candidates` and `loadUGCCandidates` already accept an optional `freshnessCutoff`, but current callers pass `nil`.
+- The existing optional `freshnessCutoff` branches filter `i.last_seen_at`, not `p.captured_at`. FB-019 must not use that as the final policy implementation.
+- `NotificationCandidate` currently does not include `captured_at`, `received_at`, or `location_auth`, so the delivery loop cannot yet choose freshness-aware copy or stale suppression after broad candidate selection.
+- `NotificationEngine.deriveSubtitle` currently returns `Includes your location` for new H3 notifications and `For your area` for new UGC notifications.
+- `NotificationEngine.deriveSubtitle` currently ignores candidate freshness because freshness is not modeled on `NotificationCandidate`.
+- `notification_ledger` currently enforces a sent-delivery identity around `(installation_id, series_id, revision_urn)` through the claim path.
+- `notification_ledger` records status and APNs failures but does not currently record freshness state.
+- No dedicated missed-decision table exists yet.
+- `OperatorDashboardConfig.presenceFreshnessThresholdSeconds` currently uses a flat 6-hour threshold for dashboard calculations.
+- `OperatorDashboardSnapshotRefresher` already has stale presence metrics, but they use a single cutoff rather than the FB-019 permission-aware policy.
+- `docs/event-cleanup-strategy.md` explicitly calls out that `device_presence` has no `expires_at` and notification queries currently pass no freshness cutoff.
+- Presence cleanup remains adjacent but out of scope for the initial targeting policy. Stale presence should be excluded from targeting before deletion/retention policy is solved.
+
+---
+
+## Suggested Issue Slices
+
+## Issue 1 - Add location freshness policy model
+
+### Status
+- Completed (2026-05-05)
+
+### Scope
+- Define a small, testable policy model that computes `fresh`, `degraded`, or `stale`.
+- Inputs should include:
+  - `capturedAt`
+  - permission mode / `LocationAuth`
+  - current server time
+- Keep threshold logic isolated from SQL and APNs sending.
+- Cover exact boundary behavior for When In Use and Always.
+- Decide and document fallback behavior for denied, restricted, not determined, and unknown authorization.
+
+### Relevant feature brief sections
+- `Decisions`
+- `Target behavior`
+- `Constraints / invariants`
+- `Acceptance criteria`
+
+### Handoff notes
+- Implemented a pure value policy under `Sources/App/Infrastructure/Notifications/LocationFreshnessPolicy.swift`:
+  - `LocationFreshnessState` (`fresh`, `degraded`, `stale`)
+  - `LocationFreshnessDecision` (`state`, computed `age`)
+  - `LocationFreshnessPolicy.decide(capturedAt:locationAuth:now:)`
+- Threshold behavior implemented exactly:
+  - `whenInUse`: fresh `<=2h`, degraded `>2h && <=24h`, stale `>24h`
+  - `always`: fresh `<=6h`, degraded `>6h && <=24h`, stale `>24h`
+- Global hard stale threshold enforced at `>24h` for all modes.
+- Conservative fallback decision for non-granted/unknown auth (`denied`, `restricted`, `notDetermined`, `unknown`): classify as `stale`.
+- Freshness computation is explicitly `capturedAt`-based; policy API does not accept `receivedAt`, `updatedAt`, or `lastSeenAt`.
+- Added focused deterministic boundary tests in `Tests/AppTests/LocationFreshnessPolicyTests.swift`.
+- No NotificationEngine integration and no delivery behavior change in this slice.
+
+### Files changed
+- `Sources/App/Infrastructure/Notifications/LocationFreshnessPolicy.swift`
+- `Tests/AppTests/LocationFreshnessPolicyTests.swift`
+- `docs/plans/FB-019-progress.md`
+
+### Tests run
+- `swift test --filter LocationFreshness`
+- `swift test`
+
+---
+
+## Issue 2 - Add missed notification decision persistence
+
+### Status
+- Not started
+
+### Scope
+- Add a dedicated table/model/migration for stale or missed notification decisions.
+- Use an idempotent key aligned as closely as practical with the existing delivery ledger identity.
+- Record enough context to debug stale suppression without storing raw location.
+- Add tests or SQL-level validation for duplicate suppression.
+
+### Relevant feature brief sections
+- `Dependencies`
+- `Acceptance criteria`
+- `Done means`
+- `Open questions`
+
+### Handoff notes
+- Open design question: exact schema and unique constraint.
+- Candidate identity should likely include installation, series, revision, mode, reason, and missed reason.
+- Keep this separate from sent-delivery ledger unless the current implementation proves a unified ledger is cleaner without weakening semantics.
+- Do not delete stale presence records in this slice.
+
+---
+
+## Issue 3 - Integrate freshness into notification candidate decisions
+
+### Status
+- Not started
+
+### Scope
+- Load candidate presence `captured_at` and installation `location_auth` for H3 and UGC candidates.
+- Evaluate freshness before claiming/sending delivery.
+- Suppress stale candidates.
+- Write missed-decision rows for stale candidates.
+- Allow fresh and degraded candidates through the existing delivery path.
+
+### Relevant feature brief sections
+- `Target behavior`
+- `Constraints / invariants`
+- `Acceptance criteria`
+- `Done means`
+
+### Handoff notes
+- The current `freshnessCutoff` parameter in candidate loaders filters `i.last_seen_at`; it should not be used as-is for FB-019 freshness.
+- Prefer one clear candidate shape that carries freshness inputs into the decision point.
+- Preserve idempotent behavior on job retry.
+- Ensure zero-candidate/no-op metrics distinguish no matching candidates from stale-suppressed candidates when practical.
+
+---
+
+## Issue 4 - Select push subtitle by freshness state
+
+### Status
+- Not started
+
+### Scope
+- Centralize subtitle selection based on freshness state.
+- Use `Includes your location` only for fresh current-location warning/watch notifications.
+- Use `For your last known area` for degraded warning/watch notifications.
+- Preserve existing non-current-area semantics where the feature brief does not require a copy change.
+- Add focused notification engine tests.
+
+### Relevant feature brief sections
+- `Target behavior`
+- `Copy and trust rules`
+- `Acceptance criteria`
+
+### Handoff notes
+- `NotificationEngine` currently has no freshness input.
+- Avoid threading raw presence models into `NotificationEngine`; pass only derived decision state needed for copy.
+- Stale candidates should not reach push composition for delivery.
+
+---
+
+## Issue 5 - Record freshness state on delivered decisions
+
+### Status
+- Not started
+
+### Scope
+- Persist freshness state used at decision time for delivered or attempted notification decisions.
+- Keep the recorded value stable even if presence changes after the decision.
+- Update relevant models, migrations, and tests.
+
+### Relevant feature brief sections
+- `Acceptance criteria`
+- `Done means`
+
+### Handoff notes
+- The likely target is `notification_ledger`, but verify against the missed-decision design before committing.
+- Avoid recomputing freshness later from mutable presence for historical reporting.
+
+---
+
+## Issue 6 - Add freshness observability and validation
+
+### Status
+- Not started
+
+### Scope
+- Add metrics/logging/reporting for:
+  - freshness state
+  - permission mode
+  - delivery outcome
+  - stale-miss reason
+- Update operator dashboard queries only as much as needed.
+- Add or update SQL diagnostic docs.
+- Run end-to-end validation where practical.
+
+### Relevant feature brief sections
+- `Goals`
+- `Dependencies`
+- `Acceptance criteria`
+- `Done means`
+
+### Handoff notes
+- Existing dashboard stale-presence metrics use a flat 6-hour threshold.
+- Align dashboard reporting with the FB-019 policy after the core decision path is implemented.
+- Do not redesign the dashboard layout unless required by the metric surface.
+
+---
+
+## Open Questions
+
+1. Should denied, restricted, not determined, and unknown authorization modes be treated as When In Use degradation, immediately stale, or a separate ineligible reason?
+2. What exact schema and unique constraint should the missed-decision table use?
+3. Should stale suppressions be recorded for all event kinds/reasons, or only warning/watch pushes covered by the brief?
+4. Should `endedAllClear` and `cancelInError` notifications bypass freshness because they are cleanup/trust messages, or should they follow the same current-location targeting policy?
+5. How long should stale presence records and missed-decision records be retained for diagnostics?
+
+---
+
+## Verification Ledger
+
+No FB-019 verification has been run yet.

--- a/docs/plans/FB-019-progress.md
+++ b/docs/plans/FB-019-progress.md
@@ -365,6 +365,11 @@ Related GitHub issues:
 - `swift test --filter NotificationMissedDecisionPersistenceTests`
 - `swift test`
 
+### Review follow-up (2026-05-06)
+- Added DB-backed send-path boundary tests in `NotificationSendJobDeliveryBoundaryTests` that execute `NotificationSendJob.dispatchNotifications(...)` with a stub sender (no live APNs) and assert side effects at the real gate/claim boundary.
+- Verified stale candidates are blocked before ledger claim (`notification_ledger` count stays zero) while exactly one stale miss row persists in `notification_missed_decisions` across repeated evaluations.
+- Verified degraded and fresh candidates stay eligible, create ledger claims, and persist `freshness_state` as `degraded` and `fresh` respectively.
+
 ---
 
 ## Issue 6 - Add freshness observability and validation

--- a/docs/plans/FB-019-progress.md
+++ b/docs/plans/FB-019-progress.md
@@ -279,7 +279,7 @@ Related GitHub issues:
 ## Issue 4 - Select push subtitle by freshness state
 
 ### Status
-- Not started
+- Completed (2026-05-05)
 
 ### Scope
 - Centralize subtitle selection based on freshness state.
@@ -294,9 +294,31 @@ Related GitHub issues:
 - `Acceptance criteria`
 
 ### Handoff notes
-- `NotificationEngine` currently has no freshness input.
-- Avoid threading raw presence models into `NotificationEngine`; pass only derived decision state needed for copy.
-- Stale candidates should not reach push composition for delivery.
+- Threaded only derived freshness context (`LocationFreshnessState`) into notification composition.
+- `NotificationEngine.buildNotification(...)` now accepts optional `freshnessState` so copy remains centralized in `NotificationEngine` without passing raw presence models.
+- `NotificationSendJob` now forwards the already-computed freshness decision from Issue 3 when building sendable notifications.
+- Subtitle selection decision implemented for `.new` warning/watch notifications:
+  - `fresh` -> `Includes your location`
+  - `degraded` -> `For your last known area`
+  - `stale` -> `preconditionFailure` guard because stale candidates should have been filtered before composition in Issue 3.
+- Existing subtitle copy for `.update`, `.endedAllClear`, and `.cancelInError` is intentionally preserved unchanged.
+- Notification body composition remains unchanged and focused on event content.
+- Existing fallback copy for cases without freshness context (e.g., preview/no-candidate flows) is preserved.
+
+### Files changed
+- `Sources/App/Infrastructure/Notifications/NotificationEngine.swift`
+- `Sources/App/Jobs/NotificationSendJob.swift`
+- `Tests/AppTests/NotificationEngineTests.swift`
+- `docs/plans/FB-019-progress.md`
+
+### Tests run
+- `swift test --filter NotificationEngine`
+- `swift test --filter LocationFreshness`
+- `swift test`
+
+### Deferred
+- Delivered freshness-state persistence remains deferred to Issue 5.
+- Freshness observability/dashboard additions remain deferred to Issue 6 / GitHub #56.
 
 ---
 


### PR DESCRIPTION
# Summary
This branch implements FB-019 location freshness policy end-to-end in the notification send path, persists freshness decisions for both delivered and stale-suppressed candidates, adds DB-backed coverage for the delivery-side safety boundary, and hardens legacy migrations to run safely across drifted local/prod schemas.

# What Changed
- Added `LocationFreshnessPolicy` with `fresh`/`degraded`/`stale` decision states and integrated it into `NotificationSendJob` before ledger claim and send.
- Added missed-decision persistence (`notification_missed_decisions`) with idempotent uniqueness for stale suppressions and wired stale skips to persist once across retries.
- Persisted delivery freshness on `notification_ledger` via `freshness_state` and updated claim flow/tests accordingly.
- Updated notification composition to use freshness-aware subtitle copy for warning/watch notifications (`Includes your location` vs `For your last known area`).
- Added focused and DB-backed tests for freshness classification, send-path boundary behavior, ledger/missed persistence, and idempotency.
- Hardened migration scripts for mixed schema histories using idempotent Postgres DDL (`ADD COLUMN IF NOT EXISTS`, guarded constraint adds/drops, and safe create-table checks).

# User Impact
Push targeting now enforces the intended trust boundary: stale location candidates are suppressed before delivery side effects, while fresh/degraded candidates remain deliverable with accurate freshness-aware messaging. Migration reliability is improved for environments with schema drift.

# Testing
- `swift test`
- `swift run Run migrate --yes`

# Notes
- This branch includes both FB-019 feature work and migration hardening needed to safely apply the next migration on drifted databases.
- Deprecated `title` warning in `ArcusEvent.swift` remains pre-existing and unchanged.
