### PR TITLE
Add endpoint docs and source-controlled Postman workspace

### DIFF
--- a/.postman/resources.yaml
+++ b/.postman/resources.yaml
@@ -1,0 +1,12 @@
+# Use this workspace to collaborate
+workspace:
+  id: cf119fa9-628a-459d-8ffb-fe8063be69e9
+
+localResources:
+  collections:
+    - ../docs/postman/arcus-signal.postman_collection.json
+
+# Each entry here maps a local resource to one or more corresponding objects in Postman Cloud
+
+cloudResources:
+  collections: {}

--- a/Fixtures/NWSReplay/nws-series-geometry-v1.json
+++ b/Fixtures/NWSReplay/nws-series-geometry-v1.json
@@ -8,12 +8,12 @@
         "type": "Polygon",
         "coordinates": [
           [
-            [-104.95, 39.70],
-            [-104.75, 39.80],
-            [-104.60, 39.70],
-            [-104.70, 39.55],
-            [-104.90, 39.50],
-            [-104.95, 39.70]
+            [-107.95, 41.70],
+            [-107.75, 41.80],
+            [-107.60, 41.70],
+            [-107.70, 41.55],
+            [-107.90, 41.50],
+            [-107.95, 41.70]
           ]
         ]
       },
@@ -21,7 +21,7 @@
         "id": "urn:oid:2.49.0.1.840.0.replay.alert.001",
         "areaDesc": "Replay County Alpha",
         "geocode": {
-          "UGC": ["COC001", "COC031"],
+          "UGC": ["COTC001", "COTC031"],
           "SAME": ["08001", "08031"]
         },
         "sent": "2026-03-02T15:00:00Z",
@@ -35,12 +35,12 @@
         "severity": "Severe",
         "certainty": "Observed",
         "urgency": "Immediate",
-        "event": "Tornado Warning",
+        "event": "Tornado Warning - TEST",
         "sender": "w-nws.webmaster@noaa.gov",
         "senderName": "NWS Replay Office",
         "headline": "Replay Tornado Warning",
         "description": "Replay fixture initial message.",
-        "instruction": "Seek shelter immediately.",
+        "instruction": "Seek shelter immediately. - TEST",
         "response": "Shelter",
         "parameters": {
           "VTEC": ["/O.NEW.KBOU.TO.W.0001.260302T1500Z-260302T1620Z/"]
@@ -54,12 +54,12 @@
         "type": "Polygon",
         "coordinates": [
           [
-            [-104.98, 39.72],
-            [-104.72, 39.84],
-            [-104.52, 39.72],
-            [-104.66, 39.48],
-            [-104.92, 39.44],
-            [-104.98, 39.72]
+            [-106.98, 41.72],
+            [-106.72, 41.84],
+            [-106.52, 41.72],
+            [-106.66, 41.48],
+            [-106.92, 41.44],
+            [-106.98, 41.72]
           ]
         ]
       },
