### PR TITLE
Add hot alert payload support and targeted /api/v2/alerts lookup by series ID

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/justinrooks/ArcusCore.git",
       "state" : {
-        "revision" : "99d4f0ccc31ad94656232653fc5e9ee6c688abfc",
-        "version" : "0.2.0"
+        "revision" : "18f78615f7777081cb8b9afdd24fcba45f9d9896",
+        "version" : "0.3.0"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
-        "version" : "1.1.3"
+        "revision" : "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
+        "version" : "1.1.4"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
-        "version" : "1.5.0"
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
       }
     },
     {
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
-        "version" : "1.12.0"
+        "revision" : "a012e0ad8a8a72de92b0e008c81a9b793f70e73a",
+        "version" : "1.12.1"
       }
     },
     {
@@ -276,8 +276,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "d51c8d13fa366eec807eedb4e37daa60ff5bfdd5",
-        "version" : "2.10.1"
+        "revision" : "087e8074afa97040c3b870c8664fe5482fb87cc4",
+        "version" : "2.11.0"
       }
     },
     {
@@ -285,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
-        "version" : "2.99.0"
+        "revision" : "57c0a08a331aaea9f5d7a932ad94ef43be942a95",
+        "version" : "2.100.0"
       }
     },
     {
@@ -294,8 +294,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
-        "version" : "1.34.0"
+        "revision" : "d2eeec0339074034f11a040a74aa2a341a2c4506",
+        "version" : "1.34.1"
       }
     },
     {
@@ -303,8 +303,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
-        "version" : "1.43.0"
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/justinrooks/ArcusCore.git",
       "state" : {
-        "revision" : "18f78615f7777081cb8b9afdd24fcba45f9d9896",
-        "version" : "0.3.0"
+        "revision" : "618bf3d5a28b1ffd2fbda9fc181d7a431a096105",
+        "version" : "0.3.1"
       }
     },
     {

--- a/Sources/App/Clients/APNsClient.swift
+++ b/Sources/App/Clients/APNsClient.swift
@@ -10,6 +10,7 @@ import APNS
 import VaporAPNS
 import APNSCore
 import Vapor
+import ArcusCore
 
 // Custom Codable Payload
 struct MyPayload: Codable {
@@ -27,6 +28,7 @@ protocol NotificationSender: Sendable {
     func sendNotification(
         app: Application,
         with details: AlertDetails,
+        hotAlertPayload: HotAlertAPNsPayload,
         to device: String,
         environment: APNsEnvironment
     ) async throws
@@ -36,6 +38,7 @@ struct APNsClient: NotificationSender {
     func sendNotification(
         app: Application,
         with details: AlertDetails,
+        hotAlertPayload: HotAlertAPNsPayload,
         to device: String,
         environment: APNsEnvironment
     ) async throws {
@@ -62,7 +65,7 @@ struct APNsClient: NotificationSender {
             expiration: .immediately,
             priority: .immediately,
             topic: topic,
-            payload: EmptyPayload(),
+            payload: hotAlertPayload,
             badge: 0
         )
         

--- a/Sources/App/Controllers/AlertsController.swift
+++ b/Sources/App/Controllers/AlertsController.swift
@@ -17,10 +17,17 @@ private struct AlertLookupQueryV1: Content {
 }
 
 private struct AlertLookupQueryV2: Content {
+    let id: String?
+    let sent: String?
     let county: String?
     let forecast: String?
     let fire: String?
     let h3: Int64?
+}
+
+private enum AlertLookupModeV2 {
+    case targeted(id: UUID, sent: String?)
+    case collection(ugcCodes: [String], h3: Int64?)
 }
 
 struct AlertsController: RouteCollection {
@@ -79,6 +86,34 @@ private func loadAlertSeriesV2(
         throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
     }
 
+    switch try parseLookupModeV2(query) {
+    case .targeted(let id, let sent):
+        return try await loadAlertSeries(sql: sql, id: id, sent: sent)
+    case .collection(let ugcCodes, let h3):
+        return try await loadAlertSeries(sql: sql, ugcCodes: ugcCodes, h3: h3)
+    }
+}
+
+private func hasLocationFilters(_ query: AlertLookupQueryV2) -> Bool {
+    normalizedOptional(query.county) != nil ||
+    normalizedOptional(query.forecast) != nil ||
+    normalizedOptional(query.fire) != nil ||
+    query.h3 != nil
+}
+
+private func parseLookupModeV2(_ query: AlertLookupQueryV2) throws -> AlertLookupModeV2 {
+    if let id = normalizedOptional(query.id) {
+        if hasLocationFilters(query) {
+            throw Abort(.badRequest, reason: "id cannot be combined with county, forecast, fire, or h3")
+        }
+
+        guard let seriesID = UUID(uuidString: id) else {
+            throw Abort(.badRequest, reason: "id must be a valid UUID")
+        }
+
+        return .targeted(id: seriesID, sent: query.sent)
+    }
+
     if let h3 = query.h3, h3 <= 0 {
         throw Abort(.badRequest, reason: "h3 must be > 0 when provided")
     }
@@ -89,7 +124,7 @@ private func loadAlertSeriesV2(
         throw Abort(.badRequest, reason: "At least one of county, forecast, fire, or h3 is required")
     }
 
-    return try await loadAlertSeries(sql: sql, ugcCodes: ugcCodes, h3: query.h3)
+    return .collection(ugcCodes: ugcCodes, h3: query.h3)
 }
 
 private func loadAlertSeries(
@@ -126,6 +161,27 @@ private func loadAlertSeries(
                  \(ident: "s").\(ident: "id") ASC
         """)
         .all(decoding: AlertSeriesRow.self)
+}
+
+private func loadAlertSeries(
+    sql: any SQLDatabase,
+    id: UUID,
+    sent _: String?
+) async throws -> [AlertSeriesRow] {
+    guard let row = try await sql.raw("""
+        SELECT \(AlertSeriesRow.sqlSelectColumns())
+        FROM \(ident: ArcusSeriesModel.schema) AS \(ident: "s")
+        LEFT JOIN \(ident: ArcusGeolocationModel.schema) AS \(ident: "g")
+          ON \(ident: "g").\(ident: "series_id") = \(ident: "s").\(ident: "id")
+        WHERE \(ident: "s").\(ident: "id") = \(bind: id)
+          AND \(ident: "s").\(ident: "state") <> \(bind: EventState.cancelled_in_error.rawValue)
+        LIMIT 1
+        """)
+        .first(decoding: AlertSeriesRow.self) else {
+        throw Abort(.notFound)
+    }
+
+    return [row]
 }
 
 private func uniqueUGCCodes(_ values: [String?]) -> [String] {

--- a/Sources/App/Jobs/NotificationSendJob.swift
+++ b/Sources/App/Jobs/NotificationSendJob.swift
@@ -497,6 +497,11 @@ extension NotificationSendJob {
                 try await sender.sendNotification(
                     app: context.application,
                     with: alert,
+                    hotAlertPayload: .init(
+                        alertID: payload.seriesId.uuidString,
+                        seriesId: payload.seriesId.uuidString,
+                        revisionSent: series.currentRevisionSent
+                    ),
                     to: candidate.apnsToken,
                     environment: apnsEnvironment
                 )

--- a/Sources/App/Jobs/NotificationSendJob.swift
+++ b/Sources/App/Jobs/NotificationSendJob.swift
@@ -11,6 +11,7 @@ import FluentSQL
 import Foundation
 import Queues
 import Vapor
+import ArcusCore
 
 struct NotificationCandidate: Decodable {
     let id: UUID
@@ -498,8 +499,7 @@ extension NotificationSendJob {
                     app: context.application,
                     with: alert,
                     hotAlertPayload: .init(
-                        alertID: payload.seriesId.uuidString,
-                        seriesId: payload.seriesId.uuidString,
+                        arcusAlertId: payload.seriesId.uuidString,
                         revisionSent: series.currentRevisionSent
                     ),
                     to: candidate.apnsToken,

--- a/Tests/AppTests/AlertsControllerTests.swift
+++ b/Tests/AppTests/AlertsControllerTests.swift
@@ -1,0 +1,154 @@
+@testable import App
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+import ArcusCore
+
+@Suite("Alerts controller", .serialized)
+struct AlertsControllerTests {
+    private struct DecodedAlertPayload: Decodable {
+        let id: UUID
+        let event: String
+        let currentRevisionUrn: String
+        let ugc: [String]
+        let h3Cells: [Int64]
+    }
+
+    private func withApp(
+        test: (Application) async throws -> Void
+    ) async throws {
+        let app = try await Application.make(.testing)
+        do {
+            try await configure(app, mode: .api)
+            try await test(app)
+        } catch {
+            try? await app.asyncShutdown()
+            throw error
+        }
+        try await app.asyncShutdown()
+    }
+
+    private func isoDate(_ value: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        guard let date = formatter.date(from: value) else {
+            fatalError("Invalid ISO8601 date in test fixture: \(value)")
+        }
+        return date
+    }
+
+    private func seedSeries(
+        id: UUID,
+        on app: Application
+    ) async throws {
+        let now = isoDate("2026-05-21T18:00:00Z")
+        let series = ArcusSeriesModel(
+            id: id,
+            source: EventSource.nws.rawValue,
+            event: "Tornado Warning",
+            sourceURL: "https://api.weather.gov/alerts/\(id.uuidString)",
+            currentRevisionUrn: "urn:oid:\(id.uuidString)",
+            currentRevisionSent: now,
+            messageType: NWSAlertMessageType.alert.rawValue,
+            contentFingerprint: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            state: EventState.active.rawValue,
+            created: now,
+            updated: now,
+            sent: now,
+            effective: now,
+            onset: nil,
+            expires: nil,
+            ends: nil,
+            lastSeenActive: now,
+            severity: EventSeverity.severe.rawValue,
+            urgency: EventUrgency.immediate.rawValue,
+            certainty: EventCertainty.observed.rawValue,
+            ugcCodes: ["COC031"],
+            areaDesc: "Denver County",
+            senderName: "NWS Boulder CO",
+            headline: "Tornado Warning issued",
+            description: "Storm text",
+            instructions: "Take shelter now",
+            response: "Shelter"
+        )
+        try await series.save(on: app.db)
+
+        let geolocation = ArcusGeolocationModel(
+            series: id,
+            geometry: .point(lon: -104.9903, lat: 39.7392),
+            geometryHash: "geom-hash",
+            h3Cells: [617700169958293503],
+            h3Resolution: 8,
+            h3Hash: "h3-hash"
+        )
+        try await geolocation.save(on: app.db)
+    }
+
+    @Test("GET /api/v2/alerts supports targeted series UUID lookup")
+    func targetedLookupBySeriesUUID() async throws {
+        try await withApp { app in
+            let seriesID = UUID()
+            try await seedSeries(id: seriesID, on: app)
+
+            try await app.testing().test(.GET, "api/v2/alerts?id=\(seriesID.uuidString)", afterResponse: { res async throws in
+                #expect(res.status == .ok)
+
+                let payload = try res.content.decode([DecodedAlertPayload].self)
+                #expect(payload.count == 1)
+                #expect(payload.first?.id == seriesID)
+                #expect(payload.first?.event == "Tornado Warning")
+                #expect(payload.first?.ugc == ["COC031"])
+                #expect(payload.first?.h3Cells == [617700169958293503])
+            })
+        }
+    }
+
+    @Test("GET /api/v2/alerts rejects malformed targeted UUID")
+    func targetedLookupRejectsMalformedUUID() async throws {
+        try await withApp { app in
+            try await app.testing().test(.GET, "api/v2/alerts?id=not-a-uuid", afterResponse: { res async in
+                #expect(res.status == .badRequest)
+            })
+        }
+    }
+
+    @Test("GET /api/v2/alerts returns 404 for missing targeted series UUID")
+    func targetedLookupReturnsNotFoundForMissingSeries() async throws {
+        try await withApp { app in
+            try await app.testing().test(.GET, "api/v2/alerts?id=\(UUID().uuidString)", afterResponse: { res async in
+                #expect(res.status == .notFound)
+            })
+        }
+    }
+
+    @Test("GET /api/v2/alerts rejects mixed targeted and location filters")
+    func targetedLookupRejectsMixedFilters() async throws {
+        try await withApp { app in
+            try await app.testing().test(.GET, "api/v2/alerts?id=\(UUID().uuidString)&county=COC031", afterResponse: { res async in
+                #expect(res.status == .badRequest)
+            })
+        }
+    }
+
+    @Test("GET /api/v2/alerts targeted response uses existing device alert payload contract")
+    func targetedLookupResponseUsesDeviceAlertPayloadContract() async throws {
+        try await withApp { app in
+            let seriesID = UUID()
+            try await seedSeries(id: seriesID, on: app)
+
+            try await app.testing().test(
+                .GET,
+                "api/v2/alerts?id=\(seriesID.uuidString)&sent=2026-05-21T18:00:00Z",
+                afterResponse: { res async throws in
+                    #expect(res.status == .ok)
+                    #expect(res.headers.contentType == .json)
+
+                    let payload = try res.content.decode([DecodedAlertPayload].self)
+                    #expect(payload.count == 1)
+                    #expect(payload[0].id == seriesID)
+                    #expect(payload[0].currentRevisionUrn == "urn:oid:\(seriesID.uuidString)")
+                }
+            )
+        }
+    }
+}

--- a/Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift
+++ b/Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift
@@ -1,5 +1,4 @@
 @testable import App
-import ArcusCore
 import Fluent
 import FluentPostgresDriver
 import FluentSQL
@@ -7,6 +6,7 @@ import Foundation
 import Queues
 import Testing
 import Vapor
+import ArcusCore
 
 @Suite("Notification send job delivery boundary", .serialized)
 struct NotificationSendJobDeliveryBoundaryTests {

--- a/Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift
+++ b/Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift
@@ -1,4 +1,5 @@
 @testable import App
+import ArcusCore
 import Fluent
 import FluentPostgresDriver
 import FluentSQL
@@ -363,6 +364,7 @@ private actor RecordingNotificationSender: NotificationSender {
     func sendNotification(
         app _: Application,
         with _: AlertDetails,
+        hotAlertPayload _: HotAlertAPNsPayload,
         to _: String,
         environment _: APNsEnvironment
     ) async throws {

--- a/Tests/AppTests/OperatorDashboardTests.swift
+++ b/Tests/AppTests/OperatorDashboardTests.swift
@@ -353,7 +353,7 @@ struct OperatorDashboardTests {
                 #expect(res.body.string.contains("CONSIDERABLE"))
                 #expect(res.body.string.contains("urn:oid:series-1"))
                 #expect(res.body.string.contains("fetch('/v1/metrics'"))
-                #expect(res.body.string.contains("window.setInterval(fetchSnapshot, pollIntervalMs)"))
+                #expect(res.body.string.contains("window.setTimeout(fetchSnapshot, nextDelay)"))
                 #expect(res.body.string.contains("The page polls the canonical"))
                 #expect(res.body.string.contains("hero-rendered-at"))
                 #expect(res.body.string.contains("http-equiv=\"refresh\"") == false)

--- a/docs/Sql/Device.sql
+++ b/docs/Sql/Device.sql
@@ -7,7 +7,7 @@ SELECT * FROM device_presence;
 SELECT d.location_auth, d.app_version,p.*
 FROM device_presence p
 LEFT JOIN device_installations d ON d.installation_id = p.installation_id
-WHERE d.apns_environment = 'prod'
+WHERE d.apns_environment = 'prod' AND p.county NOT LIKE 'CA%'
 ORDER BY p.updated_at DESC
 
 

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -110,18 +110,33 @@ curl -i "http://localhost:8080/api/v1/alerts?ugc=COC001"
 
 - Runtime: API
 - Query params:
+  - `id` (optional, Arcus series UUID; maps to `arcus_series.id` / APNs hot-alert `arcusAlertId`)
+  - `sent` (optional; currently ignored for lookup behavior)
   - `county` (optional)
   - `forecast` (optional)
   - `fire` (optional)
   - `h3` (optional, must be `> 0` when present)
-- At least one of `county`, `forecast`, `fire`, `h3` is required.
+- Lookup modes:
+  - Targeted lookup: provide `id` only (plus optional `sent`) to fetch exactly one current alert by `arcus_series.id`.
+  - Collection lookup: provide one or more of `county`, `forecast`, `fire`, `h3`.
+  - `id` is mutually exclusive with `county`, `forecast`, `fire`, `h3`.
 - Response: `200 OK` JSON array of alert payloads.
-- Error: `400 Bad Request` when no filter is provided or `h3 <= 0`.
+- Error:
+  - `400 Bad Request` when no valid filter is provided.
+  - `400 Bad Request` when `h3 <= 0`.
+  - `400 Bad Request` when `id` is malformed or combined with location filters.
+  - `404 Not Found` when targeted `id` does not match an existing series.
 
 Example:
 
 ```bash
 curl -i "http://localhost:8080/api/v2/alerts?county=COC001&forecast=COZ041"
+```
+
+Targeted example:
+
+```bash
+curl -i "http://localhost:8080/api/v2/alerts?id=11111111-1111-1111-1111-111111111111"
 ```
 
 ## `GET /api/v1/notifications`

--- a/docs/audits/weekly-bug-scan.md
+++ b/docs/audits/weekly-bug-scan.md
@@ -1,0 +1,59 @@
+# Weekly Bug Scan
+
+## 2026-05-21
+
+### 1. Repos scanned
+- `arcus-signal`
+- `project-arcus`
+
+### 2. Commit window inspected
+- Last automation run marker: `2026-05-14T16:06:33.583Z`
+- Window used: commits after `2026-05-14T16:06:33Z`
+- `arcus-signal` commits inspected:
+  - `091c45c898343894e06e9c05d0fd976644115e56` (APNs HotAlert payload change)
+  - `191dd6b59482461154c540446658c6249914c2a0` (operator dashboard rendering changes)
+- `project-arcus` commits inspected:
+  - `b5d15fea95d29b430d4304edda3c53ca6c1eab62` (alert architecture streamlining)
+  - Other commits in window were release/docs/project metadata updates only.
+
+### 3. Highest-risk changed areas
+- Notification delivery payload contract (`arcus-signal` APNs payload generation)
+- Remote alert ingestion/update lifecycle (`project-arcus` remote push handling + targeted alert sync)
+- Shared API contract between backend APNs payload and iOS decoder (`HotAlertAPNsPayload` / `APNsHotAlertPayloadContract`)
+
+### 4. Findings table
+
+| Bug | Repo | Evidence | Impact | Confidence | Minimal fix | Validation |
+|---|---|---|---|---|---|---|
+| APNs hot-alert payload sends series UUID as `alertID`, causing targeted remote refresh to query wrong identifier | `arcus-signal` + `project-arcus` | `arcus-signal` `091c45c` sets `hotAlertPayload.alertID` to `payload.seriesId.uuidString` and `seriesId` same value in [`/Users/justin/Code/arcus-signal/Sources/App/Jobs/NotificationSendJob.swift`](/Users/justin/Code/arcus-signal/Sources/App/Jobs/NotificationSendJob.swift:500). iOS resolves `alertID ?? seriesId` and uses it for targeted refresh in [`/Users/justin/Code/project-arcus/Sources/App/RemoteHotAlertHandler.swift`](/Users/justin/Code/project-arcus/Sources/App/RemoteHotAlertHandler.swift:147) and fetch call in [`/Users/justin/Code/project-arcus/Sources/Clients/ArcusClient.swift`](/Users/justin/Code/project-arcus/Sources/Clients/ArcusClient.swift:54). App-side matcher expects canonical alert id semantics in [`/Users/justin/Code/project-arcus/Sources/App/RemoteHotAlertHandler.swift`](/Users/justin/Code/project-arcus/Sources/App/RemoteHotAlertHandler.swift:267). | Missed or failed remote hot-alert updates and deep-link context after push. Background fetch can return `.failed`, reducing reliability of severe-weather alert freshness. | High | Populate APNs `alertID` with the canonical Arcus alert id (NWS/canonical id), not internal series UUID. Keep `seriesId` optional/backward-compatible for transition, but prioritize `alertID` correctness. | Unit: add assertion in `NotificationSendJob` tests that emitted payload `alertID` equals canonical alert identifier. Integration: push -> app receipt -> targeted refresh returns `.newData` for real alert id and not `.failed`. Manual: send test push and confirm alert detail opens with latest revision. Log/metric: track remote ingestion `.failed` rate keyed by source payload id kind. |
+
+### 5. Top recommended fix
+- Highest-priority bug: APNs payload identifier mismatch (`alertID` incorrectly uses series UUID).
+- Why it matters: it directly affects push-to-refresh correctness during active severe weather and can suppress timely user-visible updates.
+- Expected files touched:
+  - [`/Users/justin/Code/arcus-signal/Sources/App/Jobs/NotificationSendJob.swift`](/Users/justin/Code/arcus-signal/Sources/App/Jobs/NotificationSendJob.swift)
+  - [`/Users/justin/Code/arcus-signal/Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift`](/Users/justin/Code/arcus-signal/Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift)
+  - Optional contract guard in [`/Users/justin/Code/project-arcus/Sources/App/RemoteHotAlertHandler.swift`](/Users/justin/Code/project-arcus/Sources/App/RemoteHotAlertHandler.swift)
+- Estimated churn: small (roughly 20-60 LOC).
+- Regression risk: low-to-moderate; limited to payload mapping and contract tests.
+
+### 6. Watchlist
+- No additional low-confidence bug candidates promoted. Reviewed `191dd6b` dashboard/UI polling changes and did not find concrete correctness/reliability regressions from inspected diff hunks.
+
+### 7. Implementation recommendation
+- Implementation is recommended for the APNs `alertID` payload correction.
+
+### Audit entry (short)
+- Date: `2026-05-21`
+- Workflow reviewed: weekly bug scan (commits since last run marker)
+- Files inspected:
+  - `/Users/justin/Code/arcus-signal/Sources/App/Jobs/NotificationSendJob.swift`
+  - `/Users/justin/Code/arcus-signal/Sources/App/Clients/APNsClient.swift`
+  - `/Users/justin/Code/arcus-signal/Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift`
+  - `/Users/justin/Code/project-arcus/Sources/App/RemoteHotAlertHandler.swift`
+  - `/Users/justin/Code/project-arcus/Sources/Clients/ArcusClient.swift`
+  - `/Users/justin/Code/project-arcus/Tests/UnitTests/RemoteHotAlertHandlerTests.swift`
+  - `/Users/justin/Code/project-arcus/Sources/Repos/AlertRepo.swift`
+- Top finding: APNs payload `alertID` is currently set to `seriesId` UUID instead of canonical alert id.
+- Best next fix: map canonical alert id into APNs `alertID` and add contract assertions.
+- Implementation recommended: `yes`

--- a/postman/collections/Arcus Signal API/.resources/definition.yaml
+++ b/postman/collections/Arcus Signal API/.resources/definition.yaml
@@ -11,6 +11,7 @@ variables:
   sampleCounty: "COC001"
   sampleForecast: "COZ041"
   sampleFire: "COC001"
+  sampleArcusSeriesId: ""
   capturedAtNow: ""
   capturedAtFuture10m: ""
 scripts:

--- a/postman/collections/Arcus Signal API/Alerts/GET -api-v2-alerts (targeted id malformed).request.yaml
+++ b/postman/collections/Arcus Signal API/Alerts/GET -api-v2-alerts (targeted id malformed).request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+name: GET /api/v2/alerts (targeted id malformed)
+url: "{{apiBaseUrl}}/api/v2/alerts?id=not-a-uuid"
+method: GET
+description: |-
+  Negative test for targeted lookup.
+  
+  `id` must be a valid UUID.
+  
+  Expected: 400 Bad Request.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 400', function () { pm.response.to.have.status(400); });
+    language: text/javascript
+order: 8500

--- a/postman/collections/Arcus Signal API/Alerts/GET -api-v2-alerts (targeted id missing series).request.yaml
+++ b/postman/collections/Arcus Signal API/Alerts/GET -api-v2-alerts (targeted id missing series).request.yaml
@@ -1,0 +1,13 @@
+$kind: http-request
+name: GET /api/v2/alerts (targeted id missing series)
+url: "{{apiBaseUrl}}/api/v2/alerts?id=00000000-0000-0000-0000-000000000000"
+method: GET
+description: |-
+  Negative test for targeted lookup when series does not exist.
+  
+  Expected: 404 Not Found.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 404', function () { pm.response.to.have.status(404); });
+    language: text/javascript
+order: 8700

--- a/postman/collections/Arcus Signal API/Alerts/GET -api-v2-alerts (targeted id mixed filters).request.yaml
+++ b/postman/collections/Arcus Signal API/Alerts/GET -api-v2-alerts (targeted id mixed filters).request.yaml
@@ -1,0 +1,18 @@
+$kind: http-request
+name: GET /api/v2/alerts (targeted id mixed filters)
+url: "{{apiBaseUrl}}/api/v2/alerts?id={{sampleArcusSeriesId}}&county={{sampleCounty}}"
+method: GET
+queryParams:
+  id: "{{sampleArcusSeriesId}}"
+  county: "{{sampleCounty}}"
+description: |-
+  Negative test for mutually exclusive lookup modes.
+  
+  `id` cannot be combined with `county`, `forecast`, `fire`, or `h3`.
+  
+  Expected: 400 Bad Request.
+scripts:
+  - type: afterResponse
+    code: pm.test('status is 400', function () { pm.response.to.have.status(400); });
+    language: text/javascript
+order: 8600

--- a/postman/collections/Arcus Signal API/Alerts/GET -api-v2-alerts (targeted id).request.yaml
+++ b/postman/collections/Arcus Signal API/Alerts/GET -api-v2-alerts (targeted id).request.yaml
@@ -1,0 +1,23 @@
+$kind: http-request
+name: GET /api/v2/alerts (targeted id)
+url: "{{apiBaseUrl}}/api/v2/alerts?id={{sampleArcusSeriesId}}&sent={{capturedAtNow}}"
+method: GET
+queryParams:
+  id: "{{sampleArcusSeriesId}}"
+  sent: "{{capturedAtNow}}"
+description: |-
+  Targeted lookup by Arcus series UUID (`arcus_series.id`).
+  
+  `id` maps to APNs hot-alert payload `arcusAlertId`.
+  
+  Set `sampleArcusSeriesId` to an existing series UUID to validate the success path.
+  
+  Expected: 200 OK with JSON array containing one `DeviceAlertPayload`.
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', function () { pm.response.to.have.status(200); });
+      pm.test('response is array', function () { pm.expect(pm.response.json()).to.be.an('array'); });
+      pm.test('response has one payload', function () { pm.expect(pm.response.json().length).to.eql(1); });
+    language: text/javascript
+order: 5500


### PR DESCRIPTION
# Summary
This branch adds APNs hot-alert payload wiring and extends `GET /api/v2/alerts` to support targeted lookup by Arcus series UUID while preserving the existing device payload response contract, with matching tests and API/Postman documentation updates.

# What Changed
- Added hot-alert payload support in the APNs send path and related model/dependency updates.
- Extended `GET /api/v2/alerts` to accept targeted `id` lookup (Arcus series UUID) with optional `sent`, while keeping collection lookup behavior intact.
- Enforced targeted/collection mode validation rules: malformed UUID returns `400`, mixed `id` + location filters returns `400`, and missing targeted series returns `404`.
- Added `AlertsControllerTests` coverage for targeted success, malformed UUID, mixed filters, missing series, and response contract shape.
- Updated API docs for v2 alerts targeted semantics and added Postman collection requests for targeted success and negative cases.

# User Impact
Clients can now request a targeted alert refresh through `GET /api/v2/alerts?id=<arcus_series_uuid>` using the same `DeviceAlertPayload` response shape they already consume; invalid targeted inputs now fail with explicit `400`/`404` outcomes.

# Testing
- `swift test --filter AlertsControllerTests`

# Notes
- Branch also includes hot-alert APNs payload plumbing and corresponding dependency/test/doc updates in the same PR scope.