### PR TITLE
Fix expanded device presence sources and H3 dispatch regression

### DIFF
--- a/Sources/App/Jobs/TargetEventRevisionJob.swift
+++ b/Sources/App/Jobs/TargetEventRevisionJob.swift
@@ -185,16 +185,15 @@ private extension TargetEventRevisionJob {
                     "Geolocation unchanged; skipping update.",
                     metadata: ["seriesId": .string(payload.seriesId.uuidString)]
                 )
-                return .succeeded
+            } else {
+                existing.geometry = payload.geometry
+                existing.geometryHash = geometryHash
+                existing.h3Cells = cover.cells
+                existing.h3Resolution = h3Resolution
+                existing.h3Hash = cover.hash
+                try await existing.update(on: database)
+                logger.info("Updated geolocation cover", metadata: ["seriesId": .string(payload.seriesId.uuidString)])
             }
-
-            existing.geometry = payload.geometry
-            existing.geometryHash = geometryHash
-            existing.h3Cells = cover.cells
-            existing.h3Resolution = h3Resolution
-            existing.h3Hash = cover.hash
-            try await existing.update(on: database)
-            logger.info("Updated geolocation cover", metadata: ["seriesId": .string(payload.seriesId.uuidString)])
         } else {
             let geoRecord = ArcusGeolocationModel(
                 series: payload.seriesId,

--- a/Sources/App/Migrations/UpdateDevicePresenceSourceConstraintForExpandedLocationUploadSources.swift
+++ b/Sources/App/Migrations/UpdateDevicePresenceSourceConstraintForExpandedLocationUploadSources.swift
@@ -43,7 +43,22 @@ struct UpdateDevicePresenceSourceConstraintForExpandedLocationUploadSources: Asy
         try await sql.raw("""
             ALTER TABLE device_presence
             ADD CONSTRAINT device_presence_source_check
-            CHECK (source IN ('foreground', 'backgroundRefresh', 'significantChange', 'manual', 'unknown'));
+            CHECK (
+                source IN (
+                    'foreground',
+                    'backgroundRefresh',
+                    'significantChange',
+                    'manual',
+                    'foregroundPrime',
+                    'foregroundActivate',
+                    'foregroundLocationChange',
+                    'manualRefresh',
+                    'backgroundLocationChange',
+                    'onboarding',
+                    'settingsPreference',
+                    'unknown'
+                )
+            );
             """).run()
     }
 }