@@ -67,7 +67,7 @@
         "id": "urn:oid:2.49.0.1.840.0.replay.alert.002",
         "areaDesc": "Replay County Alpha, Replay County Beta",
         "geocode": {
-          "UGC": ["COC001", "COC031", "COC005"],
+          "UGC": ["COTC001", "COTC031", "COTC005"],
           "SAME": ["08001", "08031", "08005"]
         },
         "references": [
@@ -89,12 +89,12 @@
         "severity": "Severe",
         "certainty": "Observed",
         "urgency": "Immediate",
-        "event": "Tornado Warning",
+        "event": "Tornado Warning - TEST",
         "sender": "w-nws.webmaster@noaa.gov",
         "senderName": "NWS Replay Office",
         "headline": "Replay Tornado Warning (Updated Polygon)",
         "description": "Replay fixture update message with expanded polygon.",
-        "instruction": "Remain in shelter.",
+        "instruction": "Remain in shelter. - TEST",
         "response": "Shelter",
         "parameters": {
           "VTEC": ["/O.CON.KBOU.TO.W.0001.260302T1500Z-260302T1640Z/"]

--- a/README.md
+++ b/README.md
@@ -99,3 +99,7 @@ Services:
 - `postgres` on `:5432`
 
 The worker uses Vapor Queues scheduled jobs to dispatch `IngestNWSAlertsJob` every 60 seconds (`minutely().at(0)`).
+
+## Endpoint Docs
+
+Detailed endpoint behavior, validation rules, and examples are documented in [docs/api-endpoints.md](docs/api-endpoints.md).

--- a/docs/Sql/StaleVerification.sql
+++ b/docs/Sql/StaleVerification.sql
@@ -1,0 +1,101 @@
+SELECT
+  i.installation_id,
+  i.is_active,
+  i.is_subscribed,
+  i.apns_environment,
+  i.location_auth,
+  i.last_seen_at,
+  p.captured_at,
+  p.received_at,
+  p.h3_cell,
+  p.county,
+  p.zone,
+  p.fire_zone
+FROM device_installations i
+JOIN device_presence p ON p.installation_id = i.installation_id -- 88268cd713fffff
+ORDER BY i.last_seen_at DESC;
+
+
+-- Step 2 - Update the presence
+UPDATE device_presence
+SET captured_at = NOW() - INTERVAL '25 hours', 
+    county = 'COTC001',
+    zone = 'COTZ045',
+    fire_zone = 'COTFZ245',
+    h3_cell = '-1'
+WHERE installation_id = '131c8480-c74a-47c2-8cec-8d10ee6dc19f';
+
+
+-- Verify ensure targetable
+SELECT
+  i.installation_id,
+  i.is_active,
+  i.is_subscribed,
+  i.apns_device_token <> '' AS has_token,
+  i.location_auth,
+  p.captured_at,
+  NOW() - p.captured_at AS presence_age,
+  p.h3_cell,
+  p.county,
+  p.zone,
+  p.fire_zone
+FROM device_installations i
+JOIN device_presence p ON p.installation_id = i.installation_id
+WHERE i.installation_id = '131c8480-c74a-47c2-8cec-8d10ee6dc19f';
+
+
+-- Verify suppression
+SELECT
+  installation_id,
+  series_id,
+  revision_urn,
+  mode,
+  reason,
+  freshness_state,
+  miss_reason,
+  permission_mode,
+  captured_at,
+  received_at,
+  evaluated_at,
+  created
+FROM notification_missed_decisions
+WHERE installation_id = '131c8480-c74a-47c2-8cec-8d10ee6dc19f'
+ORDER BY created DESC
+LIMIT 20;
+
+
+-- no delivery ledger
+SELECT *
+FROM notification_ledger
+WHERE installation_id = '131c8480-c74a-47c2-8cec-8d10ee6dc19f'
+ORDER BY created DESC
+LIMIT 20;
+
+-- Send attempt summary
+SELECT
+  series_id,
+  revision_urn,
+  mode,
+  reason,
+  outcome,
+  no_op_reason,
+  candidate_count,
+--   stale_missed_count,
+  claimed_count,
+  sent_count,
+  failed_count,
+  attempted_at
+FROM notification_send_attempts
+WHERE no_op_reason <> 'zero_candidates'
+ORDER BY attempted_at DESC
+LIMIT 20;
+
+-- Restore
+-- UPDATE device_presence
+-- SET captured_at = NOW(), 
+--     received_at = NOW(),
+--     county = 'COC001',
+--     zone = 'COZ045',
+--     fire_zone = 'COZ245',
+--     h3_cell = '613167714648719359'
+-- WHERE installation_id = '131c8480-c74a-47c2-8cec-8d10ee6dc19f';

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -1,0 +1,213 @@
+# API Endpoint Reference
+
+This document reflects the currently registered routes in `Sources/App/apiRoutes.swift`, `Sources/App/Controllers/*`, and worker-only route wiring in `Sources/App/configure.swift`.
+
+## Runtime split
+
+- API process (`Run`, default `http://localhost:8080`): all endpoints below except worker health.
+- Worker process (`RunWorker`, default `http://localhost:8081`): `GET /health` only.
+
+## `GET /health` (API)
+
+- Runtime: API
+- Purpose: basic liveness check
+- Response: `200 OK` with empty body
+
+Example:
+
+```bash
+curl -i http://localhost:8080/health
+```
+
+## `GET /health` (Worker)
+
+- Runtime: Worker
+- Purpose: worker liveness check
+- Response: `200 OK` body `ok`
+
+Example:
+
+```bash
+curl -i http://localhost:8081/health
+```
+
+## `GET /api/v1/devices`
+
+- Runtime: API
+- Purpose: placeholder device endpoint
+- Response: `200` with custom reason phrase `fetch the devices`
+
+Example:
+
+```bash
+curl -i http://localhost:8080/api/v1/devices
+```
+
+## `POST /api/v1/devices/location-snapshots`
+
+- Runtime: API
+- Purpose: upsert device installation + latest location presence
+- Success response: `200 OK`
+
+```json
+{
+  "status": "ok",
+  "receivedAt": "2026-05-09T22:00:00Z"
+}
+```
+
+Required body schema (`application/json`):
+
+- `capturedAt` (ISO8601 date)
+- `locationAgeSeconds` (`>= 0`)
+- `horizontalAccuracyMeters` (`>= 0`)
+- `cellScheme` (`h3` or `ugc-only`)
+- `apnsDeviceToken` (non-empty)
+- `installationId` (UUID string)
+- `source` (`foreground|backgroundRefresh|significantChange|manual|unknown`)
+- `auth` (`always|whenInUse|denied|restricted|notDetermined|unknown`)
+- `appVersion` (non-empty)
+- `buildNumber` (non-empty)
+- `platform` (`iOS|watchOS`)
+- `osVersion` (non-empty)
+- `apnsEnvironment` (`prod|sandbox`)
+
+Optional:
+
+- `h3Cell` and `h3Resolution` (must be provided together)
+- `county`, `zone`, `fireZone`, `countyLabel`, `fireZoneLabel`, `isSubscribed`
+
+Validation rules:
+
+- `installationId` must be a valid UUID.
+- `h3Cell` must be `> 0` when provided.
+- `h3Resolution` must be in `0...15` when provided.
+- `capturedAt` cannot be more than 5 minutes in the future.
+- If `cellScheme = h3`, then both `h3Cell` and `h3Resolution` are required.
+
+Common errors:
+
+- `400 Bad Request` on enum mismatch, UUID parse failure, bounds issues, pair mismatch.
+
+## `GET /api/v1/alerts`
+
+- Runtime: API
+- Query params:
+  - `ugc` (optional)
+  - `fire` (optional)
+  - `h3` (optional, must be `> 0` when present)
+- At least one of `ugc`, `fire`, `h3` is required.
+- Response: `200 OK` JSON array of alert payloads.
+- Error: `400 Bad Request` when no filter is provided or `h3 <= 0`.
+
+Example:
+
+```bash
+curl -i "http://localhost:8080/api/v1/alerts?ugc=COC001"
+```
+
+## `GET /api/v2/alerts`
+
+- Runtime: API
+- Query params:
+  - `county` (optional)
+  - `forecast` (optional)
+  - `fire` (optional)
+  - `h3` (optional, must be `> 0` when present)
+- At least one of `county`, `forecast`, `fire`, `h3` is required.
+- Response: `200 OK` JSON array of alert payloads.
+- Error: `400 Bad Request` when no filter is provided or `h3 <= 0`.
+
+Example:
+
+```bash
+curl -i "http://localhost:8080/api/v2/alerts?county=COC001&forecast=COZ041"
+```
+
+## `GET /api/v1/notifications`
+
+- Runtime: API
+- Query param:
+  - `status` optional
+  - Allowed values: `all`, `claimed`, `sent`, `failed`
+- Behavior:
+  - no `status`: returns all rows
+  - `status=all`: returns all rows
+  - otherwise filters by exact status
+- Response: `200 OK` JSON array
+- Error: `400 Bad Request` for unsupported status
+
+Example:
+
+```bash
+curl -i "http://localhost:8080/api/v1/notifications?status=sent"
+```
+
+## `POST /api/v1/dev`
+
+- Runtime: API
+- Purpose: enqueue fixture replay ingest job (non-production only)
+- Request body:
+
+```json
+{
+  "fixtureName": "nws-series-geometry-v1",
+  "runLabel": "manual-replay-001"
+}
+```
+
+Behavior by environment:
+
+- `production`: returns `404 Not Found`
+- non-production: validates payload and enqueues `IngestNWSAlertsJob`
+
+Success response (non-production): `202 Accepted`
+
+```json
+{
+  "status": "accepted",
+  "source": "fixture",
+  "fixtureName": "nws-series-geometry-v1",
+  "runLabel": "manual-replay-001",
+  "queuedAt": "2026-05-09T22:00:00Z"
+}
+```
+
+Validation:
+
+- `fixtureName` is required and must be non-empty after trimming.
+
+## `GET /v1/metrics`
+
+- Runtime: API
+- Purpose: return operator dashboard snapshot JSON
+- Success: `200 OK` with `OperatorDashboardSnapshotResponse`
+- If no snapshot exists yet: `503 Service Unavailable` with reason `Operator dashboard snapshot unavailable.`
+
+Example:
+
+```bash
+curl -i http://localhost:8080/v1/metrics
+```
+
+## `GET /dashboard`
+
+- Runtime: API
+- Purpose: return operator dashboard HTML
+- Response:
+  - `200 OK` HTML when snapshot exists
+  - `503 Service Unavailable` HTML unavailable page when snapshot missing
+
+Example:
+
+```bash
+curl -i http://localhost:8080/dashboard
+```
+
+## Postman collection
+
+Use:
+
+- `docs/postman/arcus-signal.postman_collection.json`
+
+It includes happy-path and negative-path coverage for all routes above.

--- a/docs/postman/arcus-signal.postman_collection.json
+++ b/docs/postman/arcus-signal.postman_collection.json
@@ -1,0 +1,682 @@
+{
+  "info": {
+    "name": "Arcus Signal API",
+    "description": "Comprehensive endpoint coverage for Arcus Signal API and worker health routes.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "if (!pm.collectionVariables.get('installationId')) {",
+          "  pm.collectionVariables.set('installationId', pm.variables.replaceIn('{{$guid}}'));",
+          "}",
+          "pm.collectionVariables.set('capturedAtNow', new Date().toISOString());",
+          "pm.collectionVariables.set('capturedAtFuture10m', new Date(Date.now() + 10 * 60 * 1000).toISOString());"
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "apiBaseUrl",
+      "value": "http://localhost:8080"
+    },
+    {
+      "key": "workerBaseUrl",
+      "value": "http://localhost:8081"
+    },
+    {
+      "key": "installationId",
+      "value": ""
+    },
+    {
+      "key": "apnsDeviceToken",
+      "value": "test-token-1234567890abcdef"
+    },
+    {
+      "key": "validH3Cell",
+      "value": "622236750694711295"
+    },
+    {
+      "key": "validH3Resolution",
+      "value": "9"
+    },
+    {
+      "key": "sampleCounty",
+      "value": "COC001"
+    },
+    {
+      "key": "sampleForecast",
+      "value": "COZ041"
+    },
+    {
+      "key": "sampleFire",
+      "value": "COC001"
+    },
+    {
+      "key": "capturedAtNow",
+      "value": ""
+    },
+    {
+      "key": "capturedAtFuture10m",
+      "value": ""
+    }
+  ],
+  "item": [
+    {
+      "name": "Health",
+      "item": [
+        {
+          "name": "API Health GET /health",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/health"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });"
+                ]
+              }
+            }
+          ],
+          "description": "Runtime: API\n\nPurpose: Liveness check for the API process.\n\nExpected: 200 OK."
+        },
+        {
+          "name": "Worker Health GET /health",
+          "request": {
+            "method": "GET",
+            "url": "{{workerBaseUrl}}/health"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });"
+                ]
+              }
+            }
+          ],
+          "description": "Runtime: Worker\n\nPurpose: Liveness check for the worker process.\n\nExpected: 200 OK with body `ok`."
+        }
+      ]
+    },
+    {
+      "name": "Devices",
+      "item": [
+        {
+          "name": "GET /api/v1/devices",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/api/v1/devices"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('reason phrase is custom', function () { pm.expect(pm.response.reason()).to.eql('fetch the devices'); });"
+                ]
+              }
+            }
+          ],
+          "description": "Runtime: API\n\nPurpose: Placeholder device endpoint.\n\nExpected: 200 with reason phrase `fetch the devices`."
+        },
+        {
+          "name": "POST /api/v1/devices/location-snapshots (valid h3 payload)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{apiBaseUrl}}/api/v1/devices/location-snapshots",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"capturedAt\": \"{{capturedAtNow}}\",\n  \"locationAgeSeconds\": 2.5,\n  \"horizontalAccuracyMeters\": 18.2,\n  \"cellScheme\": \"h3\",\n  \"h3Cell\": {{validH3Cell}},\n  \"h3Resolution\": {{validH3Resolution}},\n  \"county\": \"{{sampleCounty}}\",\n  \"zone\": \"{{sampleForecast}}\",\n  \"fireZone\": \"{{sampleFire}}\",\n  \"apnsDeviceToken\": \"{{apnsDeviceToken}}\",\n  \"installationId\": \"{{installationId}}\",\n  \"source\": \"foreground\",\n  \"auth\": \"always\",\n  \"appVersion\": \"1.0.0\",\n  \"buildNumber\": \"100\",\n  \"platform\": \"iOS\",\n  \"osVersion\": \"26.0\",\n  \"apnsEnvironment\": \"sandbox\",\n  \"countyLabel\": \"Boulder County\",\n  \"fireZoneLabel\": \"Front Range\",\n  \"isSubscribed\": true\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.test('response status=ok', function () { pm.expect(body.status).to.eql('ok'); });",
+                  "pm.test('response includes receivedAt', function () { pm.expect(body.receivedAt).to.be.a('string'); });"
+                ]
+              }
+            }
+          ],
+          "description": "Runtime: API\n\nPurpose: Upsert device installation and latest location presence.\n\nValidation highlights: UUID `installationId`, enum values, non-empty APNS token/app/build/os fields, `locationAgeSeconds >= 0`, `horizontalAccuracyMeters >= 0`, h3 pair required together, `h3Resolution` in 0...15, and `capturedAt` <= now + 5 minutes.\n\nExpected: 200 OK with `{ status: \"ok\", receivedAt: ISO8601 }`."
+        },
+        {
+          "name": "POST /api/v1/devices/location-snapshots (invalid installationId)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{apiBaseUrl}}/api/v1/devices/location-snapshots",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"capturedAt\": \"{{capturedAtNow}}\",\n  \"locationAgeSeconds\": 2.5,\n  \"horizontalAccuracyMeters\": 18.2,\n  \"cellScheme\": \"h3\",\n  \"h3Cell\": {{validH3Cell}},\n  \"h3Resolution\": {{validH3Resolution}},\n  \"county\": \"{{sampleCounty}}\",\n  \"zone\": \"{{sampleForecast}}\",\n  \"fireZone\": \"{{sampleFire}}\",\n  \"apnsDeviceToken\": \"{{apnsDeviceToken}}\",\n  \"installationId\": \"not-a-uuid\",\n  \"source\": \"foreground\",\n  \"auth\": \"always\",\n  \"appVersion\": \"1.0.0\",\n  \"buildNumber\": \"100\",\n  \"platform\": \"iOS\",\n  \"osVersion\": \"26.0\",\n  \"apnsEnvironment\": \"sandbox\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 400', function () { pm.response.to.have.status(400); });"
+                ]
+              }
+            }
+          ],
+          "description": "Negative test. `installationId` must be a valid UUID.\n\nExpected: 400 Bad Request."
+        },
+        {
+          "name": "POST /api/v1/devices/location-snapshots (invalid enum: apnsEnvironment)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{apiBaseUrl}}/api/v1/devices/location-snapshots",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"capturedAt\": \"{{capturedAtNow}}\",\n  \"locationAgeSeconds\": 2.5,\n  \"horizontalAccuracyMeters\": 18.2,\n  \"cellScheme\": \"h3\",\n  \"h3Cell\": {{validH3Cell}},\n  \"h3Resolution\": {{validH3Resolution}},\n  \"county\": \"{{sampleCounty}}\",\n  \"zone\": \"{{sampleForecast}}\",\n  \"fireZone\": \"{{sampleFire}}\",\n  \"apnsDeviceToken\": \"{{apnsDeviceToken}}\",\n  \"installationId\": \"{{installationId}}\",\n  \"source\": \"foreground\",\n  \"auth\": \"always\",\n  \"appVersion\": \"1.0.0\",\n  \"buildNumber\": \"100\",\n  \"platform\": \"iOS\",\n  \"osVersion\": \"26.0\",\n  \"apnsEnvironment\": \"staging\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 400', function () { pm.response.to.have.status(400); });"
+                ]
+              }
+            }
+          ],
+          "description": "Negative test. `apnsEnvironment` must be `prod` or `sandbox`.\n\nExpected: 400 Bad Request."
+        },
+        {
+          "name": "POST /api/v1/devices/location-snapshots (future capturedAt rejected)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{apiBaseUrl}}/api/v1/devices/location-snapshots",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"capturedAt\": \"{{capturedAtFuture10m}}\",\n  \"locationAgeSeconds\": 2.5,\n  \"horizontalAccuracyMeters\": 18.2,\n  \"cellScheme\": \"h3\",\n  \"h3Cell\": {{validH3Cell}},\n  \"h3Resolution\": {{validH3Resolution}},\n  \"county\": \"{{sampleCounty}}\",\n  \"zone\": \"{{sampleForecast}}\",\n  \"fireZone\": \"{{sampleFire}}\",\n  \"apnsDeviceToken\": \"{{apnsDeviceToken}}\",\n  \"installationId\": \"{{installationId}}\",\n  \"source\": \"foreground\",\n  \"auth\": \"always\",\n  \"appVersion\": \"1.0.0\",\n  \"buildNumber\": \"100\",\n  \"platform\": \"iOS\",\n  \"osVersion\": \"26.0\",\n  \"apnsEnvironment\": \"sandbox\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 400', function () { pm.response.to.have.status(400); });"
+                ]
+              }
+            }
+          ],
+          "description": "Negative test. `capturedAt` cannot be more than 5 minutes in the future.\n\nExpected: 400 Bad Request."
+        },
+        {
+          "name": "POST /api/v1/devices/location-snapshots (h3 pair mismatch)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{apiBaseUrl}}/api/v1/devices/location-snapshots",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"capturedAt\": \"{{capturedAtNow}}\",\n  \"locationAgeSeconds\": 2.5,\n  \"horizontalAccuracyMeters\": 18.2,\n  \"cellScheme\": \"h3\",\n  \"h3Cell\": {{validH3Cell}},\n  \"h3Resolution\": null,\n  \"county\": \"{{sampleCounty}}\",\n  \"zone\": \"{{sampleForecast}}\",\n  \"fireZone\": \"{{sampleFire}}\",\n  \"apnsDeviceToken\": \"{{apnsDeviceToken}}\",\n  \"installationId\": \"{{installationId}}\",\n  \"source\": \"foreground\",\n  \"auth\": \"always\",\n  \"appVersion\": \"1.0.0\",\n  \"buildNumber\": \"100\",\n  \"platform\": \"iOS\",\n  \"osVersion\": \"26.0\",\n  \"apnsEnvironment\": \"sandbox\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 400', function () { pm.response.to.have.status(400); });"
+                ]
+              }
+            }
+          ],
+          "description": "Negative test. `h3Cell` and `h3Resolution` must either both be set or both be null.\n\nExpected: 400 Bad Request."
+        }
+      ]
+    },
+    {
+      "name": "Alerts",
+      "item": [
+        {
+          "name": "GET /api/v1/alerts (ugc)",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/api/v1/alerts?ugc={{sampleCounty}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('response is array', function () { pm.expect(pm.response.json()).to.be.an('array'); });"
+                ]
+              }
+            }
+          ],
+          "description": "Runtime: API\n\nQuery options: `ugc`, `fire`, `h3`. At least one is required.\n\nExpected: 200 OK with JSON array."
+        },
+        {
+          "name": "GET /api/v1/alerts (h3)",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/api/v1/alerts?h3={{validH3Cell}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });"
+                ]
+              }
+            }
+          ],
+          "description": "Runtime: API\n\nQuery options: `ugc`, `fire`, `h3`. `h3` must be > 0 when provided.\n\nExpected: 200 OK with JSON array."
+        },
+        {
+          "name": "GET /api/v1/alerts (missing required filters)",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/api/v1/alerts"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 400', function () { pm.response.to.have.status(400); });"
+                ]
+              }
+            }
+          ],
+          "description": "Negative test. At least one of `ugc`, `fire`, or `h3` is required.\n\nExpected: 400 Bad Request."
+        },
+        {
+          "name": "GET /api/v1/alerts (invalid h3)",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/api/v1/alerts?h3=0"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 400', function () { pm.response.to.have.status(400); });"
+                ]
+              }
+            }
+          ],
+          "description": "Negative test. `h3` must be > 0 when provided.\n\nExpected: 400 Bad Request."
+        },
+        {
+          "name": "GET /api/v2/alerts (county + forecast + fire)",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/api/v2/alerts?county={{sampleCounty}}&forecast={{sampleForecast}}&fire={{sampleFire}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('response is array', function () { pm.expect(pm.response.json()).to.be.an('array'); });"
+                ]
+              }
+            }
+          ],
+          "description": "Runtime: API\n\nQuery options: `county`, `forecast`, `fire`, `h3`. At least one is required.\n\nExpected: 200 OK with JSON array."
+        },
+        {
+          "name": "GET /api/v2/alerts (h3)",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/api/v2/alerts?h3={{validH3Cell}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });"
+                ]
+              }
+            }
+          ],
+          "description": "Runtime: API\n\nQuery options: `county`, `forecast`, `fire`, `h3`. `h3` must be > 0 when provided.\n\nExpected: 200 OK with JSON array."
+        },
+        {
+          "name": "GET /api/v2/alerts (missing required filters)",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/api/v2/alerts"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 400', function () { pm.response.to.have.status(400); });"
+                ]
+              }
+            }
+          ],
+          "description": "Negative test. At least one of `county`, `forecast`, `fire`, or `h3` is required.\n\nExpected: 400 Bad Request."
+        },
+        {
+          "name": "GET /api/v2/alerts (invalid h3)",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/api/v2/alerts?h3=-1"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 400', function () { pm.response.to.have.status(400); });"
+                ]
+              }
+            }
+          ],
+          "description": "Negative test. `h3` must be > 0 when provided.\n\nExpected: 400 Bad Request."
+        }
+      ]
+    },
+    {
+      "name": "Notifications",
+      "item": [
+        {
+          "name": "GET /api/v1/notifications",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/api/v1/notifications"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('response is array', function () { pm.expect(pm.response.json()).to.be.an('array'); });"
+                ]
+              }
+            }
+          ],
+          "description": "Runtime: API\n\nPurpose: List notification ledger rows.\n\nBehavior: No `status` query returns all rows.\n\nExpected: 200 OK with JSON array."
+        },
+        {
+          "name": "GET /api/v1/notifications?status=all",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/api/v1/notifications?status=all"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });"
+                ]
+              }
+            }
+          ],
+          "description": "Runtime: API\n\nBehavior: `status=all` returns all rows.\n\nExpected: 200 OK."
+        },
+        {
+          "name": "GET /api/v1/notifications?status=sent",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/api/v1/notifications?status=sent"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });"
+                ]
+              }
+            }
+          ],
+          "description": "Runtime: API\n\nAllowed status filters: `claimed`, `sent`, `failed`, `all`.\n\nExpected: 200 OK."
+        },
+        {
+          "name": "GET /api/v1/notifications?status=claimed",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/api/v1/notifications?status=claimed"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });"
+                ]
+              }
+            }
+          ],
+          "description": "Runtime: API\n\nAllowed status filters: `claimed`, `sent`, `failed`, `all`.\n\nExpected: 200 OK."
+        },
+        {
+          "name": "GET /api/v1/notifications?status=failed",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/api/v1/notifications?status=failed"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });"
+                ]
+              }
+            }
+          ],
+          "description": "Runtime: API\n\nAllowed status filters: `claimed`, `sent`, `failed`, `all`.\n\nExpected: 200 OK."
+        },
+        {
+          "name": "GET /api/v1/notifications?status=bad-value",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/api/v1/notifications?status=bad-value"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 400', function () { pm.response.to.have.status(400); });"
+                ]
+              }
+            }
+          ],
+          "description": "Negative test. Unsupported `status` filter should fail.\n\nExpected: 400 Bad Request."
+        }
+      ]
+    },
+    {
+      "name": "Dev",
+      "item": [
+        {
+          "name": "POST /api/v1/dev (fixture replay)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{apiBaseUrl}}/api/v1/dev",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"fixtureName\": \"nws-series-geometry-v1\",\n  \"runLabel\": \"postman-smoke\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 202 in non-prod, 404 in prod', function () {",
+                  "  pm.expect([202, 404]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "description": "Runtime: API\n\nPurpose: Enqueue fixture ingest replay (`IngestNWSAlertsJob`) for non-production environments.\n\nEnvironment behavior: production returns 404; non-production returns 202 with accepted payload."
+        },
+        {
+          "name": "POST /api/v1/dev (missing fixtureName)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{apiBaseUrl}}/api/v1/dev",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"fixtureName\": \"   \",\n  \"runLabel\": \"postman-negative\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 400 in non-prod, 404 in prod', function () {",
+                  "  pm.expect([400, 404]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "description": "Negative test. `fixtureName` is required after trimming.\n\nEnvironment behavior: non-production returns 400; production returns 404."
+        }
+      ]
+    },
+    {
+      "name": "Operator Dashboard",
+      "item": [
+        {
+          "name": "GET /v1/metrics",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/v1/metrics"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200 or 503', function () { pm.expect([200,503]).to.include(pm.response.code); });",
+                  "if (pm.response.code === 200) {",
+                  "  const body = pm.response.json();",
+                  "  pm.test('metrics response has renderedAt', function () { pm.expect(body.renderedAt).to.be.a('string'); });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "description": "Runtime: API\n\nPurpose: Return operator dashboard snapshot JSON.\n\nExpected: 200 when snapshot exists, 503 when unavailable."
+        },
+        {
+          "name": "GET /dashboard",
+          "request": {
+            "method": "GET",
+            "url": "{{apiBaseUrl}}/dashboard"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200 or 503', function () { pm.expect([200,503]).to.include(pm.response.code); });",
+                  "pm.test('response content-type contains text/html', function () {",
+                  "  pm.expect(pm.response.headers.get('Content-Type') || '').to.include('text/html');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "description": "Runtime: API\n\nPurpose: Return operator dashboard HTML.\n\nExpected: 200 (HTML) when snapshot exists, 503 (HTML unavailable page) when missing."
+        }
+      ]
+    }
+  ]
+}

