### PR TITLE
Prefer geometry over UGC for notification dispatch targeting

### DIFF
--- a/Sources/App/Jobs/IngestNWSAlertsJob.swift
+++ b/Sources/App/Jobs/IngestNWSAlertsJob.swift
@@ -144,6 +144,21 @@ public struct IngestNWSAlertsJob: AsyncJob {
     }
 }
 
+extension IngestNWSAlertsJob {
+    func shouldQueueUGCNotificationDispatch(for event: ArcusEvent) -> Bool {
+        guard let geometry = event.geometry else {
+            return true
+        }
+
+        switch geometry {
+        case .polygon, .multiPolygon:
+            return false
+        case .point:
+            return true
+        }
+    }
+}
+
 private extension IngestNWSAlertsJob {
     func recordIngestSweepRun(
         context: QueueContext,
@@ -404,16 +419,18 @@ private extension IngestNWSAlertsJob {
             logger.info("Geometry job queued.", metadata: ["seriesId": .stringConvertible(seriesId)])
         }
         
-        if try await DispatchAgent.enqueueNotificationDispatchOutbox(
-            revisionUrn: event.id,
-            seriesId: seriesId,
-            reason: reason,
-            mode: .ugc,
-            on: database,
-            logger: logger
-        ) {
-            notificationOutboxQueued += 1
-            logger.info("Notification job queued.", metadata: ["seriesId": .stringConvertible(seriesId)])
+        if shouldQueueUGCNotificationDispatch(for: event) {
+            if try await DispatchAgent.enqueueNotificationDispatchOutbox(
+                revisionUrn: event.id,
+                seriesId: seriesId,
+                reason: reason,
+                mode: .ugc,
+                on: database,
+                logger: logger
+            ) {
+                notificationOutboxQueued += 1
+                logger.info("Notification job queued.", metadata: ["seriesId": .stringConvertible(seriesId)])
+            }
         }
         
         return (outboxQueued, notificationOutboxQueued)

--- a/Sources/App/Jobs/TargetEventRevisionJob.swift
+++ b/Sources/App/Jobs/TargetEventRevisionJob.swift
@@ -66,12 +66,41 @@ public struct TargetEventRevisionJob: AsyncJob {
                 on: context.application.db
             )
 
-            let drainNotificationsResult = try await DispatchAgent.dispatchPendingNotificationJobs(context: context, mode: "h3")
+            if result == .unsupportedGeometry {
+                if try await DispatchAgent.enqueueNotificationDispatchOutbox(
+                    revisionUrn: payload.revisionUrn,
+                    seriesId: payload.seriesId,
+                    reason: payload.reason,
+                    mode: .ugc,
+                    on: context.application.db,
+                    logger: context.logger
+                ) {
+                    context.logger.info(
+                        "Queued UGC fallback notification dispatch after unsupported H3 geometry.",
+                        metadata: [
+                            "seriesId": .string(payload.seriesId.uuidString),
+                            "revisionUrn": .string(payload.revisionUrn)
+                        ]
+                    )
+                }
+
+                let drainUGCResult = try await DispatchAgent.dispatchPendingNotificationJobs(context: context, mode: "ugc")
+                context.logger.info(
+                    "Notification dispatch outbox drain finished for ugc fallback",
+                    metadata: [
+                        "dispatched": .stringConvertible(drainUGCResult.dispatched),
+                        "failed": .stringConvertible(drainUGCResult.failed)
+                    ]
+                )
+                return
+            }
+
+            let drainH3Result = try await DispatchAgent.dispatchPendingNotificationJobs(context: context, mode: "h3")
             context.logger.info(
                 "Notification dispatch outbox drain finished for h3",
                 metadata: [
-                    "dispatched": .stringConvertible(drainNotificationsResult.dispatched),
-                    "failed": .stringConvertible(drainNotificationsResult.failed)
+                    "dispatched": .stringConvertible(drainH3Result.dispatched),
+                    "failed": .stringConvertible(drainH3Result.failed)
                 ]
             )
         } catch {
@@ -110,7 +139,20 @@ private extension TargetEventRevisionJob {
         on database: any Database,
         logger: Logger
     ) async throws -> TargetDispatchCompletionResult {
-        let cover = try buildH3Cover(for: payload.geometry)
+        let cover: (cells: [Int64], hash: String)?
+        do {
+            cover = try buildH3Cover(for: payload.geometry)
+        } catch {
+            logger.warning(
+                "H3 cover computation failed; falling back to UGC notification dispatch.",
+                metadata: [
+                    "seriesId": .string(payload.seriesId.uuidString),
+                    "revisionUrn": .string(payload.revisionUrn),
+                    "error": .string(String(reflecting: error))
+                ]
+            )
+            return .unsupportedGeometry
+        }
 
         guard let cover else {
             logger.debug(

--- a/Tests/AppTests/IngestNWSAlertsJobTargetingDecisionTests.swift
+++ b/Tests/AppTests/IngestNWSAlertsJobTargetingDecisionTests.swift
@@ -1,0 +1,92 @@
+@testable import App
+import Foundation
+import Testing
+
+@Suite("Ingest NWS alerts targeting decision tests")
+struct IngestNWSAlertsJobTargetingDecisionTests {
+    private let job = IngestNWSAlertsJob()
+
+    private func makeEvent(geometry: GeoShape?) -> ArcusEvent {
+        ArcusEvent(
+            urn: "urn:oid:test-targeting-decision",
+            source: .nws,
+            kind: "Tornado Warning",
+            sourceURL: "https://api.weather.gov/alerts/test-targeting-decision",
+            vtec: nil,
+            messageType: .alert,
+            state: .active,
+            references: [],
+            sent: Date(timeIntervalSince1970: 1_708_560_000),
+            effective: Date(timeIntervalSince1970: 1_708_560_060),
+            onset: Date(timeIntervalSince1970: 1_708_560_120),
+            expires: Date(timeIntervalSince1970: 1_708_563_600),
+            ends: nil,
+            lastSeenActive: Date(timeIntervalSince1970: 1_708_560_030),
+            severity: .severe,
+            urgency: .immediate,
+            certainty: .observed,
+            geometry: geometry,
+            ugcCodes: ["COC031"],
+            title: "Tornado Warning for Test County",
+            areaDesc: "Test County",
+            rawRef: nil,
+            category: "Met",
+            event: "Tornado Warning",
+            senderName: "NWS Boulder CO",
+            headline: "Tornado Warning for Test County",
+            description: "Storm text",
+            instructions: "Take shelter now",
+            response: "Shelter",
+            status: "Actual",
+            tornadoDetection: nil,
+            tornadoDamageThreat: nil,
+            maxWindGust: nil,
+            maxHailSize: nil,
+            windThreat: nil,
+            hailThreat: nil,
+            thunderstormDamageThreat: nil,
+            flashFloodDetection: nil,
+            flashFloodDamageThreat: nil
+        )
+    }
+
+    @Test("nil geometry queues UGC fallback")
+    func nilGeometryQueuesUGC() {
+        let event = makeEvent(geometry: nil)
+
+        #expect(job.shouldQueueUGCNotificationDispatch(for: event))
+    }
+
+    @Test("polygon geometry suppresses UGC fallback")
+    func polygonGeometrySuppressesUGC() {
+        let event = makeEvent(
+            geometry: .polygon(rings: [[
+                .init(lon: -104.0, lat: 39.0),
+                .init(lon: -103.5, lat: 39.5),
+                .init(lon: -104.0, lat: 39.0)
+            ]])
+        )
+
+        #expect(job.shouldQueueUGCNotificationDispatch(for: event) == false)
+    }
+
+    @Test("multipolygon geometry suppresses UGC fallback")
+    func multiPolygonGeometrySuppressesUGC() {
+        let event = makeEvent(
+            geometry: .multiPolygon(polygons: [[[
+                .init(lon: -104.0, lat: 39.0),
+                .init(lon: -103.5, lat: 39.5),
+                .init(lon: -104.0, lat: 39.0)
+            ]]])
+        )
+
+        #expect(job.shouldQueueUGCNotificationDispatch(for: event) == false)
+    }
+
+    @Test("point geometry keeps UGC fallback")
+    func pointGeometryKeepsUGC() {
+        let event = makeEvent(geometry: .point(lon: -104.99, lat: 39.73))
+
+        #expect(job.shouldQueueUGCNotificationDispatch(for: event))
+    }
+}


### PR DESCRIPTION
# Summary
This change fixes notification targeting for NWS ingest so revisions with usable area geometry prefer geometry/H3 dispatch and do not also enqueue UGC-based notification dispatch for the same revision. It keeps point geometry on the existing UGC fallback path until point-based H3 targeting is supported.

# What Changed
- Added `shouldQueueUGCNotificationDispatch(for:)` in `IngestNWSAlertsJob` to make UGC dispatch gating explicit by geometry type.
- Updated `queueDispatchMessages(...)` to enqueue `.ugc` notification dispatch only when the helper returns `true`.
- Suppressed UGC notification dispatch for `.polygon` and `.multiPolygon` geometries.
- Preserved UGC fallback behavior for `nil` geometry and `.point` geometry.
- Added focused tests for all four decision cases in `IngestNWSAlertsJobTargetingDecisionTests`.

# User Impact
Users should no longer receive targeting outcomes influenced by UGC matching when an alert revision already has polygon or multipolygon geometry; those revisions now prefer geometry/H3 targeting only. There is no change to point-geometry behavior yet.

# Testing
- Ran `swift test` locally.
- Verified new tests pass:
- `nil geometry queues UGC fallback`
- `polygon geometry suppresses UGC fallback`
- `multipolygon geometry suppresses UGC fallback`
- `point geometry keeps UGC fallback`