--- a/Sources/App/lib/DispatchAgent.swift
+++ b/Sources/App/lib/DispatchAgent.swift
@@ -98,6 +98,25 @@ public struct DispatchAgent {
         on database: any Database,
         logger: Logger
     ) async throws -> Bool {
+        let existing = try await ArcusNotificationOutboxModel.query(on: database)
+            .group(.and) { group in
+                group.filter(\.$series.$id == seriesId)
+                    .filter(\.$revisionUrn == revisionUrn)
+                    .filter(\.$mode == mode.rawValue)
+            }
+            .first()
+
+        if let existing {
+            return try await handleExistingNotificationDispatchOutbox(
+                existing,
+                revisionUrn: revisionUrn,
+                reason: reason,
+                mode: mode,
+                on: database,
+                logger: logger
+            )
+        }
+
         let outboxRecord = ArcusNotificationOutboxModel(
             series: seriesId,
             revisionUrn: revisionUrn,
@@ -107,7 +126,7 @@ public struct DispatchAgent {
             attempts: 0,
             availableAt: .now
         )
-        
+
         do {
             try await outboxRecord.create(on: database)
             return true
@@ -122,39 +141,14 @@ public struct DispatchAgent {
                     .first()
 
                 if let existing {
-                    let previousState = existing.state
-                    if existing.state == "done" {
-                        logger.debug(
-                            "Notification dispatch already completed for revision.",
-                            metadata: [
-                                "revisionUrn": .string(revisionUrn),
-                                "mode": .string(mode.rawValue),
-                                "previousState": .string(previousState)
-                            ]
-                        )
-                        return false
-                    }
-
-                    let shouldResetForDispatch = existing.state != "ready" || existing.availableAt > .now || existing.reason != reason.rawValue
-
-                    if shouldResetForDispatch {
-                        existing.state = "ready"
-                        existing.reason = reason.rawValue
-                        existing.attempts = 0
-                        existing.lastError = nil
-                        existing.availableAt = .now
-                        try await existing.update(on: database)
-
-                        logger.info(
-                            "Notification dispatch re-queued for revision.",
-                            metadata: [
-                                "revisionUrn": .string(revisionUrn),
-                                "mode": .string(mode.rawValue),
-                                "previousState": .string(previousState)
-                            ]
-                        )
-                        return true
-                    }
+                    return try await handleExistingNotificationDispatchOutbox(
+                        existing,
+                        revisionUrn: revisionUrn,
+                        reason: reason,
+                        mode: mode,
+                        on: database,
+                        logger: logger
+                    )
                 }
 
                 logger.debug(
@@ -169,5 +163,58 @@ public struct DispatchAgent {
 
             throw error
         }
+    }
+
+    private static func handleExistingNotificationDispatchOutbox(
+        _ existing: ArcusNotificationOutboxModel,
+        revisionUrn: String,
+        reason: NotificationReason,
+        mode: NotificationTargetMode,
+        on database: any Database,
+        logger: Logger
+    ) async throws -> Bool {
+        let previousState = existing.state
+
+        if existing.state == "done" {
+            logger.debug(
+                "Notification dispatch already completed for revision.",
+                metadata: [
+                    "revisionUrn": .string(revisionUrn),
+                    "mode": .string(mode.rawValue),
+                    "previousState": .string(previousState)
+                ]
+            )
+            return false
+        }
+
+        let shouldResetForDispatch = existing.state != "ready" || existing.availableAt > .now || existing.reason != reason.rawValue
+
+        if shouldResetForDispatch {
+            existing.state = "ready"
+            existing.reason = reason.rawValue
+            existing.attempts = 0
+            existing.lastError = nil
+            existing.availableAt = .now
+            try await existing.update(on: database)
+
+            logger.info(
+                "Notification dispatch re-queued for revision.",
+                metadata: [
+                    "revisionUrn": .string(revisionUrn),
+                    "mode": .string(mode.rawValue),
+                    "previousState": .string(previousState)
+                ]
+            )
+            return true
+        }
+
+        logger.debug(
+            "Notification dispatch already queued for revision.",
+            metadata: [
+                "revisionUrn": .string(revisionUrn),
+                "mode": .string(mode.rawValue)
+            ]
+        )
+        return false
     }
 }

--- a/Sources/App/lib/DispatchAgent.swift
+++ b/Sources/App/lib/DispatchAgent.swift
@@ -123,6 +123,18 @@ public struct DispatchAgent {
 
                 if let existing {
                     let previousState = existing.state
+                    if existing.state == "done" {
+                        logger.debug(
+                            "Notification dispatch already completed for revision.",
+                            metadata: [
+                                "revisionUrn": .string(revisionUrn),
+                                "mode": .string(mode.rawValue),
+                                "previousState": .string(previousState)
+                            ]
+                        )
+                        return false
+                    }
+
                     let shouldResetForDispatch = existing.state != "ready" || existing.availableAt > .now || existing.reason != reason.rawValue
 
                     if shouldResetForDispatch {

--- a/Tests/AppTests/DeviceControllerTests.swift
+++ b/Tests/AppTests/DeviceControllerTests.swift
@@ -65,8 +65,10 @@ struct DeviceControllerTests {
                     .POST,
                     "api/v1/devices/location-snapshots",
                     beforeRequest: { req in
+                        let encoder = JSONEncoder()
+                        encoder.dateEncodingStrategy = .iso8601
                         req.headers.contentType = .json
-                        req.body = .init(data: try JSONEncoder().encode(payload))
+                        req.body = .init(data: try encoder.encode(payload))
                     },
                     afterResponse: { res async in
                         #expect(res.status == .ok)

--- a/Tests/AppTests/DeviceControllerTests.swift
+++ b/Tests/AppTests/DeviceControllerTests.swift
@@ -1,0 +1,82 @@
+@testable import App
+import ArcusCore
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@Suite("Device controller", .serialized)
+struct DeviceControllerTests {
+    private func withApp(test: (Application) async throws -> Void) async throws {
+        let app = try await Application.make(.testing)
+        do {
+            try await configure(app, mode: .api)
+            try await app.autoMigrate()
+            try await test(app)
+        } catch {
+            try? await app.asyncShutdown()
+            throw error
+        }
+        try await app.asyncShutdown()
+    }
+
+    private func makePayload(
+        installationId: String,
+        source: LocationUploadSource
+    ) -> LocationSnapshotPushPayload {
+        LocationSnapshotPushPayload(
+            capturedAt: Date(timeIntervalSince1970: 1_717_513_600),
+            locationAgeSeconds: 12,
+            horizontalAccuracyMeters: 25,
+            cellScheme: CellScheme.ugcOnly.rawValue,
+            h3Cell: nil,
+            h3Resolution: nil,
+            county: "COC031",
+            zone: "COZ041",
+            fireZone: "COF241",
+            apnsDeviceToken: "abcd1234efgh5678ijkl9012mnop3456",
+            installationId: installationId,
+            source: source.rawValue,
+            auth: LocationAuth.always.rawValue,
+            appVersion: "1.0.0",
+            buildNumber: "100",
+            platform: Platform.iOS.rawValue,
+            osVersion: "26.0",
+            apnsEnvironment: APNsEnvironment.sandbox.rawValue,
+            countyLabel: "Boulder County",
+            fireZoneLabel: "Front Range",
+            isSubscribed: true
+        )
+    }
+
+    @Test("POST /api/v1/devices/location-snapshots persists expanded source values")
+    func createPersistsExpandedSourceValues() async throws {
+        try await withApp { app in
+            let cases: [LocationUploadSource] = [.settingsPreference, .foregroundPrime]
+
+            for source in cases {
+                let installationID = UUID()
+                let payload = makePayload(
+                    installationId: installationID.uuidString,
+                    source: source
+                )
+
+                try await app.testing().test(
+                    .POST,
+                    "api/v1/devices/location-snapshots",
+                    beforeRequest: { req in
+                        req.headers.contentType = .json
+                        req.body = .init(data: try JSONEncoder().encode(payload))
+                    },
+                    afterResponse: { res async in
+                        #expect(res.status == .ok)
+                    }
+                )
+
+                let storedPresence = try await DevicePresenceModel.find(installationID, on: app.db)
+                #expect(storedPresence != nil)
+                #expect(storedPresence?.source == source)
+            }
+        }
+    }
+}

--- a/Tests/AppTests/DevicePresenceMigrationTests.swift
+++ b/Tests/AppTests/DevicePresenceMigrationTests.swift
@@ -21,7 +21,7 @@ struct DevicePresenceMigrationTests {
     @Test("rollback keeps expanded source values valid")
     func revertPreservesExpandedSources() async throws {
         try await withApp { app in
-            let installationID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+            let installationID = UUID()
             let now = Date(timeIntervalSince1970: 1_717_513_600)
 
             try await DeviceInstallationModel(

--- a/Tests/AppTests/DevicePresenceMigrationTests.swift
+++ b/Tests/AppTests/DevicePresenceMigrationTests.swift
@@ -1,0 +1,63 @@
+@testable import App
+import Foundation
+import Testing
+import Vapor
+
+@Suite("Device presence migration tests", .serialized)
+struct DevicePresenceMigrationTests {
+    private func withApp(test: (Application) async throws -> Void) async throws {
+        let app = try await Application.make(.testing)
+        do {
+            try await configure(app, mode: .api)
+            try await app.autoMigrate()
+            try await test(app)
+        } catch {
+            try? await app.asyncShutdown()
+            throw error
+        }
+        try await app.asyncShutdown()
+    }
+
+    @Test("rollback keeps expanded source values valid")
+    func revertPreservesExpandedSources() async throws {
+        try await withApp { app in
+            let installationID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+            let now = Date(timeIntervalSince1970: 1_717_513_600)
+
+            try await DeviceInstallationModel(
+                installationId: installationID,
+                apnsDeviceToken: "apns-token-1234",
+                apnsEnvironment: .sandbox,
+                platform: .iOS,
+                osVersion: "26.0",
+                appVersion: "1.0.0",
+                buildNumber: "100",
+                locationAuth: .always,
+                lastSeenAt: now,
+                isSubscribed: true
+            ).create(on: app.db)
+
+            try await DevicePresenceModel(
+                installationId: installationID,
+                capturedAt: now,
+                receivedAt: now,
+                locationAgeSeconds: 5,
+                horizontalAccuracyMeters: 10,
+                cellScheme: .ugcOnly,
+                h3Cell: nil,
+                h3Resolution: nil,
+                county: nil,
+                zone: nil,
+                fireZone: nil,
+                source: .settingsPreference,
+                countyLabel: nil,
+                fireZoneLabel: nil
+            ).create(on: app.db)
+
+            try await UpdateDevicePresenceSourceConstraintForExpandedLocationUploadSources().revert(on: app.db)
+
+            let storedPresence = try await DevicePresenceModel.find(installationID, on: app.db)
+            #expect(storedPresence?.source == .settingsPreference)
+        }
+    }
+}

--- a/Tests/AppTests/TargetEventRevisionJobFallbackTests.swift
+++ b/Tests/AppTests/TargetEventRevisionJobFallbackTests.swift
@@ -1,4 +1,5 @@
 @testable import App
+import Fluent
 import Foundation
 import Queues
 import SwiftyH3
@@ -13,14 +14,23 @@ struct TargetEventRevisionJobFallbackTests {
             try await configure(app, mode: .worker)
             try await app.autoMigrate()
             app.queues.use(.test)
+            try await deleteTargetFallbackFixtures(on: app.db)
             try await test(app)
+            try await deleteTargetFallbackFixtures(on: app.db)
         } catch {
             Issue.record("Worker app bootstrap/test failed: \(String(reflecting: error))")
+            try? await deleteTargetFallbackFixtures(on: app.db)
             try? await app.asyncShutdown()
             throw error
         }
 
         try await app.asyncShutdown()
+    }
+
+    private func deleteTargetFallbackFixtures(on database: any Database) async throws {
+        try await ArcusSeriesModel.query(on: database)
+            .filter(\.$sourceURL, .equal, "https://api.weather.gov/alerts/test-target-fallback")
+            .delete()
     }
 
     private func makeQueueContext(app: Application) -> QueueContext {
@@ -151,9 +161,8 @@ struct TargetEventRevisionJobFallbackTests {
                 .filter(\.$mode, .equal, NotificationTargetMode.h3.rawValue)
                 .all()
             #expect(h3Rows.count == 1)
-            #expect(h3Rows.first?.state == "done")
-            #expect(h3Rows.first?.attempts == 1)
-            #expect(h3Rows.first?.lastError == nil)
+            #expect(h3Rows.first?.state == "ready")
+            #expect(h3Rows.first?.attempts == 0)
         }
     }
 
@@ -250,6 +259,12 @@ struct TargetEventRevisionJobFallbackTests {
             ).create(on: app.db)
 
             try await TargetEventRevisionJob().dequeue(makeQueueContext(app: app), payload)
+
+            let targetDispatchRow = try await ArcusTargetDispatchOutboxModel.query(on: app.db)
+                .filter(\.$revisionUrn, .equal, revisionUrn)
+                .first()
+            #expect(targetDispatchRow?.result == "succeeded")
+            #expect(targetDispatchRow?.completed != nil)
 
             let h3Rows = try await ArcusNotificationOutboxModel.query(on: app.db)
                 .filter(\.$revisionUrn, .equal, revisionUrn)

--- a/Tests/AppTests/TargetEventRevisionJobFallbackTests.swift
+++ b/Tests/AppTests/TargetEventRevisionJobFallbackTests.swift
@@ -1,6 +1,7 @@
 @testable import App
 import Foundation
 import Queues
+import SwiftyH3
 import Testing
 import Vapor
 
@@ -49,6 +50,54 @@ struct TargetEventRevisionJobFallbackTests {
             certainty: EventCertainty.observed.rawValue,
             ugcCodes: ["COC031"]
         )
+    }
+
+    private func makePolygonGeometry() -> GeoShape {
+        .polygon(rings: [[
+            .init(lon: -104.9903, lat: 39.7392),
+            .init(lon: -104.9703, lat: 39.7392),
+            .init(lon: -104.9803, lat: 39.7592),
+            .init(lon: -104.9903, lat: 39.7392)
+        ]])
+    }
+
+    private func h3Cover(for geometry: GeoShape) throws -> (geometryHash: String, h3Cells: [Int64], h3Hash: String) {
+        let geometryHash = try StableContentHasher.sha256Hex(of: geometry, dateEncodingStrategy: .deferredToDate)
+
+        switch geometry {
+        case .point:
+            throw Abort(.badRequest, reason: "Test fixture requires polygon geometry.")
+        case .polygon(let rings):
+            let cells = try h3Cells(for: rings)
+            let sorted = Array(Set(cells)).sorted()
+            return (geometryHash, sorted, h3Hash(for: sorted))
+        case .multiPolygon:
+            throw Abort(.badRequest, reason: "Test fixture requires polygon geometry.")
+        }
+    }
+
+    private func h3Cells(for rings: [[GeoShape.GeoCoordinate]]) throws -> [Int64] {
+        guard let boundaryRing = rings.first, !boundaryRing.isEmpty else {
+            throw SwiftyH3Error.invalidInput
+        }
+
+        let boundary: H3Loop = boundaryRing.map { coordinate in
+            H3LatLng(latitudeDegs: coordinate.lat, longitudeDegs: coordinate.lon)
+        }
+
+        let polygon = H3Polygon(boundary, holes: [])
+        let resolution = H3Cell.Resolution(rawValue: Int32(8)) ?? .res8
+        let cells = try polygon.cells(at: resolution)
+        return cells.map { Int64(bitPattern: $0.id) }
+    }
+
+    private func h3Hash(for sortedCells: [Int64]) -> String {
+        var data = Data(capacity: sortedCells.count * MemoryLayout<UInt64>.size)
+        for value in sortedCells {
+            var bigEndian = UInt64(bitPattern: value).bigEndian
+            withUnsafeBytes(of: &bigEndian) { data.append(contentsOf: $0) }
+        }
+        return StableContentHasher.sha256Hex(of: data)
     }
 
     @Test("unsupported geometry enqueues and drains ugc fallback without draining h3")
@@ -101,6 +150,50 @@ struct TargetEventRevisionJobFallbackTests {
                 .filter(\.$revisionUrn, .equal, revisionUrn)
                 .filter(\.$mode, .equal, NotificationTargetMode.h3.rawValue)
                 .all()
+            #expect(h3Rows.count == 1)
+            #expect(h3Rows.first?.state == "ready")
+            #expect(h3Rows.first?.attempts == 0)
+        }
+    }
+
+    @Test("unchanged polygon geometry still enqueues h3 notification dispatch")
+    func unchangedPolygonGeometryStillQueuesH3Notification() async throws {
+        try await withWorkerApp { app in
+            let now = Date()
+            let seriesID = UUID()
+            let revisionUrn = "urn:oid:test-unchanged-geometry-\(UUID().uuidString.lowercased())"
+            let geometry = makePolygonGeometry()
+            let cover = try h3Cover(for: geometry)
+            let payload = TargetEventRevisionPayload(
+                seriesId: seriesID,
+                revisionUrn: revisionUrn,
+                geometry: geometry,
+                reason: .update
+            )
+
+            try await makeSeries(id: seriesID, revisionUrn: revisionUrn, now: now).create(on: app.db)
+            try await ArcusGeolocationModel(
+                series: seriesID,
+                geometry: geometry,
+                geometryHash: cover.geometryHash,
+                h3Cells: cover.h3Cells,
+                h3Resolution: 8,
+                h3Hash: cover.h3Hash
+            ).create(on: app.db)
+
+            try await TargetEventRevisionJob().dequeue(makeQueueContext(app: app), payload)
+
+            let targetDispatchRow = try await ArcusTargetDispatchOutboxModel.query(on: app.db)
+                .filter(\.$revisionUrn, .equal, revisionUrn)
+                .first()
+            #expect(targetDispatchRow?.result == "succeeded")
+            #expect(targetDispatchRow?.completed != nil)
+
+            let h3Rows = try await ArcusNotificationOutboxModel.query(on: app.db)
+                .filter(\.$revisionUrn, .equal, revisionUrn)
+                .filter(\.$mode, .equal, NotificationTargetMode.h3.rawValue)
+                .all()
+
             #expect(h3Rows.count == 1)
             #expect(h3Rows.first?.state == "ready")
             #expect(h3Rows.first?.attempts == 0)

--- a/Tests/AppTests/TargetEventRevisionJobFallbackTests.swift
+++ b/Tests/AppTests/TargetEventRevisionJobFallbackTests.swift
@@ -151,8 +151,9 @@ struct TargetEventRevisionJobFallbackTests {
                 .filter(\.$mode, .equal, NotificationTargetMode.h3.rawValue)
                 .all()
             #expect(h3Rows.count == 1)
-            #expect(h3Rows.first?.state == "ready")
-            #expect(h3Rows.first?.attempts == 0)
+            #expect(h3Rows.first?.state == "done")
+            #expect(h3Rows.first?.attempts == 1)
+            #expect(h3Rows.first?.lastError == nil)
         }
     }
 
@@ -180,6 +181,11 @@ struct TargetEventRevisionJobFallbackTests {
                 h3Resolution: 8,
                 h3Hash: cover.h3Hash
             ).create(on: app.db)
+            try await ArcusTargetDispatchOutboxModel(
+                revisionUrn: revisionUrn,
+                seriesId: seriesID,
+                payload: payload
+            ).create(on: app.db)
 
             try await TargetEventRevisionJob().dequeue(makeQueueContext(app: app), payload)
 
@@ -195,8 +201,9 @@ struct TargetEventRevisionJobFallbackTests {
                 .all()
 
             #expect(h3Rows.count == 1)
-            #expect(h3Rows.first?.state == "ready")
-            #expect(h3Rows.first?.attempts == 0)
+            #expect(h3Rows.first?.state == "done")
+            #expect(h3Rows.first?.attempts == 1)
+            #expect(h3Rows.first?.lastError == nil)
         }
     }
 
@@ -223,6 +230,14 @@ struct TargetEventRevisionJobFallbackTests {
                 h3Cells: cover.h3Cells,
                 h3Resolution: 8,
                 h3Hash: cover.h3Hash
+            ).create(on: app.db)
+            try await ArcusTargetDispatchOutboxModel(
+                revisionUrn: revisionUrn,
+                seriesId: seriesID,
+                payload: payload,
+                attemptCount: 1,
+                completed: now,
+                result: "succeeded"
             ).create(on: app.db)
             try await ArcusNotificationOutboxModel(
                 series: seriesID,

--- a/Tests/AppTests/TargetEventRevisionJobFallbackTests.swift
+++ b/Tests/AppTests/TargetEventRevisionJobFallbackTests.swift
@@ -199,4 +199,52 @@ struct TargetEventRevisionJobFallbackTests {
             #expect(h3Rows.first?.attempts == 0)
         }
     }
+
+    @Test("redelivered same-geometry revision does not requeue completed h3 dispatch")
+    func redeliveredSameGeometryRevisionDoesNotRequeueCompletedDispatch() async throws {
+        try await withWorkerApp { app in
+            let now = Date()
+            let seriesID = UUID()
+            let revisionUrn = "urn:oid:test-redelivered-geometry-\(UUID().uuidString.lowercased())"
+            let geometry = makePolygonGeometry()
+            let cover = try h3Cover(for: geometry)
+            let payload = TargetEventRevisionPayload(
+                seriesId: seriesID,
+                revisionUrn: revisionUrn,
+                geometry: geometry,
+                reason: .update
+            )
+
+            try await makeSeries(id: seriesID, revisionUrn: revisionUrn, now: now).create(on: app.db)
+            try await ArcusGeolocationModel(
+                series: seriesID,
+                geometry: geometry,
+                geometryHash: cover.geometryHash,
+                h3Cells: cover.h3Cells,
+                h3Resolution: 8,
+                h3Hash: cover.h3Hash
+            ).create(on: app.db)
+            try await ArcusNotificationOutboxModel(
+                series: seriesID,
+                revisionUrn: revisionUrn,
+                mode: NotificationTargetMode.h3.rawValue,
+                reason: NotificationReason.update.rawValue,
+                state: "done",
+                attempts: 1,
+                availableAt: now
+            ).create(on: app.db)
+
+            try await TargetEventRevisionJob().dequeue(makeQueueContext(app: app), payload)
+
+            let h3Rows = try await ArcusNotificationOutboxModel.query(on: app.db)
+                .filter(\.$revisionUrn, .equal, revisionUrn)
+                .filter(\.$mode, .equal, NotificationTargetMode.h3.rawValue)
+                .all()
+
+            #expect(h3Rows.count == 1)
+            #expect(h3Rows.first?.state == "done")
+            #expect(h3Rows.first?.attempts == 1)
+            #expect(h3Rows.first?.lastError == nil)
+        }
+    }
 }

--- a/docs/audits/weekly-bug-scan.md
+++ b/docs/audits/weekly-bug-scan.md
@@ -43,6 +43,9 @@
 ### 7. Implementation recommendation
 - Implementation is recommended for the APNs `alertID` payload correction.
 
+### 8. Implementation status
+- Marked stale on 2026-06-04 after re-checking the shared contract: `ArcusCore/Sources/ArcusCore/HotAlertAPNsPayload.swift` defines `arcusAlertId` as the canonical hot-alert identifier, `project-arcus/docs/audits/weekly-contract-drift-audit.md` already records that contract as resolved, and the current `NotificationSendJob` payload mapping still matches that series-id contract. No backend code change is recommended for this audit item.
+
 ### Audit entry (short)
 - Date: `2026-05-21`
 - Workflow reviewed: weekly bug scan (commits since last run marker)
@@ -56,7 +59,7 @@
   - `/Users/justin/Code/project-arcus/Sources/Repos/AlertRepo.swift`
 - Top finding: APNs payload `alertID` is currently set to `seriesId` UUID instead of canonical alert id.
 - Best next fix: map canonical alert id into APNs `alertID` and add contract assertions.
-- Implementation recommended: `yes`
+- Implementation recommended: `no` - stale after contract re-check on 2026-06-04
 
 ## 2026-05-28
 

--- a/docs/audits/weekly-bug-scan.md
+++ b/docs/audits/weekly-bug-scan.md
@@ -57,3 +57,130 @@
 - Top finding: APNs payload `alertID` is currently set to `seriesId` UUID instead of canonical alert id.
 - Best next fix: map canonical alert id into APNs `alertID` and add contract assertions.
 - Implementation recommended: `yes`
+
+## 2026-05-28
+
+### 1. Repos scanned
+- `arcus-signal`
+- `project-arcus`
+
+### 2. Commit window inspected
+- Last automation run marker: `2026-05-21T16:05:46.968Z`
+- Window used: commits after `2026-05-21T16:05:46Z`
+- `arcus-signal` commits inspected:
+  - `4469c10c667df02bc54711d6566f95b9472bfc90`
+  - `c4232cc77d7c565e8eeaeed891fbe5f6427efcee`
+  - `2c0103316e7b6a5baf7d82f557cf392e49ae4021`
+  - `9d1cacac5923944cf6981c65168f4fa325f5c6e2`
+- `project-arcus` commits inspected (high-risk subset):
+  - `9c08b1333fa61fce999eaaf87dd818c949ba07c6`
+  - `58272f407d67ec04beb14a6fe216d5767cbd988e`
+  - `99278828060652975def6648979591d9ceb918fb`
+  - `8f1f27209c101f69eaf5516bd0b45f24054133cf`
+  - `97391228e63ba88664e6b402cac7e8bf97f928ac`
+
+### 3. Highest-risk changed areas
+- alert ingestion/update lifecycle and geometry-first targeting
+- notification delivery/APNs payload path
+- location/presence + preference upload reliability
+- persistence migrations and rollback safety
+- shared API contracts (`ArcusCore` payloads across server/app)
+
+### 4. Findings table
+
+| Bug | Repo | Evidence | Impact | Confidence | Minimal fix | Validation |
+|---|---|---|---|---|---|---|
+| Rollback migration can fail in production-like data after new `source` values are written | `arcus-signal` | `9d1cacac5923944cf6981c65168f4fa325f5c6e2` adds [`/Users/justin/Code/arcus-signal/Sources/App/Migrations/UpdateDevicePresenceSourceConstraintForExpandedLocationUploadSources.swift`](/Users/justin/Code/arcus-signal/Sources/App/Migrations/UpdateDevicePresenceSourceConstraintForExpandedLocationUploadSources.swift). `prepare` allows expanded sources (`foregroundPrime`, `settingsPreference`, etc.), but `revert` re-adds old narrow check (`foreground`, `backgroundRefresh`, `significantChange`, `manual`, `unknown`). Any row inserted after deploy with expanded values violates revert constraint and causes rollback migration failure at `ADD CONSTRAINT`. | Operational reliability risk during rollback/recovery. Failed rollback can prolong incident response and keep deploys stuck while severe-weather notification pipeline is degraded. | High | Keep rollback safe by making `revert` non-breaking for existing rows: either (a) keep expanded allow-list in revert, or (b) map unsupported rows to `unknown` in a data update before re-adding narrow constraint. Smallest safe option: revert to expanded allow-list. | Migration check: apply migration, insert `device_presence.source='settingsPreference'`, run revert, confirm success. Integration: run migrate+revert in ephemeral DB CI job. Log/metric: migration failure count and startup abort reason. |
+
+### 5. Top recommended fix
+- Highest-priority bug: rollback migration failure in `UpdateDevicePresenceSourceConstraintForExpandedLocationUploadSources`.
+- Why it matters: this is a concrete recoverability bug; rollback paths fail exactly when you need them most.
+- Expected files touched:
+  - [`/Users/justin/Code/arcus-signal/Sources/App/Migrations/UpdateDevicePresenceSourceConstraintForExpandedLocationUploadSources.swift`](/Users/justin/Code/arcus-signal/Sources/App/Migrations/UpdateDevicePresenceSourceConstraintForExpandedLocationUploadSources.swift)
+  - optional migration test file in `Tests/AppTests`
+- Estimated churn: very small (roughly 5-25 LOC).
+- Regression risk: low (constraint text only, no runtime code path changes).
+
+### 6. Watchlist
+- `project-arcus` `99278828060652975def6648979591d9ceb918fb`: [`/Users/justin/Code/project-arcus/Sources/Infrastructure/Location/LocationSession.swift`](/Users/justin/Code/project-arcus/Sources/Infrastructure/Location/LocationSession.swift) methods `syncNotificationPreference(enabled:)` / `syncLocationSharingPreference(enabled:)` ignore their `enabled` argument and rely on downstream state reads. This may be intentional, but it increases race-window risk for stale preference uploads if state persistence timing changes.
+- `arcus-signal` `4469c10c667df02bc54711d6566f95b9472bfc90`: `sent` query param is accepted on targeted `/api/v2/alerts` but currently ignored by implementation and docs. Not a correctness bug today, but it can mislead clients expecting freshness gating.
+
+### 7. Implementation recommendation
+- Implementation is recommended for the migration rollback bug.
+
+### Audit entry (short)
+- Date: `2026-05-28`
+- Workflow reviewed: weekly bug scan (commits since last automation run marker)
+- Files inspected:
+  - `/Users/justin/Code/arcus-signal/Sources/App/Migrations/UpdateDevicePresenceSourceConstraintForExpandedLocationUploadSources.swift`
+  - `/Users/justin/Code/arcus-signal/Sources/App/Controllers/AlertsController.swift`
+  - `/Users/justin/Code/arcus-signal/Sources/App/Jobs/IngestNWSAlertsJob.swift`
+  - `/Users/justin/Code/arcus-signal/Sources/App/Jobs/TargetEventRevisionJob.swift`
+  - `/Users/justin/Code/arcus-signal/Sources/App/Jobs/NotificationSendJob.swift`
+  - `/Users/justin/Code/project-arcus/Sources/Infrastructure/Location/LocationSnapshotPusher.swift`
+  - `/Users/justin/Code/project-arcus/Sources/Infrastructure/Location/LocationSession.swift`
+  - `/Users/justin/Code/project-arcus/Sources/App/RemoteHotAlertHandler.swift`
+  - `/Users/justin/Code/project-arcus/Sources/Repos/AlertRepo.swift`
+- Top finding: rollback migration for `device_presence.source` can fail with post-deploy rows using expanded source values.
+- Best next fix: make migration `revert` path data-safe (prefer expanded allow-list to avoid rollback failure).
+- Implementation recommended: `yes`
+
+## 2026-06-04
+
+### 1. Repos scanned
+- `arcus-signal`
+- `project-arcus`
+
+### 2. Commit window inspected
+- Last automation run marker: `2026-05-28T16:06:26.231Z`
+- Window used: commits after `2026-05-28T16:06:26Z`
+- `arcus-signal` commits inspected: none
+- `project-arcus` commits inspected:
+  - `a9b833fabf2fa016055433a5924628c34d7fed43`
+  - `2ff15307a9a559004b1c8eb48b502a45f5a6a513`
+
+### 3. Highest-risk changed areas
+- legacy `MdDTO` persistence / Codable compatibility
+- location upload payload decode compatibility
+- target/revision dispatch and notification outbox enqueueing
+- device presence and H3 targeting
+
+### 4. Findings table
+
+| Bug | Repo | Evidence | Impact | Confidence | Minimal fix | Validation |
+|---|---|---|---|---|---|---|
+| `TargetEventRevisionJob.persistGeolocation` returns before enqueuing notification dispatch when H3 geometry is unchanged | `arcus-signal` | [`/Users/justin/Code/arcus-signal/Sources/App/Jobs/TargetEventRevisionJob.swift`](/Users/justin/Code/arcus-signal/Sources/App/Jobs/TargetEventRevisionJob.swift) lines 177-188 return `.succeeded` on unchanged geometry. The notification enqueue happens later in the same function, so unchanged polygons never queue the revision’s notification outbox. `queueDispatchMessages` in [`/Users/justin/Code/arcus-signal/Sources/App/Jobs/IngestNWSAlertsJob.swift`](/Users/justin/Code/arcus-signal/Sources/App/Jobs/IngestNWSAlertsJob.swift) only queues UGC fallback for non-polygon shapes, so polygon updates/cancels rely entirely on the H3 path. | Missed severe-weather notifications for updates/cancels that reuse the same polygon, which is a real user-visible awareness failure. | High | Keep the no-op geolocation shortcut, but move notification outbox enqueueing ahead of the unchanged-geometry early return, or split the “unchanged geolocation” and “notification enqueue” responsibilities. | Unit test: add a TargetEventRevisionJob test proving a same-geometry update still queues and drains the H3 notification outbox. Integration test: run the job against a seeded series with existing geolocation and a new revision using the same polygon. Log/metric: count of updated revisions where notification outbox rows are created. |
+
+### 5. Top recommended fix
+- Highest-priority bug: unchanged-geometry early return in `TargetEventRevisionJob`.
+- Why it matters: polygon-based revisions can silently skip notification fanout even though the alert content changed.
+- Expected files touched:
+  - [`/Users/justin/Code/arcus-signal/Sources/App/Jobs/TargetEventRevisionJob.swift`](/Users/justin/Code/arcus-signal/Sources/App/Jobs/TargetEventRevisionJob.swift)
+  - optional test file under [`/Users/justin/Code/arcus-signal/Tests/AppTests`](/Users/justin/Code/arcus-signal/Tests/AppTests)
+- Estimated churn: very small, likely under 30 LOC.
+- Regression risk: low if the fix only reorders notification enqueueing and leaves geolocation deduplication intact.
+
+### 6. Watchlist
+- `arcus-signal` `IngestNWSAlertsJob.shouldAdvanceSeriesSnapshot(currentSent:incomingSent:)` drops revisions when `event.sent` is nil even though the DTO/model allow nil. That could suppress a rare revision update if upstream omits `sent`, but I did not find a concrete recent payload proving it in this run.
+- `project-arcus` `MdDTO` legacy decode fallback uses localized number formatting for `watchProbabilityText`; if a legacy payload ever carries a fractional probability on a locale that formats decimals with commas, the derived text may stop parsing as numeric in `MesoComposer`.
+
+### 7. Implementation recommendation
+- Implementation is recommended for the unchanged-geometry notification enqueue bug.
+
+### 8. Implementation status
+- Fixed on `2026-06-04` by removing the premature unchanged-geometry return in `TargetEventRevisionJob.persistGeolocation` and adding a regression test in `Tests/AppTests/TargetEventRevisionJobFallbackTests.swift`.
+
+### Audit entry (short)
+- Date: `2026-06-04`
+- Workflow reviewed: weekly bug scan (audit-only)
+- Files inspected:
+  - `/Users/justin/Code/project-arcus/Sources/Models/Meso/MdDTO.swift`
+  - `/Users/justin/Code/project-arcus/Tests/UnitTests/MdDTOCodableCompatibilityTests.swift`
+  - `/Users/justin/Code/arcus-signal/Sources/App/Jobs/TargetEventRevisionJob.swift`
+  - `/Users/justin/Code/arcus-signal/Sources/App/Jobs/IngestNWSAlertsJob.swift`
+  - `/Users/justin/Code/arcus-signal/Sources/App/Jobs/NotificationSendJob.swift`
+  - `/Users/justin/Code/arcus-signal/Sources/App/Controllers/DeviceController.swift`
+  - `/Users/justin/Code/arcus-signal/Sources/App/Models/Device/DevicePresenceModel.swift`
+- Top finding: unchanged H3 geometry short-circuits notification enqueueing in `TargetEventRevisionJob`.
+- Best next fix: enqueue notification outbox before the unchanged-geometry early return.
+- Implementation recommended: `yes`

--- a/docs/audits/weekly-bug-scan.md
+++ b/docs/audits/weekly-bug-scan.md
@@ -108,6 +108,9 @@
 ### 7. Implementation recommendation
 - Implementation is recommended for the migration rollback bug.
 
+### 8. Implementation status
+- Fixed on `2026-06-04` by making the rollback constraint match the expanded allow-list and adding a regression test in `Tests/AppTests/DevicePresenceMigrationTests.swift`.
+
 ### Audit entry (short)
 - Date: `2026-05-28`
 - Workflow reviewed: weekly bug scan (commits since last automation run marker)

--- a/docs/audits/weekly-test-gap-audit.md
+++ b/docs/audits/weekly-test-gap-audit.md
@@ -12,7 +12,10 @@
 - Top recommended test: add `TargetEventRevisionJob` fallback-path test that asserts unsupported geometry triggers UGC notification dispatch enqueue + UGC drain (and does not run H3 drain in that path)
 - Watchlist:
   - targeted `/api/v2/alerts?id=...&sent=...` currently accepts `sent` but server-side targeted query does not filter by it; likely intentional, but contract expectation should be clarified before adding strict tests
-- Implementation recommended: Yes (tests only; no production code changes in this automation)
+- Implementation recommended: no - handled on 2026-06-04 by [`/Users/justin/Code/arcus-signal/Tests/AppTests/TargetEventRevisionJobFallbackTests.swift`](/Users/justin/Code/arcus-signal/Tests/AppTests/TargetEventRevisionJobFallbackTests.swift)
+
+### 6. Implementation status
+- Added a regression test for the fallback path: unsupported geometry now asserts UGC notification dispatch enqueue + UGC drain without running the H3 drain path.
 
 ## 2026-06-02
 - Repos scanned: `project-arcus` (SkyAware), `arcus-signal`, `ArcusCore`
@@ -24,4 +27,7 @@
 - Top recommended test: add an `arcus-signal` endpoint test proving `POST /api/v1/devices/location-snapshots` accepts newly introduced `LocationUploadSource` values and persists them without triggering the client’s legacy `"unknown"` fallback path
 - Watchlist:
   - `project-arcus` `HTTPDevicePreferenceSyncUploader` still treats 2xx response decoding as best-effort; current evidence does not justify a stricter test yet because the client ignores malformed success bodies by design
-- Implementation recommended: Yes (targeted tests only; no production code changes in this automation)
+- Implementation recommended: no - handled on 2026-06-04 by [`/Users/justin/Code/arcus-signal/Tests/AppTests/DeviceControllerTests.swift`](/Users/justin/Code/arcus-signal/Tests/AppTests/DeviceControllerTests.swift)
+
+### 6. Implementation status
+- Added a controller regression test that posts `LocationUploadSource.settingsPreference` and `LocationUploadSource.foregroundPrime` through `/api/v1/devices/location-snapshots` and asserts the persisted `device_presence.source` matches the submitted value.

--- a/docs/audits/weekly-test-gap-audit.md
+++ b/docs/audits/weekly-test-gap-audit.md
@@ -13,3 +13,15 @@
 - Watchlist:
   - targeted `/api/v2/alerts?id=...&sent=...` currently accepts `sent` but server-side targeted query does not filter by it; likely intentional, but contract expectation should be clarified before adding strict tests
 - Implementation recommended: Yes (tests only; no production code changes in this automation)
+
+## 2026-06-02
+- Repos scanned: `project-arcus` (SkyAware), `arcus-signal`, `ArcusCore`
+- Commit window: since last automation run (`2026-05-26T15:00:38Z` to `2026-06-02T00:00:00-06:00`)
+- High-risk areas inspected:
+  - `arcus-signal` device preference sync endpoint and expanded `device_presence.source` constraint (`DeviceController`, `UpdateDevicePresenceSourceConstraintForExpandedLocationUploadSources`)
+  - `project-arcus` location/preference upload reliability, explicit-source fallback, SPC batch persistence, mesoscale notification copy, and `MdDTO` Codable compatibility
+  - `ArcusCore` shared device preference DTOs and `LocationUploadSource`
+- Top recommended test: add an `arcus-signal` endpoint test proving `POST /api/v1/devices/location-snapshots` accepts newly introduced `LocationUploadSource` values and persists them without triggering the client’s legacy `"unknown"` fallback path
+- Watchlist:
+  - `project-arcus` `HTTPDevicePreferenceSyncUploader` still treats 2xx response decoding as best-effort; current evidence does not justify a stricter test yet because the client ignores malformed success bodies by design
+- Implementation recommended: Yes (targeted tests only; no production code changes in this automation)


### PR DESCRIPTION
# Summary
This branch fixes two production-path regressions: the geolocation job now still enqueues notification dispatch when polygon geometry is unchanged, and the device presence migration accepts the expanded location upload source set in both directions. It also adds regression coverage for the controller, migration revert, and unchanged-geometry job path, plus updates the audit docs to reflect the resolved findings.

# What Changed
- Removed the premature early return in `TargetEventRevisionJob` so unchanged geolocation still proceeds to notification dispatch.
- Expanded the `device_presence.source` constraint in the migration to include the newer upload sources used by the client.
- Added tests for `POST /api/v1/devices/location-snapshots`, migration revert behavior, and unchanged polygon geometry dispatch.
- Updated the weekly bug scan and test-gap audit docs to mark the related findings as resolved.

# User Impact
Users keep receiving H3-based severe-weather notifications when a polygon revision reuses the same geometry, and device presence uploads with the newer source values no longer depend on the client collapsing them to `unknown`. There is no direct UI change.

# Testing
- Ran `swift test`.
- The build completed, but the test run failed because local Postgres and Redis were not available at `127.0.0.1:5432` and `127.0.0.1:6379`, so database-backed tests exited with connection-refused errors.

# Notes
- This is a narrow fix set; it does not change the broader ingest or notification pipeline design.