--- a/docs/replay-ingest-runbook.md
+++ b/docs/replay-ingest-runbook.md
@@ -16,7 +16,7 @@ Use this runbook to manually exercise the NWS ingest pipeline with a known fixtu
 ## 2) Trigger replay ingest
 
 ```bash
-curl -i -X POST http://localhost:8080/api/v1/dev/replay-ingest \
+curl -i -X POST http://localhost:8080/api/v1/dev \
   -H "Content-Type: application/json" \
   -d '{
     "fixtureName": "nws-series-geometry-v1",
@@ -114,7 +114,7 @@ Expected:
 Replay same fixture again with a new run label:
 
 ```bash
-curl -i -X POST http://localhost:8080/api/v1/dev/replay-ingest \
+curl -i -X POST http://localhost:8080/api/v1/dev \
   -H "Content-Type: application/json" \
   -d '{
     "fixtureName": "nws-series-geometry-v1",

--- a/postman/collections/Arcus Signal API/.resources/definition.yaml
+++ b/postman/collections/Arcus Signal API/.resources/definition.yaml
@@ -1,0 +1,24 @@
+$kind: collection
+name: Arcus Signal API
+description: Comprehensive endpoint coverage for Arcus Signal API and worker health routes.
+variables:
+  apiBaseUrl: "http://localhost:8080"
+  workerBaseUrl: "http://localhost:8081"
+  installationId: ""
+  apnsDeviceToken: "test-token-1234567890abcdef"
+  validH3Cell: "622236750694711295"
+  validH3Resolution: "9"
+  sampleCounty: "COC001"
+  sampleForecast: "COZ041"
+  sampleFire: "COC001"
+  capturedAtNow: ""
+  capturedAtFuture10m: ""
+scripts:
+  - type: http:beforeRequest
+    code: |-
+      if (!pm.collectionVariables.get('installationId')) {
+        pm.collectionVariables.set('installationId', pm.variables.replaceIn('{{$guid}}'));
+      }
+      pm.collectionVariables.set('capturedAtNow', new Date().toISOString());
+      pm.collectionVariables.set('capturedAtFuture10m', new Date(Date.now() + 10 * 60 * 1000).toISOString());
+    language: text/javascript

--- a/postman/collections/Arcus Signal API/Alerts/.resources/definition.yaml
+++ b/postman/collections/Arcus Signal API/Alerts/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+order: 3000

--- a/postman/collections/Arcus Signal API/Alerts/GET -api-v1-alerts (h3).request.yaml
+++ b/postman/collections/Arcus Signal API/Alerts/GET -api-v1-alerts (h3).request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+name: GET /api/v1/alerts (h3)
+url: "{{apiBaseUrl}}/api/v1/alerts?h3={{validH3Cell}}"
+method: GET
+queryParams:
+  h3: "{{validH3Cell}}"
+description: |-
+  Runtime: API
+  
+  Query options: `ugc`, `fire`, `h3`. `h3` must be > 0 when provided.
+  
+  Expected: 200 OK with JSON array.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 200', function () { pm.response.to.have.status(200); });
+    language: text/javascript
+order: 2000

--- a/postman/collections/Arcus Signal API/Alerts/GET -api-v1-alerts (invalid h3).request.yaml
+++ b/postman/collections/Arcus Signal API/Alerts/GET -api-v1-alerts (invalid h3).request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+name: GET /api/v1/alerts (invalid h3)
+url: "{{apiBaseUrl}}/api/v1/alerts?h3=0"
+method: GET
+queryParams:
+  h3: "0"
+description: |-
+  Negative test. `h3` must be > 0 when provided.
+  
+  Expected: 400 Bad Request.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 400', function () { pm.response.to.have.status(400); });
+    language: text/javascript
+order: 4000

--- a/postman/collections/Arcus Signal API/Alerts/GET -api-v1-alerts (missing required filters).request.yaml
+++ b/postman/collections/Arcus Signal API/Alerts/GET -api-v1-alerts (missing required filters).request.yaml
@@ -1,0 +1,13 @@
+$kind: http-request
+name: GET /api/v1/alerts (missing required filters)
+url: "{{apiBaseUrl}}/api/v1/alerts"
+method: GET
+description: |-
+  Negative test. At least one of `ugc`, `fire`, or `h3` is required.
+  
+  Expected: 400 Bad Request.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 400', function () { pm.response.to.have.status(400); });
+    language: text/javascript
+order: 3000

--- a/postman/collections/Arcus Signal API/Alerts/GET -api-v1-alerts (ugc).request.yaml
+++ b/postman/collections/Arcus Signal API/Alerts/GET -api-v1-alerts (ugc).request.yaml
@@ -1,0 +1,19 @@
+$kind: http-request
+name: GET /api/v1/alerts (ugc)
+url: "{{apiBaseUrl}}/api/v1/alerts?ugc={{sampleCounty}}"
+method: GET
+queryParams:
+  ugc: "{{sampleCounty}}"
+description: |-
+  Runtime: API
+  
+  Query options: `ugc`, `fire`, `h3`. At least one is required.
+  
+  Expected: 200 OK with JSON array.
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', function () { pm.response.to.have.status(200); });
+      pm.test('response is array', function () { pm.expect(pm.response.json()).to.be.an('array'); });
+    language: text/javascript
+order: 1000

--- a/postman/collections/Arcus Signal API/Alerts/GET -api-v2-alerts (county + forecast + fire).request.yaml
+++ b/postman/collections/Arcus Signal API/Alerts/GET -api-v2-alerts (county + forecast + fire).request.yaml
@@ -1,0 +1,21 @@
+$kind: http-request
+name: GET /api/v2/alerts (county + forecast + fire)
+url: "{{apiBaseUrl}}/api/v2/alerts?county={{sampleCounty}}&forecast={{sampleForecast}}&fire={{sampleFire}}"
+method: GET
+queryParams:
+  county: "{{sampleCounty}}"
+  forecast: "{{sampleForecast}}"
+  fire: "{{sampleFire}}"
+description: |-
+  Runtime: API
+  
+  Query options: `county`, `forecast`, `fire`, `h3`. At least one is required.
+  
+  Expected: 200 OK with JSON array.
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', function () { pm.response.to.have.status(200); });
+      pm.test('response is array', function () { pm.expect(pm.response.json()).to.be.an('array'); });
+    language: text/javascript
+order: 5000

--- a/postman/collections/Arcus Signal API/Alerts/GET -api-v2-alerts (h3).request.yaml
+++ b/postman/collections/Arcus Signal API/Alerts/GET -api-v2-alerts (h3).request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+name: GET /api/v2/alerts (h3)
+url: "{{apiBaseUrl}}/api/v2/alerts?h3={{validH3Cell}}"
+method: GET
+queryParams:
+  h3: "{{validH3Cell}}"
+description: |-
+  Runtime: API
+  
+  Query options: `county`, `forecast`, `fire`, `h3`. `h3` must be > 0 when provided.
+  
+  Expected: 200 OK with JSON array.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 200', function () { pm.response.to.have.status(200); });
+    language: text/javascript
+order: 6000

--- a/postman/collections/Arcus Signal API/Alerts/GET -api-v2-alerts (invalid h3).request.yaml
+++ b/postman/collections/Arcus Signal API/Alerts/GET -api-v2-alerts (invalid h3).request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+name: GET /api/v2/alerts (invalid h3)
+url: "{{apiBaseUrl}}/api/v2/alerts?h3=-1"
+method: GET
+queryParams:
+  h3: "-1"
+description: |-
+  Negative test. `h3` must be > 0 when provided.
+  
+  Expected: 400 Bad Request.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 400', function () { pm.response.to.have.status(400); });
+    language: text/javascript
+order: 8000

--- a/postman/collections/Arcus Signal API/Alerts/GET -api-v2-alerts (missing required filters).request.yaml
+++ b/postman/collections/Arcus Signal API/Alerts/GET -api-v2-alerts (missing required filters).request.yaml
@@ -1,0 +1,13 @@
+$kind: http-request
+name: GET /api/v2/alerts (missing required filters)
+url: "{{apiBaseUrl}}/api/v2/alerts"
+method: GET
+description: |-
+  Negative test. At least one of `county`, `forecast`, `fire`, or `h3` is required.
+  
+  Expected: 400 Bad Request.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 400', function () { pm.response.to.have.status(400); });
+    language: text/javascript
+order: 7000

--- a/postman/collections/Arcus Signal API/Dev/.resources/definition.yaml
+++ b/postman/collections/Arcus Signal API/Dev/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+order: 5000

--- a/postman/collections/Arcus Signal API/Dev/POST -api-v1-dev (fixture replay).request.yaml
+++ b/postman/collections/Arcus Signal API/Dev/POST -api-v1-dev (fixture replay).request.yaml
@@ -1,0 +1,27 @@
+$kind: http-request
+name: POST /api/v1/dev (fixture replay)
+url: "{{apiBaseUrl}}/api/v1/dev"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: |-
+    {
+      "fixtureName": "nws-series-geometry-v1",
+      "runLabel": "postman-smoke"
+    }
+description: |-
+  Runtime: API
+  
+  Purpose: Enqueue fixture ingest replay (`IngestNWSAlertsJob`) for non-production environments.
+  
+  Environment behavior: production returns 404; non-production returns 202 with accepted payload.
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 202 in non-prod, 404 in prod', function () {
+        pm.expect([202, 404]).to.include(pm.response.code);
+      });
+    language: text/javascript
+order: 1000

--- a/postman/collections/Arcus Signal API/Dev/POST -api-v1-dev (missing fixtureName).request.yaml
+++ b/postman/collections/Arcus Signal API/Dev/POST -api-v1-dev (missing fixtureName).request.yaml
@@ -1,0 +1,25 @@
+$kind: http-request
+name: POST /api/v1/dev (missing fixtureName)
+url: "{{apiBaseUrl}}/api/v1/dev"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: |-
+    {
+      "fixtureName": "   ",
+      "runLabel": "postman-negative"
+    }
+description: |-
+  Negative test. `fixtureName` is required after trimming.
+  
+  Environment behavior: non-production returns 400; production returns 404.
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 400 in non-prod, 404 in prod', function () {
+        pm.expect([400, 404]).to.include(pm.response.code);
+      });
+    language: text/javascript
+order: 2000

--- a/postman/collections/Arcus Signal API/Devices/.resources/definition.yaml
+++ b/postman/collections/Arcus Signal API/Devices/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+order: 2000

--- a/postman/collections/Arcus Signal API/Devices/GET -api-v1-devices.request.yaml
+++ b/postman/collections/Arcus Signal API/Devices/GET -api-v1-devices.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+name: GET /api/v1/devices
+url: "{{apiBaseUrl}}/api/v1/devices"
+method: GET
+description: |-
+  Runtime: API
+  
+  Purpose: Placeholder device endpoint.
+  
+  Expected: 200 with reason phrase `fetch the devices`.
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', function () { pm.response.to.have.status(200); });
+      pm.test('reason phrase is custom', function () { pm.expect(pm.response.reason()).to.eql('fetch the devices'); });
+    language: text/javascript
+order: 1000

--- a/postman/collections/Arcus Signal API/Devices/POST -api-v1-devices-location-snapshots (future capturedAt rejected).request.yaml
+++ b/postman/collections/Arcus Signal API/Devices/POST -api-v1-devices-location-snapshots (future capturedAt rejected).request.yaml
@@ -1,0 +1,38 @@
+$kind: http-request
+name: POST /api/v1/devices/location-snapshots (future capturedAt rejected)
+url: "{{apiBaseUrl}}/api/v1/devices/location-snapshots"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: |-
+    {
+      "capturedAt": "{{capturedAtFuture10m}}",
+      "locationAgeSeconds": 2.5,
+      "horizontalAccuracyMeters": 18.2,
+      "cellScheme": "h3",
+      "h3Cell": {{validH3Cell}},
+      "h3Resolution": {{validH3Resolution}},
+      "county": "{{sampleCounty}}",
+      "zone": "{{sampleForecast}}",
+      "fireZone": "{{sampleFire}}",
+      "apnsDeviceToken": "{{apnsDeviceToken}}",
+      "installationId": "{{installationId}}",
+      "source": "foreground",
+      "auth": "always",
+      "appVersion": "1.0.0",
+      "buildNumber": "100",
+      "platform": "iOS",
+      "osVersion": "26.0",
+      "apnsEnvironment": "sandbox"
+    }
+description: |-
+  Negative test. `capturedAt` cannot be more than 5 minutes in the future.
+  
+  Expected: 400 Bad Request.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 400', function () { pm.response.to.have.status(400); });
+    language: text/javascript
+order: 5000

--- a/postman/collections/Arcus Signal API/Devices/POST -api-v1-devices-location-snapshots (h3 pair mismatch).request.yaml
+++ b/postman/collections/Arcus Signal API/Devices/POST -api-v1-devices-location-snapshots (h3 pair mismatch).request.yaml
@@ -1,0 +1,38 @@
+$kind: http-request
+name: POST /api/v1/devices/location-snapshots (h3 pair mismatch)
+url: "{{apiBaseUrl}}/api/v1/devices/location-snapshots"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: |-
+    {
+      "capturedAt": "{{capturedAtNow}}",
+      "locationAgeSeconds": 2.5,
+      "horizontalAccuracyMeters": 18.2,
+      "cellScheme": "h3",
+      "h3Cell": {{validH3Cell}},
+      "h3Resolution": null,
+      "county": "{{sampleCounty}}",
+      "zone": "{{sampleForecast}}",
+      "fireZone": "{{sampleFire}}",
+      "apnsDeviceToken": "{{apnsDeviceToken}}",
+      "installationId": "{{installationId}}",
+      "source": "foreground",
+      "auth": "always",
+      "appVersion": "1.0.0",
+      "buildNumber": "100",
+      "platform": "iOS",
+      "osVersion": "26.0",
+      "apnsEnvironment": "sandbox"
+    }
+description: |-
+  Negative test. `h3Cell` and `h3Resolution` must either both be set or both be null.
+  
+  Expected: 400 Bad Request.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 400', function () { pm.response.to.have.status(400); });
+    language: text/javascript
+order: 6000

--- a/postman/collections/Arcus Signal API/Devices/POST -api-v1-devices-location-snapshots (invalid enum apnsEnvironment).request.yaml
+++ b/postman/collections/Arcus Signal API/Devices/POST -api-v1-devices-location-snapshots (invalid enum apnsEnvironment).request.yaml
@@ -1,0 +1,38 @@
+$kind: http-request
+name: "POST /api/v1/devices/location-snapshots (invalid enum: apnsEnvironment)"
+url: "{{apiBaseUrl}}/api/v1/devices/location-snapshots"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: |-
+    {
+      "capturedAt": "{{capturedAtNow}}",
+      "locationAgeSeconds": 2.5,
+      "horizontalAccuracyMeters": 18.2,
+      "cellScheme": "h3",
+      "h3Cell": {{validH3Cell}},
+      "h3Resolution": {{validH3Resolution}},
+      "county": "{{sampleCounty}}",
+      "zone": "{{sampleForecast}}",
+      "fireZone": "{{sampleFire}}",
+      "apnsDeviceToken": "{{apnsDeviceToken}}",
+      "installationId": "{{installationId}}",
+      "source": "foreground",
+      "auth": "always",
+      "appVersion": "1.0.0",
+      "buildNumber": "100",
+      "platform": "iOS",
+      "osVersion": "26.0",
+      "apnsEnvironment": "staging"
+    }
+description: |-
+  Negative test. `apnsEnvironment` must be `prod` or `sandbox`.
+  
+  Expected: 400 Bad Request.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 400', function () { pm.response.to.have.status(400); });
+    language: text/javascript
+order: 4000

--- a/postman/collections/Arcus Signal API/Devices/POST -api-v1-devices-location-snapshots (invalid installationId).request.yaml
+++ b/postman/collections/Arcus Signal API/Devices/POST -api-v1-devices-location-snapshots (invalid installationId).request.yaml
@@ -1,0 +1,38 @@
+$kind: http-request
+name: POST /api/v1/devices/location-snapshots (invalid installationId)
+url: "{{apiBaseUrl}}/api/v1/devices/location-snapshots"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: |-
+    {
+      "capturedAt": "{{capturedAtNow}}",
+      "locationAgeSeconds": 2.5,
+      "horizontalAccuracyMeters": 18.2,
+      "cellScheme": "h3",
+      "h3Cell": {{validH3Cell}},
+      "h3Resolution": {{validH3Resolution}},
+      "county": "{{sampleCounty}}",
+      "zone": "{{sampleForecast}}",
+      "fireZone": "{{sampleFire}}",
+      "apnsDeviceToken": "{{apnsDeviceToken}}",
+      "installationId": "not-a-uuid",
+      "source": "foreground",
+      "auth": "always",
+      "appVersion": "1.0.0",
+      "buildNumber": "100",
+      "platform": "iOS",
+      "osVersion": "26.0",
+      "apnsEnvironment": "sandbox"
+    }
+description: |-
+  Negative test. `installationId` must be a valid UUID.
+  
+  Expected: 400 Bad Request.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 400', function () { pm.response.to.have.status(400); });
+    language: text/javascript
+order: 3000

--- a/postman/collections/Arcus Signal API/Devices/POST -api-v1-devices-location-snapshots (valid h3 payload).request.yaml
+++ b/postman/collections/Arcus Signal API/Devices/POST -api-v1-devices-location-snapshots (valid h3 payload).request.yaml
@@ -1,0 +1,49 @@
+$kind: http-request
+name: POST /api/v1/devices/location-snapshots (valid h3 payload)
+url: "{{apiBaseUrl}}/api/v1/devices/location-snapshots"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: |-
+    {
+      "capturedAt": "{{capturedAtNow}}",
+      "locationAgeSeconds": 2.5,
+      "horizontalAccuracyMeters": 18.2,
+      "cellScheme": "h3",
+      "h3Cell": {{validH3Cell}},
+      "h3Resolution": {{validH3Resolution}},
+      "county": "{{sampleCounty}}",
+      "zone": "{{sampleForecast}}",
+      "fireZone": "{{sampleFire}}",
+      "apnsDeviceToken": "{{apnsDeviceToken}}",
+      "installationId": "{{installationId}}",
+      "source": "foreground",
+      "auth": "always",
+      "appVersion": "1.0.0",
+      "buildNumber": "100",
+      "platform": "iOS",
+      "osVersion": "26.0",
+      "apnsEnvironment": "sandbox",
+      "countyLabel": "Boulder County",
+      "fireZoneLabel": "Front Range",
+      "isSubscribed": true
+    }
+description: |-
+  Runtime: API
+  
+  Purpose: Upsert device installation and latest location presence.
+  
+  Validation highlights: UUID `installationId`, enum values, non-empty APNS token/app/build/os fields, `locationAgeSeconds >= 0`, `horizontalAccuracyMeters >= 0`, h3 pair required together, `h3Resolution` in 0...15, and `capturedAt` <= now + 5 minutes.
+  
+  Expected: 200 OK with `{ status: "ok", receivedAt: ISO8601 }`.
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', function () { pm.response.to.have.status(200); });
+      const body = pm.response.json();
+      pm.test('response status=ok', function () { pm.expect(body.status).to.eql('ok'); });
+      pm.test('response includes receivedAt', function () { pm.expect(body.receivedAt).to.be.a('string'); });
+    language: text/javascript
+order: 2000

--- a/postman/collections/Arcus Signal API/Health/.resources/definition.yaml
+++ b/postman/collections/Arcus Signal API/Health/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+order: 1000

--- a/postman/collections/Arcus Signal API/Health/API Health GET -health.request.yaml
+++ b/postman/collections/Arcus Signal API/Health/API Health GET -health.request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+name: API Health GET /health
+url: "{{apiBaseUrl}}/health"
+method: GET
+description: |-
+  Runtime: API
+  
+  Purpose: Liveness check for the API process.
+  
+  Expected: 200 OK.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 200', function () { pm.response.to.have.status(200); });
+    language: text/javascript
+order: 1000

--- a/postman/collections/Arcus Signal API/Health/Worker Health GET -health.request.yaml
+++ b/postman/collections/Arcus Signal API/Health/Worker Health GET -health.request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+name: Worker Health GET /health
+url: "{{workerBaseUrl}}/health"
+method: GET
+description: |-
+  Runtime: Worker
+  
+  Purpose: Liveness check for the worker process.
+  
+  Expected: 200 OK with body `ok`.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 200', function () { pm.response.to.have.status(200); });
+    language: text/javascript
+order: 2000

--- a/postman/collections/Arcus Signal API/Notifications/.resources/definition.yaml
+++ b/postman/collections/Arcus Signal API/Notifications/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+order: 4000

--- a/postman/collections/Arcus Signal API/Notifications/GET -api-v1-notifications.request.yaml
+++ b/postman/collections/Arcus Signal API/Notifications/GET -api-v1-notifications.request.yaml
@@ -1,0 +1,19 @@
+$kind: http-request
+name: GET /api/v1/notifications
+url: "{{apiBaseUrl}}/api/v1/notifications"
+method: GET
+description: |-
+  Runtime: API
+  
+  Purpose: List notification ledger rows.
+  
+  Behavior: No `status` query returns all rows.
+  
+  Expected: 200 OK with JSON array.
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', function () { pm.response.to.have.status(200); });
+      pm.test('response is array', function () { pm.expect(pm.response.json()).to.be.an('array'); });
+    language: text/javascript
+order: 1000

--- a/postman/collections/Arcus Signal API/Notifications/GET -api-v1-notificationsstatus=all.request.yaml
+++ b/postman/collections/Arcus Signal API/Notifications/GET -api-v1-notificationsstatus=all.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+name: GET /api/v1/notifications?status=all
+url: "{{apiBaseUrl}}/api/v1/notifications?status=all"
+method: GET
+queryParams:
+  status: "all"
+description: |-
+  Runtime: API
+  
+  Behavior: `status=all` returns all rows.
+  
+  Expected: 200 OK.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 200', function () { pm.response.to.have.status(200); });
+    language: text/javascript
+order: 2000

--- a/postman/collections/Arcus Signal API/Notifications/GET -api-v1-notificationsstatus=bad-value.request.yaml
+++ b/postman/collections/Arcus Signal API/Notifications/GET -api-v1-notificationsstatus=bad-value.request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+name: GET /api/v1/notifications?status=bad-value
+url: "{{apiBaseUrl}}/api/v1/notifications?status=bad-value"
+method: GET
+queryParams:
+  status: "bad-value"
+description: |-
+  Negative test. Unsupported `status` filter should fail.
+  
+  Expected: 400 Bad Request.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 400', function () { pm.response.to.have.status(400); });
+    language: text/javascript
+order: 6000

--- a/postman/collections/Arcus Signal API/Notifications/GET -api-v1-notificationsstatus=claimed.request.yaml
+++ b/postman/collections/Arcus Signal API/Notifications/GET -api-v1-notificationsstatus=claimed.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+name: GET /api/v1/notifications?status=claimed
+url: "{{apiBaseUrl}}/api/v1/notifications?status=claimed"
+method: GET
+queryParams:
+  status: "claimed"
+description: |-
+  Runtime: API
+  
+  Allowed status filters: `claimed`, `sent`, `failed`, `all`.
+  
+  Expected: 200 OK.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 200', function () { pm.response.to.have.status(200); });
+    language: text/javascript
+order: 4000

--- a/postman/collections/Arcus Signal API/Notifications/GET -api-v1-notificationsstatus=failed.request.yaml
+++ b/postman/collections/Arcus Signal API/Notifications/GET -api-v1-notificationsstatus=failed.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+name: GET /api/v1/notifications?status=failed
+url: "{{apiBaseUrl}}/api/v1/notifications?status=failed"
+method: GET
+queryParams:
+  status: "failed"
+description: |-
+  Runtime: API
+  
+  Allowed status filters: `claimed`, `sent`, `failed`, `all`.
+  
+  Expected: 200 OK.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 200', function () { pm.response.to.have.status(200); });
+    language: text/javascript
+order: 5000

--- a/postman/collections/Arcus Signal API/Notifications/GET -api-v1-notificationsstatus=sent.request.yaml
+++ b/postman/collections/Arcus Signal API/Notifications/GET -api-v1-notificationsstatus=sent.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+name: GET /api/v1/notifications?status=sent
+url: "{{apiBaseUrl}}/api/v1/notifications?status=sent"
+method: GET
+queryParams:
+  status: "sent"
+description: |-
+  Runtime: API
+  
+  Allowed status filters: `claimed`, `sent`, `failed`, `all`.
+  
+  Expected: 200 OK.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 200', function () { pm.response.to.have.status(200); });
+    language: text/javascript
+order: 3000

--- a/postman/collections/Arcus Signal API/Operator Dashboard/.resources/definition.yaml
+++ b/postman/collections/Arcus Signal API/Operator Dashboard/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+order: 6000

--- a/postman/collections/Arcus Signal API/Operator Dashboard/GET -dashboard.request.yaml
+++ b/postman/collections/Arcus Signal API/Operator Dashboard/GET -dashboard.request.yaml
@@ -1,0 +1,19 @@
+$kind: http-request
+name: GET /dashboard
+url: "{{apiBaseUrl}}/dashboard"
+method: GET
+description: |-
+  Runtime: API
+  
+  Purpose: Return operator dashboard HTML.
+  
+  Expected: 200 (HTML) when snapshot exists, 503 (HTML unavailable page) when missing.
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200 or 503', function () { pm.expect([200,503]).to.include(pm.response.code); });
+      pm.test('response content-type contains text/html', function () {
+        pm.expect(pm.response.headers.get('Content-Type') || '').to.include('text/html');
+      });
+    language: text/javascript
+order: 2000

--- a/postman/collections/Arcus Signal API/Operator Dashboard/GET -v1-metrics.request.yaml
+++ b/postman/collections/Arcus Signal API/Operator Dashboard/GET -v1-metrics.request.yaml
@@ -1,0 +1,20 @@
+$kind: http-request
+name: GET /v1/metrics
+url: "{{apiBaseUrl}}/v1/metrics"
+method: GET
+description: |-
+  Runtime: API
+  
+  Purpose: Return operator dashboard snapshot JSON.
+  
+  Expected: 200 when snapshot exists, 503 when unavailable.
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200 or 503', function () { pm.expect([200,503]).to.include(pm.response.code); });
+      if (pm.response.code === 200) {
+        const body = pm.response.json();
+        pm.test('metrics response has renderedAt', function () { pm.expect(body.renderedAt).to.be.a('string'); });
+      }
+    language: text/javascript
+order: 1000

--- a/postman/environments/Local.environment.yaml
+++ b/postman/environments/Local.environment.yaml
@@ -1,0 +1,6 @@
+name: Local
+values:
+  - key: apiBaseUrl
+    value: ''
+  - key: workerBaseUrl
+    value: ''

--- a/postman/environments/Prod.environment.yaml
+++ b/postman/environments/Prod.environment.yaml
@@ -1,0 +1,6 @@
+name: Prod
+values:
+  - key: apiBaseUrl
+    value: ''
+  - key: workerBaseUrl
+    value: ''

--- a/postman/globals/workspace.globals.yaml
+++ b/postman/globals/workspace.globals.yaml
@@ -1,0 +1,2 @@
+name: Globals
+values: []


### PR DESCRIPTION
# Summary
This branch adds a repository-native Postman workspace/collection for Arcus Signal endpoints, updates endpoint documentation to match current route behavior, and includes stale-verification support artifacts used for operational verification.

# What Changed
- Added endpoint reference documentation at `docs/api-endpoints.md` covering route behavior, validation, and environment-specific outcomes.
- Added and documented the Arcus Signal Postman collection in both JSON export form and split YAML workspace form under `postman/`.
- Added per-request documentation and tests in the Postman collection for health, devices, alerts, notifications, dev replay, and operator dashboard endpoints.
- Updated `README.md` to link to the endpoint docs and corrected replay runbook dev endpoint paths in `docs/replay-ingest-runbook.md`.
- Added stale verification SQL helper at `docs/Sql/StaleVerification.sql` and related fixture update for replay validation.

# User Impact
Developers and operators now have a source-controlled, reviewable API test workspace with endpoint-level documentation and validation scenarios, reducing ambiguity when exercising or verifying backend behavior. No production runtime behavior was changed by these documentation/Postman updates.

# Testing
- Verified Postman YAML files parse successfully via Ruby YAML parser (`bad_count 0`).
- Reviewed endpoint behavior and validation rules against controller/job code paths while authoring docs and request coverage.
- No Swift unit/integration test suite was run in this PR flow.

# Notes
- Branch includes both `docs/postman/arcus-signal.postman_collection.json` and split Postman workspace files under `postman/`.
- Endpoint replay docs now reference `POST /api/v1/dev` (current route) rather than the prior runbook path.
