### PR TITLE
Add exact-cycle surface loading for Anvil profile requests

### DIFF
--- a/Sources/App/Controllers/AnvilProfileAnalysisController.swift
+++ b/Sources/App/Controllers/AnvilProfileAnalysisController.swift
@@ -16,16 +16,9 @@ struct AnvilProfileAnalysisController: RouteCollection {
         guard let h3Cell = req.query[Int64.self, at: "h3"] else {
             throw Abort(.badRequest, reason: "Missing required query parameter 'h3'.")
         }
-        let surfaceHeightMslM = await req.selectedSurfaceHeightMslM(
-            for: h3Cell,
-            application: req.application
-        )
 
         do {
-            let response = try await req.application.anvilProfileAnalysisProvider.analyzeProfile(
-                for: h3Cell,
-                surfaceHeightMslM: surfaceHeightMslM
-            )
+            let response = try await req.application.anvilProfileAnalysisProvider.analyzeProfile(for: h3Cell)
             return try req.contentEncode(response, status: .ok)
         } catch let error as AnvilProfileAnalysisError {
             throw error.asAbort()
@@ -38,20 +31,5 @@ private extension Request {
         let response = Response(status: status)
         try response.content.encode(value)
         return response
-    }
-
-    func selectedSurfaceHeightMslM(for h3Cell: Int64, application: Application) async -> Double? {
-        do {
-            return try await application.stormSetupProvider.currentSnapshot(for: h3Cell).surfaceHeightMslM
-        } catch {
-            application.logger.warning(
-                "Unable to resolve selected surface height for Anvil analysis; continuing without below-ground filtering.",
-                metadata: [
-                    "h3": .string("\(h3Cell)"),
-                    "error": .string(String(describing: error))
-                ]
-            )
-            return nil
-        }
     }
 }

--- a/Sources/App/Controllers/AnvilProfilePreviewController.swift
+++ b/Sources/App/Controllers/AnvilProfilePreviewController.swift
@@ -22,16 +22,9 @@ struct AnvilProfilePreviewController: RouteCollection {
 
         let query = try req.query.decode(ProfilePreviewQuery.self)
         let h3Cell = try normalizedH3Cell(from: query.h3)
-        let surfaceHeightMslM = await selectedSurfaceHeightMslM(
-            for: h3Cell,
-            application: req.application
-        )
 
         do {
-            return try await req.application.anvilProfilePreviewProvider.previewProfile(
-                for: h3Cell,
-                surfaceHeightMslM: surfaceHeightMslM
-            )
+            return try await req.application.anvilProfilePreviewProvider.previewProfile(for: h3Cell)
         } catch let error as AnvilProfilePreviewError {
             throw error.asAbort()
         }
@@ -52,22 +45,6 @@ private extension AnvilProfilePreviewController {
         guard let h3Cell = Int64(trimmed) else {
             throw Abort(.badRequest, reason: "Invalid H3 cell '\(rawValue)'. Expected a signed 64-bit integer.")
         }
-
         return h3Cell
-    }
-
-    func selectedSurfaceHeightMslM(for h3Cell: Int64, application: Application) async -> Double? {
-        do {
-            return try await application.stormSetupProvider.currentSnapshot(for: h3Cell).surfaceHeightMslM
-        } catch {
-            application.logger.warning(
-                "Unable to resolve selected surface height for Anvil preview; continuing without below-ground filtering.",
-                metadata: [
-                    "h3": .string("\(h3Cell)"),
-                    "error": .string(String(describing: error))
-                ]
-            )
-            return nil
-        }
     }
 }

--- a/Sources/App/Models/API/AnvilAnalyzeProfilePreviewResponse.swift
+++ b/Sources/App/Models/API/AnvilAnalyzeProfilePreviewResponse.swift
@@ -16,7 +16,7 @@ struct AnvilAnalyzeProfilePreviewDebugDTO: Content, Sendable, Equatable {
     let centroid: StormSetupCentroid
     let selectedMessageCount: Int
     let selectedPressureLevels: [Int]
-    let surfacePressureMb: Int
+    let surfacePressureMb: Double
     let surfaceSubsetCacheHit: Bool
     let rangeCount: Int
     let totalSelectedRangeBytes: Int64

--- a/Sources/App/Models/API/AnvilAnalyzeProfilePreviewResponse.swift
+++ b/Sources/App/Models/API/AnvilAnalyzeProfilePreviewResponse.swift
@@ -16,6 +16,8 @@ struct AnvilAnalyzeProfilePreviewDebugDTO: Content, Sendable, Equatable {
     let centroid: StormSetupCentroid
     let selectedMessageCount: Int
     let selectedPressureLevels: [Int]
+    let surfacePressureMb: Int
+    let surfaceSubsetCacheHit: Bool
     let rangeCount: Int
     let totalSelectedRangeBytes: Int64
     let pressureLevelsRequested: [Int]

--- a/Sources/App/StormSetup/AnvilIngredientEvidence.swift
+++ b/Sources/App/StormSetup/AnvilIngredientEvidence.swift
@@ -23,11 +23,28 @@ struct AnvilIngredientEvidence: Content, Sendable, Equatable {
         response: AnvilAnalyzeProfileResponse,
         additionalWarnings: [String]
     ) {
-        let normalized = AnvilSurfaceProfileNormalizer().normalize(
-            response: response,
-            additionalWarnings: additionalWarnings
+        let combinedWarnings = response.quality.warnings + additionalWarnings
+        let diagnostics = AnvilIngredientDiagnostics(
+            hasEffectiveLayer: response.effectiveLayer.status.lowercased() == "found",
+            hasStormMotion: response.stormMotion.status.lowercased() == "computed",
+            qualityProfileLevelCount: response.quality.profileLevelCount,
+            warnings: combinedWarnings
         )
-        self = normalized
+
+        let scp = response.scp.map { AnvilIngredientMetricEvidence(support: Self.supportBand(forSCP: $0)) }
+        let stpSupports = [response.stpCin, response.stpFixed]
+            .compactMap { $0 }
+            .map(Self.supportBand(forSTP:))
+        let stp = stpSupports.max().map { AnvilIngredientMetricEvidence(support: $0) }
+        let ship = response.ship.map { AnvilIngredientMetricEvidence(support: Self.supportBand(forSHIP: $0)) }
+        let supportCount = [scp, stp, ship].compactMap { $0 }.count
+
+        self.status = diagnostics.isDegraded || supportCount == 0 ? .degraded : .available
+        self.reason = nil
+        self.scp = scp
+        self.stp = stp
+        self.ship = ship
+        self.diagnostics = diagnostics
     }
 
     static func unavailable(reason: String) -> AnvilIngredientEvidence {
@@ -72,6 +89,33 @@ struct AnvilIngredientEvidence: Content, Sendable, Equatable {
 
     var isDegraded: Bool {
         status != .available || diagnostics.isDegraded || supportCount == 0
+    }
+
+    private static func supportBand(forSCP value: Double) -> IngredientSupport {
+        switch value {
+        case ..<0.5: return .weak
+        case ..<1.5: return .conditional
+        case ..<3: return .supportive
+        default: return .strong
+        }
+    }
+
+    private static func supportBand(forSTP value: Double) -> IngredientSupport {
+        switch value {
+        case ..<0.5: return .weak
+        case ..<1.25: return .conditional
+        case ..<2.5: return .supportive
+        default: return .strong
+        }
+    }
+
+    private static func supportBand(forSHIP value: Double) -> IngredientSupport {
+        switch value {
+        case ..<0.5: return .weak
+        case ..<1: return .conditional
+        case ..<2: return .supportive
+        default: return .strong
+        }
     }
 }
 

--- a/Sources/App/StormSetup/AnvilIngredientEvidence.swift
+++ b/Sources/App/StormSetup/AnvilIngredientEvidence.swift
@@ -23,30 +23,11 @@ struct AnvilIngredientEvidence: Content, Sendable, Equatable {
         response: AnvilAnalyzeProfileResponse,
         additionalWarnings: [String]
     ) {
-        let combinedWarnings = response.quality.warnings + additionalWarnings
-        let diagnostics = AnvilIngredientDiagnostics(
-            hasEffectiveLayer: response.effectiveLayer.status.lowercased() == "found",
-            hasStormMotion: response.stormMotion.status.lowercased() == "computed",
-            qualityProfileLevelCount: response.quality.profileLevelCount,
-            warnings: combinedWarnings
+        let normalized = AnvilSurfaceProfileNormalizer().normalize(
+            response: response,
+            additionalWarnings: additionalWarnings
         )
-
-        let scp = response.scp.map { AnvilIngredientMetricEvidence(support: Self.supportBand(forSCP: $0)) }
-
-        let stpSupports = [response.stpCin, response.stpFixed]
-            .compactMap { $0 }
-            .map(Self.supportBand(forSTP:))
-        let stp = stpSupports.max().map { AnvilIngredientMetricEvidence(support: $0) }
-
-        let ship = response.ship.map { AnvilIngredientMetricEvidence(support: Self.supportBand(forSHIP: $0)) }
-        let supportCount = [scp, stp, ship].compactMap { $0 }.count
-
-        self.status = diagnostics.isDegraded || supportCount == 0 ? .degraded : .available
-        self.reason = nil
-        self.scp = scp
-        self.stp = stp
-        self.ship = ship
-        self.diagnostics = diagnostics
+        self = normalized
     }
 
     static func unavailable(reason: String) -> AnvilIngredientEvidence {
@@ -65,7 +46,7 @@ struct AnvilIngredientEvidence: Content, Sendable, Equatable {
         )
     }
 
-    private init(
+    init(
         status: AnvilIngredientEvidenceStatus,
         reason: String?,
         scp: AnvilIngredientMetricEvidence?,
@@ -91,45 +72,6 @@ struct AnvilIngredientEvidence: Content, Sendable, Equatable {
 
     var isDegraded: Bool {
         status != .available || diagnostics.isDegraded || supportCount == 0
-    }
-
-    private static func supportBand(forSCP value: Double) -> IngredientSupport {
-        switch value {
-        case ..<0.5:
-            return .weak
-        case ..<1.5:
-            return .conditional
-        case ..<3:
-            return .supportive
-        default:
-            return .strong
-        }
-    }
-
-    private static func supportBand(forSTP value: Double) -> IngredientSupport {
-        switch value {
-        case ..<0.5:
-            return .weak
-        case ..<1.25:
-            return .conditional
-        case ..<2.5:
-            return .supportive
-        default:
-            return .strong
-        }
-    }
-
-    private static func supportBand(forSHIP value: Double) -> IngredientSupport {
-        switch value {
-        case ..<0.5:
-            return .weak
-        case ..<1:
-            return .conditional
-        case ..<2:
-            return .supportive
-        default:
-            return .strong
-        }
     }
 }
 

--- a/Sources/App/StormSetup/AnvilProfileAnalysisProvider.swift
+++ b/Sources/App/StormSetup/AnvilProfileAnalysisProvider.swift
@@ -2,16 +2,10 @@ import Foundation
 import Vapor
 
 protocol AnvilProfileAnalysisProviding: Sendable {
-    func analyzeProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfileAnalysisResponse
+    func analyzeProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfileAnalysisResponse
 }
 
 extension AnvilProfileAnalysisProviding {
-    func analyzeProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfileAnalysisResponse {
-        try await analyzeProfile(for: h3Cell, surfaceHeightMslM: nil)
-    }
 }
 
 enum AnvilProfileAnalysisError: Error, Sendable, CustomStringConvertible {
@@ -89,10 +83,7 @@ struct DefaultAnvilProfileAnalysisProvider: AnvilProfileAnalysisProviding {
         )
     }
 
-    func analyzeProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfileAnalysisResponse {
+    func analyzeProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfileAnalysisResponse {
         let client: any AnvilProfileClient
         if let directClient {
             client = directClient
@@ -111,10 +102,7 @@ struct DefaultAnvilProfileAnalysisProvider: AnvilProfileAnalysisProviding {
 
         let preview: AnvilAnalyzeProfilePreviewResponse
         do {
-            preview = try await previewProvider.previewProfile(
-                for: h3Cell,
-                surfaceHeightMslM: surfaceHeightMslM
-            )
+            preview = try await previewProvider.previewProfile(for: h3Cell)
         } catch let error as AnvilProfilePreviewError {
             throw classify(previewError: error)
         } catch {

--- a/Sources/App/StormSetup/AnvilProfilePreviewProvider.swift
+++ b/Sources/App/StormSetup/AnvilProfilePreviewProvider.swift
@@ -62,7 +62,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         self.h3Resolver = h3Resolver
         self.hrrrRunResolver = hrrrRunResolver ?? DefaultHrrrRunResolver(dateProvider: dateProvider)
         self.pressureArtifactCatalogLookupService = pressureArtifactCatalogLookupService
-        self.surfaceProfileLoader = surfaceProfileLoader ?? DefaultSyntheticAnvilSurfaceProfileLoader()
+        self.surfaceProfileLoader = surfaceProfileLoader ?? DefaultUnavailableAnvilSurfaceProfileLoader()
         self.pressureSourceResolver = pressureSourceResolver
         self.pressureProfileLoader = pressureProfileLoader
         self.requestBuilder = AnvilProfileRequestBuilder(h3Resolver: h3Resolver)
@@ -523,6 +523,18 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
                 for: inputResolution,
                 around: centroid
             )
+        } catch let error as AnvilSurfaceProfileNormalizationError {
+            logger.warning(
+                "Anvil preview exact-cycle surface row rejected.",
+                metadata: surfaceDiagnosticsMetadata(
+                    pressureSource: sourceCandidate,
+                    surfaceCandidate: expectedSurfaceCandidate,
+                    surfaceStage: .incomplete,
+                    surfaceRowIncluded: false,
+                    reason: error.description
+                )
+            )
+            throw AnvilProfilePreviewError.unusableProfile(reason: error.description)
         } catch let error as AnvilProfilePreviewError {
             logger.warning(
                 "Anvil preview exact-cycle surface row rejected.",
@@ -568,22 +580,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
             )
         }
 
-        guard let surfaceLevel = makeSurfaceLevel(from: loadResult.samples) else {
-            logger.warning(
-                "Anvil preview exact-cycle surface row rejected.",
-                metadata: surfaceDiagnosticsMetadata(
-                    pressureSource: sourceCandidate,
-                    surfaceCandidate: expectedSurfaceCandidate,
-                    surfaceStage: .incomplete,
-                    surfaceSubsetCacheHit: loadResult.subsetCacheResult.cacheHit,
-                    surfaceRowIncluded: false,
-                    reason: "Matching surface profile was incomplete. Missing or invalid surface fields were not reported."
-                )
-            )
-            throw AnvilProfilePreviewError.unusableProfile(
-                reason: "Matching surface profile was incomplete. Missing or invalid surface fields were not reported."
-            )
-        }
+        let surfaceLevel = loadResult.surfaceLevel
 
         logger.info(
             "Anvil preview exact-cycle surface row included.",
@@ -600,78 +597,6 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         return SurfaceLevelLoadResult(
             level: surfaceLevel,
             subsetCacheHit: loadResult.subsetCacheResult.cacheHit
-        )
-    }
-
-    private func makeSurfaceLevel(
-        from samples: [HrrrFieldSample]
-    ) -> StormSetupPressureProfileLevel? {
-        struct Draft {
-            var pressureMb: Double?
-            var heightMslM: Double?
-            var temperatureC: Double?
-            var dewpointC: Double?
-            var uWindMs: Double?
-            var vWindMs: Double?
-        }
-
-        var draft = Draft()
-
-        for sample in samples {
-            let point = sample.point
-            guard let descriptor = point.inventoryDescriptor, let value = point.value else {
-                continue
-            }
-
-            let variable = descriptor.variable.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
-            let level = descriptor.level.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-
-            switch (variable, level) {
-            case ("PRES", "surface"):
-                if draft.pressureMb == nil {
-                    draft.pressureMb = value / 100
-                }
-            case ("HGT", "surface"):
-                if draft.heightMslM == nil {
-                    draft.heightMslM = value
-                }
-            case ("TMP", "2 m above ground"):
-                if draft.temperatureC == nil {
-                    draft.temperatureC = value - 273.15
-                }
-            case ("DPT", "2 m above ground"):
-                if draft.dewpointC == nil {
-                    draft.dewpointC = value - 273.15
-                }
-            case ("UGRD", "10 m above ground"):
-                if draft.uWindMs == nil {
-                    draft.uWindMs = value
-                }
-            case ("VGRD", "10 m above ground"):
-                if draft.vWindMs == nil {
-                    draft.vWindMs = value
-                }
-            default:
-                continue
-            }
-        }
-
-        guard let pressureMb = draft.pressureMb,
-              let heightMslM = draft.heightMslM,
-              let temperatureC = draft.temperatureC,
-              let dewpointC = draft.dewpointC,
-              let uWindMs = draft.uWindMs,
-              let vWindMs = draft.vWindMs else {
-            return nil
-        }
-
-        return StormSetupPressureProfileLevel(
-            pressureMb: Int(pressureMb.rounded()),
-            heightMslM: heightMslM,
-            temperatureC: temperatureC,
-            dewpointC: dewpointC,
-            uWindMs: uWindMs,
-            vWindMs: vWindMs
         )
     }
 
@@ -723,6 +648,13 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         case .pressureNotStrictlyDescending(let previousPressureMb, let pressureMb):
             return .unusableProfile(
                 reason: "Pressure levels were not strictly descending: \(previousPressureMb) then \(pressureMb). \(droppedSummary)"
+            )
+        case .surfaceHeightNotBelowFirstPressureLevel(
+            let surfaceHeightMslM,
+            let firstPressureLevelHeightMslM
+        ):
+            return .unusableProfile(
+                reason: "Surface height \(surfaceHeightMslM)m was not below the first retained pressure-level height \(firstPressureLevelHeightMslM)m. \(droppedSummary)"
             )
         }
     }
@@ -838,7 +770,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         surfaceCandidate: HrrrRunCandidate,
         surfaceStage: SurfaceDiagnosticsStage,
         surfaceSubsetCacheHit: Bool? = nil,
-        surfacePressureMb: Int? = nil,
+        surfacePressureMb: Double? = nil,
         surfaceRowIncluded: Bool? = nil,
         reason: String? = nil
     ) -> Logger.Metadata {
@@ -876,7 +808,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
 }
 
 private struct SurfaceLevelLoadResult: Sendable {
-    let level: StormSetupPressureProfileLevel
+    let level: StormSetupSurfaceProfileLevel
     let subsetCacheHit: Bool
 }
 
@@ -903,76 +835,15 @@ private struct AnvilProfilePreviewProviderKey: StorageKey {
     typealias Value = any AnvilProfilePreviewProviding
 }
 
-private struct DefaultSyntheticAnvilSurfaceProfileLoader: HrrrAnvilSurfaceProfileLoading {
+private struct DefaultUnavailableAnvilSurfaceProfileLoader: HrrrAnvilSurfaceProfileLoading {
     func loadSurfaceProfile(
         for resolution: HrrrRunResolution,
         around centroid: StormSetupCentroid
     ) async throws -> HrrrAnvilSurfaceProfileLoadResult {
-        guard let primaryCandidate = resolution.primaryCandidate else {
-            throw AnvilProfilePreviewError.upstreamUnavailable(
-                reason: "No HRRR surface candidate was available for the preview run."
-            )
-        }
-
-        let surfaceCandidate = HrrrRunCandidate(
-            model: primaryCandidate.model,
-            product: .wrfsfc,
-            domain: primaryCandidate.domain,
-            runTime: primaryCandidate.runTime,
-            forecastHour: primaryCandidate.forecastHour,
-            fieldSetVersion: .anvilSurfaceV1
-        )
-        let sourceResolution = HrrrRunResolution(
-            targetValidTime: resolution.targetValidTime,
-            candidates: [surfaceCandidate]
-        )
-        let source = HrrrNomadsURLBuilder().makeSourceMetadata(
-            for: surfaceCandidate,
-            around: centroid
-        )
-
-        return HrrrAnvilSurfaceProfileLoadResult(
-            sourceResolution: sourceResolution,
-            subsetCacheResult: GribSubsetCacheResult(
-                source: source,
-                localFileURL: URL(fileURLWithPath: "/private/tmp/arcus-signal-synthetic-surface.grib2"),
-                byteSize: 1_024,
-                fetchedAt: Date(),
-                expiresAt: Date().addingTimeInterval(3_600),
-                cacheHit: false
-            ),
-            samples: [
-                HrrrFieldSample(
-                    requestedLongitude: centroid.longitude,
-                    requestedLatitude: centroid.latitude,
-                    point: Wgrib2PointSample.parse(from: "1:0:d=2026060313:PRES:surface:9 hour fcst:lon=-104.47,lat=39.79,val=94000")
-                ),
-                HrrrFieldSample(
-                    requestedLongitude: centroid.longitude,
-                    requestedLatitude: centroid.latitude,
-                    point: Wgrib2PointSample.parse(from: "2:0:d=2026060313:HGT:surface:9 hour fcst:lon=-104.47,lat=39.79,val=1234")
-                ),
-                HrrrFieldSample(
-                    requestedLongitude: centroid.longitude,
-                    requestedLatitude: centroid.latitude,
-                    point: Wgrib2PointSample.parse(from: "3:0:d=2026060313:TMP:2 m above ground:9 hour fcst:lon=-104.47,lat=39.79,val=295.15")
-                ),
-                HrrrFieldSample(
-                    requestedLongitude: centroid.longitude,
-                    requestedLatitude: centroid.latitude,
-                    point: Wgrib2PointSample.parse(from: "4:0:d=2026060313:DPT:2 m above ground:9 hour fcst:lon=-104.47,lat=39.79,val=289.15")
-                ),
-                HrrrFieldSample(
-                    requestedLongitude: centroid.longitude,
-                    requestedLatitude: centroid.latitude,
-                    point: Wgrib2PointSample.parse(from: "5:0:d=2026060313:UGRD:10 m above ground:9 hour fcst:lon=-104.47,lat=39.79,val=-4.25")
-                ),
-                HrrrFieldSample(
-                    requestedLongitude: centroid.longitude,
-                    requestedLatitude: centroid.latitude,
-                    point: Wgrib2PointSample.parse(from: "6:0:d=2026060313:VGRD:10 m above ground:9 hour fcst:lon=-104.47,lat=39.79,val=6.5")
-                )
-            ]
+        _ = resolution
+        _ = centroid
+        throw AnvilProfilePreviewError.internalExecutionFailure(
+            reason: "An HRRR surface profile loader was not configured."
         )
     }
 }

--- a/Sources/App/StormSetup/AnvilProfilePreviewProvider.swift
+++ b/Sources/App/StormSetup/AnvilProfilePreviewProvider.swift
@@ -517,7 +517,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
             domain: sourceCandidate.domain,
             runTime: cycleRunTime,
             forecastHour: cycleForecastHour,
-            fieldSetVersion: HrrrProduct.wrfsfc.defaultFieldSetVersion
+            fieldSetVersion: .anvilSurfaceV1
         )
         let expectedResolution = HrrrRunResolution(
             targetValidTime: targetValidTime,
@@ -634,7 +634,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
             domain: sourceCandidate.domain,
             runTime: readyArtifact.runTime,
             forecastHour: readyArtifact.forecastHour,
-            fieldSetVersion: HrrrProduct.wrfsfc.defaultFieldSetVersion
+            fieldSetVersion: .anvilSurfaceV1
         )
     }
 
@@ -804,14 +804,14 @@ private struct DefaultSyntheticAnvilSurfaceProfileLoader: HrrrAnvilSurfaceProfil
             domain: primaryCandidate.domain,
             runTime: primaryCandidate.runTime,
             forecastHour: primaryCandidate.forecastHour,
-            fieldSetVersion: HrrrProduct.wrfsfc.defaultFieldSetVersion
+            fieldSetVersion: .anvilSurfaceV1
         )
         let sourceResolution = HrrrRunResolution(
             targetValidTime: resolution.targetValidTime,
             candidates: [surfaceCandidate]
         )
         let source = HrrrNomadsURLBuilder().makeSourceMetadata(
-            for: primaryCandidate,
+            for: surfaceCandidate,
             around: centroid
         )
 

--- a/Sources/App/StormSetup/AnvilProfilePreviewProvider.swift
+++ b/Sources/App/StormSetup/AnvilProfilePreviewProvider.swift
@@ -145,19 +145,12 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
             for candidate in runResolution.candidates {
                 try Task.checkCancellation()
                 let pressureCandidate = makePressureCandidate(from: candidate)
+                var readyArtifact: PressureArtifactCatalogReadyArtifact?
                 do {
-                    if let readyArtifact = try await pressureArtifactCatalogLookupService.readyArtifact(
+                    readyArtifact = try await pressureArtifactCatalogLookupService.readyArtifact(
                         for: pressureCandidate
-                    ) {
-                        try Task.checkCancellation()
-                    return try await previewReadyArtifact(
-                        readyArtifact,
-                        sourceCandidate: pressureCandidate,
-                        h3Cell: resolved.h3Cell,
-                        centroid: resolved.centroid,
                     )
-                }
-            } catch let error as AnvilProfilePreviewError {
+                } catch let error as AnvilProfilePreviewError {
                     switch error {
                     case .upstreamUnavailable:
                         upstreamFailures.append(error.description)
@@ -169,6 +162,16 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
                 } catch {
                     try rethrowCancellationIfNeeded(error)
                     internalFailures.append(String(describing: error))
+                }
+
+                if let readyArtifact {
+                    try Task.checkCancellation()
+                    return try await previewReadyArtifact(
+                        readyArtifact,
+                        sourceCandidate: pressureCandidate,
+                        h3Cell: resolved.h3Cell,
+                        centroid: resolved.centroid,
+                    )
                 }
             }
 
@@ -281,7 +284,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
             targetValidTime: targetValidTime
         )
         let surfaceLevelLoadResult = try await loadSurfaceLevel(
-            from: candidate,
+            from: sourceResolution.candidate,
             cycleRunTime: sourceResolution.source.runTime ?? candidate.runTime,
             cycleForecastHour: sourceResolution.source.forecastHour ?? candidate.forecastHour,
             targetValidTime: targetValidTime,

--- a/Sources/App/StormSetup/AnvilProfilePreviewProvider.swift
+++ b/Sources/App/StormSetup/AnvilProfilePreviewProvider.swift
@@ -48,6 +48,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
     private let h3Resolver: any StormSetupH3Resolving
     private let hrrrRunResolver: any HrrrRunResolving
     private let pressureArtifactCatalogLookupService: (any PressureArtifactCatalogLookupProviding)?
+    private let surfaceProfileLoader: any HrrrAnvilSurfaceProfileLoading
     private let pressureSourceResolver: any HrrrPressureDirectObjectResolving
     private let pressureProfileLoader: any HrrrPressureProfileLoading
     private let surfaceHeightMslM: Double?
@@ -58,6 +59,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         dateProvider: any StormSetupDateProviding = SystemStormSetupDateProvider(),
         hrrrRunResolver: (any HrrrRunResolving)? = nil,
         pressureArtifactCatalogLookupService: (any PressureArtifactCatalogLookupProviding)? = nil,
+        surfaceProfileLoader: (any HrrrAnvilSurfaceProfileLoading)? = nil,
         pressureSourceResolver: any HrrrPressureDirectObjectResolving,
         pressureProfileLoader: any HrrrPressureProfileLoading,
         surfaceHeightMslM: Double? = nil
@@ -65,6 +67,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         self.h3Resolver = h3Resolver
         self.hrrrRunResolver = hrrrRunResolver ?? DefaultHrrrRunResolver(dateProvider: dateProvider)
         self.pressureArtifactCatalogLookupService = pressureArtifactCatalogLookupService
+        self.surfaceProfileLoader = surfaceProfileLoader ?? DefaultSyntheticAnvilSurfaceProfileLoader()
         self.pressureSourceResolver = pressureSourceResolver
         self.pressureProfileLoader = pressureProfileLoader
         self.surfaceHeightMslM = surfaceHeightMslM
@@ -84,6 +87,16 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
             maximumStaleAgeSeconds: configuration.pressureArtifactMaxStaleAgeSeconds,
             logger: application.logger
         )
+        let surfaceSubsetLoader = NomadsGribDownloader(
+            cache: GribSubsetCache(
+                httpClient: httpClient,
+                rootURL: configuration.gribSubsetCacheRootURL,
+                dateProvider: dateProvider,
+                retentionDuration: configuration.gribSubsetCacheRetentionSeconds,
+                maximumByteCount: configuration.gribSubsetMaximumByteCount
+            ),
+            hrrrNomadsURLBuilder: HrrrNomadsURLBuilder()
+        )
         let pressureSourceResolver = DefaultHrrrPressureDirectObjectResolver(httpClient: httpClient)
         let pressureProfileLoader = DefaultHrrrPressureProfileLoader(
             httpClient: httpClient,
@@ -94,13 +107,18 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
                 dateProvider: dateProvider,
                 retentionDuration: configuration.gribSubsetCacheRetentionSeconds,
                 maximumByteCount: configuration.gribSubsetMaximumByteCount
-            ),
+                ),
+                fieldSampler: HrrrFieldSampler(client: configuration.makeWgrib2Client())
+            )
+        let surfaceProfileLoader = DefaultHrrrAnvilSurfaceProfileLoader(
+            subsetLoader: surfaceSubsetLoader,
             fieldSampler: HrrrFieldSampler(client: configuration.makeWgrib2Client())
         )
 
         self.init(
             dateProvider: dateProvider,
             pressureArtifactCatalogLookupService: pressureArtifactCatalogLookupService,
+            surfaceProfileLoader: surfaceProfileLoader,
             pressureSourceResolver: pressureSourceResolver,
             pressureProfileLoader: pressureProfileLoader
         )
@@ -110,11 +128,9 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         for h3Cell: Int64,
         surfaceHeightMslM: Double? = nil
     ) async throws -> AnvilAnalyzeProfilePreviewResponse {
+        _ = surfaceHeightMslM
         let resolved = try h3Resolver.resolve(h3Cell: h3Cell)
         let runResolution = hrrrRunResolver.resolveRunCandidates()
-        let selectedSurfaceHeightMslM = surfaceHeightMslM ?? self.surfaceHeightMslM
-        let validatedSurfaceHeightMslM = validateSurfaceHeightMslM(selectedSurfaceHeightMslM)
-        let surfaceHeightWarning = surfaceHeightWarning(for: selectedSurfaceHeightMslM, validated: validatedSurfaceHeightMslM)
 
         guard !runResolution.candidates.isEmpty else {
             throw AnvilProfilePreviewError.upstreamUnavailable(
@@ -140,15 +156,14 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
                         for: pressureCandidate
                     ) {
                         try Task.checkCancellation()
-                        return try await previewReadyArtifact(
-                            readyArtifact,
-                            h3Cell: resolved.h3Cell,
-                            centroid: resolved.centroid,
-                            surfaceHeightMslM: validatedSurfaceHeightMslM,
-                            surfaceHeightWarning: surfaceHeightWarning
-                        )
-                    }
-                } catch let error as AnvilProfilePreviewError {
+                    return try await previewReadyArtifact(
+                        readyArtifact,
+                        sourceCandidate: pressureCandidate,
+                        h3Cell: resolved.h3Cell,
+                        centroid: resolved.centroid,
+                    )
+                }
+            } catch let error as AnvilProfilePreviewError {
                     switch error {
                     case .upstreamUnavailable:
                         upstreamFailures.append(error.description)
@@ -168,13 +183,16 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
                     for: pressureResolution
                 ) {
                     try Task.checkCancellation()
+                    let staleSourceCandidate = makeStaleSurfaceSourceCandidate(
+                        from: pressureResolution.primaryCandidate ?? pressureResolution.candidates.first!,
+                        matching: staleArtifact
+                    )
                     return try await previewReadyArtifact(
                         staleArtifact,
+                        sourceCandidate: staleSourceCandidate,
                         h3Cell: resolved.h3Cell,
                         centroid: resolved.centroid,
                         staleWarning: makeStaleWarning(for: staleArtifact, targetValidTime: pressureResolution.targetValidTime),
-                        surfaceHeightMslM: validatedSurfaceHeightMslM,
-                        surfaceHeightWarning: surfaceHeightWarning
                     )
                 }
             } catch let error as AnvilProfilePreviewError {
@@ -223,8 +241,6 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
                     h3Cell: resolved.h3Cell,
                     centroid: resolved.centroid,
                     targetValidTime: runResolution.targetValidTime,
-                    surfaceHeightMslM: validatedSurfaceHeightMslM,
-                    surfaceHeightWarning: surfaceHeightWarning
                 )
                 try Task.checkCancellation()
                 return preview
@@ -265,17 +281,22 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         h3Cell: Int64,
         centroid: StormSetupCentroid,
         targetValidTime: Date,
-        surfaceHeightMslM: Double?,
-        surfaceHeightWarning: String?
     ) async throws -> AnvilAnalyzeProfilePreviewResponse {
         let sourceResolution = try await resolvePressureSource(
             for: candidate,
             targetValidTime: targetValidTime
         )
+        let surfaceLevel = try await loadSurfaceLevel(
+            from: candidate,
+            cycleRunTime: sourceResolution.source.runTime ?? candidate.runTime,
+            cycleForecastHour: sourceResolution.source.forecastHour ?? candidate.forecastHour,
+            targetValidTime: targetValidTime,
+            centroid: centroid
+        )
         let loadResult = try await loadPressureProfile(
             sourceResolution: sourceResolution,
             centroid: centroid,
-            surfaceHeightMslM: surfaceHeightMslM
+            surfaceHeightMslM: surfaceLevel.heightMslM
         )
         try Task.checkCancellation()
 
@@ -285,6 +306,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
                 h3Cell: h3Cell,
                 runTime: sourceResolution.source.runTime ?? candidate.runTime,
                 forecastHour: sourceResolution.source.forecastHour ?? candidate.forecastHour,
+                surfaceLevel: surfaceLevel,
                 groupedProfile: loadResult.groupedProfile
             )
         } catch let error as AnvilProfileRequestBuilderError {
@@ -310,8 +332,8 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
             selectedPressureLevels: uniquePressureLevels(from: loadResult.selection),
             rangeCount: loadResult.byteRangePlan.ranges.count,
             totalSelectedRangeBytes: loadResult.subsetCacheResult.byteSize,
-            pressureLevelsRequested: loadResult.selection.requestedLevels.map(\.pressureMb),
-            pressureLevelsRetained: loadResult.groupedProfile.retainedLevels.map(\.pressureMb),
+            pressureLevelsRequested: loadResult.selection.requestedLevels.map { $0.pressureMb },
+            pressureLevelsRetained: loadResult.groupedProfile.retainedLevels.map { $0.pressureMb },
             missingLevels: loadResult.selection.missingLevels.map {
                 AnvilAnalyzeProfilePreviewMissingLevelDTO(
                     pressureMb: $0.pressureMb,
@@ -320,8 +342,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
             },
             warnings: makeWarnings(
                 for: buildResult.warnings,
-                ignoredSampleCount: loadResult.groupedProfile.ignoredSamples.count,
-                additionalWarnings: surfaceHeightWarning.map { [$0] } ?? []
+                ignoredSampleCount: loadResult.groupedProfile.ignoredSamples.count
             ),
             subsetCacheHit: loadResult.subsetCacheResult.cacheHit,
             primaryDownloadURL: sourceResolution.source.primaryDownloadURL,
@@ -335,16 +356,22 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
 
     private func previewReadyArtifact(
         _ readyArtifact: PressureArtifactCatalogReadyArtifact,
+        sourceCandidate: HrrrRunCandidate,
         h3Cell: Int64,
         centroid: StormSetupCentroid,
-        staleWarning: String? = nil,
-        surfaceHeightMslM: Double?,
-        surfaceHeightWarning: String?
+        staleWarning: String? = nil
     ) async throws -> AnvilAnalyzeProfilePreviewResponse {
+        let surfaceLevel = try await loadSurfaceLevel(
+            from: sourceCandidate,
+            cycleRunTime: readyArtifact.runTime,
+            cycleForecastHour: readyArtifact.forecastHour,
+            targetValidTime: readyArtifact.validTime,
+            centroid: centroid
+        )
         let loadResult = try await loadPressureProfile(
             readyArtifact: readyArtifact,
             centroid: centroid,
-            surfaceHeightMslM: surfaceHeightMslM
+            surfaceHeightMslM: surfaceLevel.heightMslM
         )
 
         let buildResult: AnvilProfileRequestBuildResult
@@ -353,6 +380,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
                 h3Cell: h3Cell,
                 runTime: readyArtifact.runTime,
                 forecastHour: readyArtifact.forecastHour,
+                surfaceLevel: surfaceLevel,
                 groupedProfile: loadResult.groupedProfile
             )
         } catch let error as AnvilProfileRequestBuilderError {
@@ -378,8 +406,8 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
             selectedPressureLevels: uniquePressureLevels(from: loadResult.selection),
             rangeCount: loadResult.byteRangePlan.ranges.count,
             totalSelectedRangeBytes: loadResult.subsetCacheResult.byteSize,
-            pressureLevelsRequested: loadResult.selection.requestedLevels.map(\.pressureMb),
-            pressureLevelsRetained: loadResult.groupedProfile.retainedLevels.map(\.pressureMb),
+            pressureLevelsRequested: loadResult.selection.requestedLevels.map { $0.pressureMb },
+            pressureLevelsRetained: loadResult.groupedProfile.retainedLevels.map { $0.pressureMb },
             missingLevels: loadResult.selection.missingLevels.map {
                 AnvilAnalyzeProfilePreviewMissingLevelDTO(
                     pressureMb: $0.pressureMb,
@@ -389,7 +417,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
             warnings: makeWarnings(
                 for: buildResult.warnings,
                 ignoredSampleCount: loadResult.groupedProfile.ignoredSamples.count,
-                additionalWarnings: [staleWarning, surfaceHeightWarning].compactMap { $0 }
+                additionalWarnings: [staleWarning].compactMap { $0 }
             ),
             subsetCacheHit: loadResult.subsetCacheResult.cacheHit,
             primaryDownloadURL: readyArtifact.localFileURL,
@@ -458,6 +486,132 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         }
     }
 
+    private func loadSurfaceLevel(
+        from sourceCandidate: HrrrRunCandidate,
+        cycleRunTime: Date,
+        cycleForecastHour: Int,
+        targetValidTime: Date,
+        centroid: StormSetupCentroid
+    ) async throws -> StormSetupPressureProfileLevel {
+        let inputResolution = HrrrRunResolution(
+            targetValidTime: targetValidTime,
+            candidates: [sourceCandidate]
+        )
+
+        let loadResult: HrrrAnvilSurfaceProfileLoadResult
+        do {
+            loadResult = try await surfaceProfileLoader.loadSurfaceProfile(
+                for: inputResolution,
+                around: centroid
+            )
+        } catch let error as AnvilProfilePreviewError {
+            throw error
+        } catch {
+            try rethrowCancellationIfNeeded(error)
+            throw AnvilProfilePreviewError.upstreamUnavailable(reason: String(describing: error))
+        }
+
+        let expectedSurfaceCandidate = HrrrRunCandidate(
+            model: sourceCandidate.model,
+            product: .wrfsfc,
+            domain: sourceCandidate.domain,
+            runTime: cycleRunTime,
+            forecastHour: cycleForecastHour,
+            fieldSetVersion: HrrrProduct.wrfsfc.defaultFieldSetVersion
+        )
+        let expectedResolution = HrrrRunResolution(
+            targetValidTime: targetValidTime,
+            candidates: [expectedSurfaceCandidate]
+        )
+
+        guard loadResult.sourceResolution == expectedResolution else {
+            let actualSurfaceCandidate = loadResult.sourceResolution.primaryCandidate?.fileName ?? "unknown"
+            throw AnvilProfilePreviewError.unusableProfile(
+                reason: "Matching surface source identity did not match the expected exact-cycle surface candidate. Expected \(expectedSurfaceCandidate.fileName), got \(actualSurfaceCandidate)."
+            )
+        }
+
+        guard let surfaceLevel = makeSurfaceLevel(from: loadResult.samples) else {
+            throw AnvilProfilePreviewError.unusableProfile(
+                reason: "Matching surface profile was incomplete. Missing or invalid surface fields were not reported."
+            )
+        }
+
+        return surfaceLevel
+    }
+
+    private func makeSurfaceLevel(
+        from samples: [HrrrFieldSample]
+    ) -> StormSetupPressureProfileLevel? {
+        struct Draft {
+            var pressureMb: Double?
+            var heightMslM: Double?
+            var temperatureC: Double?
+            var dewpointC: Double?
+            var uWindMs: Double?
+            var vWindMs: Double?
+        }
+
+        var draft = Draft()
+
+        for sample in samples {
+            let point = sample.point
+            guard let descriptor = point.inventoryDescriptor, let value = point.value else {
+                continue
+            }
+
+            let variable = descriptor.variable.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+            let level = descriptor.level.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+            switch (variable, level) {
+            case ("PRES", "surface"):
+                if draft.pressureMb == nil {
+                    draft.pressureMb = value / 100
+                }
+            case ("HGT", "surface"):
+                if draft.heightMslM == nil {
+                    draft.heightMslM = value
+                }
+            case ("TMP", "2 m above ground"):
+                if draft.temperatureC == nil {
+                    draft.temperatureC = value - 273.15
+                }
+            case ("DPT", "2 m above ground"):
+                if draft.dewpointC == nil {
+                    draft.dewpointC = value - 273.15
+                }
+            case ("UGRD", "10 m above ground"):
+                if draft.uWindMs == nil {
+                    draft.uWindMs = value
+                }
+            case ("VGRD", "10 m above ground"):
+                if draft.vWindMs == nil {
+                    draft.vWindMs = value
+                }
+            default:
+                continue
+            }
+        }
+
+        guard let pressureMb = draft.pressureMb,
+              let heightMslM = draft.heightMslM,
+              let temperatureC = draft.temperatureC,
+              let dewpointC = draft.dewpointC,
+              let uWindMs = draft.uWindMs,
+              let vWindMs = draft.vWindMs else {
+            return nil
+        }
+
+        return StormSetupPressureProfileLevel(
+            pressureMb: Int(pressureMb.rounded()),
+            heightMslM: heightMslM,
+            temperatureC: temperatureC,
+            dewpointC: dewpointC,
+            uWindMs: uWindMs,
+            vWindMs: vWindMs
+        )
+    }
+
     private func makePressureCandidate(from candidate: HrrrRunCandidate) -> HrrrRunCandidate {
         let runTime = StormSetupUTC.calendar.date(byAdding: .hour, value: -1, to: candidate.runTime) ?? candidate.runTime
         return HrrrRunCandidate(
@@ -467,6 +621,20 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
             runTime: runTime,
             forecastHour: candidate.forecastHour + 1,
             fieldSetVersion: HrrrProduct.wrfprsf.defaultFieldSetVersion
+        )
+    }
+
+    private func makeStaleSurfaceSourceCandidate(
+        from sourceCandidate: HrrrRunCandidate,
+        matching readyArtifact: PressureArtifactCatalogReadyArtifact
+    ) -> HrrrRunCandidate {
+        HrrrRunCandidate(
+            model: sourceCandidate.model,
+            product: .wrfsfc,
+            domain: sourceCandidate.domain,
+            runTime: readyArtifact.runTime,
+            forecastHour: readyArtifact.forecastHour,
+            fieldSetVersion: HrrrProduct.wrfsfc.defaultFieldSetVersion
         )
     }
 
@@ -602,25 +770,6 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         return "Pressure artifact stale fallback selected: \(ageSeconds)s older than target valid time \(targetLabel)."
     }
 
-    private func validateSurfaceHeightMslM(_ value: Double?) -> Double? {
-        guard let value, value.isFinite, (-500...9_000).contains(value) else {
-            return nil
-        }
-
-        return value
-    }
-
-    private func surfaceHeightWarning(for selectedSurfaceHeightMslM: Double?, validated: Double?) -> String? {
-        guard selectedSurfaceHeightMslM != nil else {
-            return "Below-ground pressure-level filtering unavailable because selected surface height was missing."
-        }
-
-        guard validated == nil else {
-            return nil
-        }
-
-        return "Below-ground pressure-level filtering unavailable because selected surface height was invalid."
-    }
 }
 
 extension Application {
@@ -636,4 +785,78 @@ extension Application {
 
 private struct AnvilProfilePreviewProviderKey: StorageKey {
     typealias Value = any AnvilProfilePreviewProviding
+}
+
+private struct DefaultSyntheticAnvilSurfaceProfileLoader: HrrrAnvilSurfaceProfileLoading {
+    func loadSurfaceProfile(
+        for resolution: HrrrRunResolution,
+        around centroid: StormSetupCentroid
+    ) async throws -> HrrrAnvilSurfaceProfileLoadResult {
+        guard let primaryCandidate = resolution.primaryCandidate else {
+            throw AnvilProfilePreviewError.upstreamUnavailable(
+                reason: "No HRRR surface candidate was available for the preview run."
+            )
+        }
+
+        let surfaceCandidate = HrrrRunCandidate(
+            model: primaryCandidate.model,
+            product: .wrfsfc,
+            domain: primaryCandidate.domain,
+            runTime: primaryCandidate.runTime,
+            forecastHour: primaryCandidate.forecastHour,
+            fieldSetVersion: HrrrProduct.wrfsfc.defaultFieldSetVersion
+        )
+        let sourceResolution = HrrrRunResolution(
+            targetValidTime: resolution.targetValidTime,
+            candidates: [surfaceCandidate]
+        )
+        let source = HrrrNomadsURLBuilder().makeSourceMetadata(
+            for: primaryCandidate,
+            around: centroid
+        )
+
+        return HrrrAnvilSurfaceProfileLoadResult(
+            sourceResolution: sourceResolution,
+            subsetCacheResult: GribSubsetCacheResult(
+                source: source,
+                localFileURL: URL(fileURLWithPath: "/private/tmp/arcus-signal-synthetic-surface.grib2"),
+                byteSize: 1_024,
+                fetchedAt: Date(),
+                expiresAt: Date().addingTimeInterval(3_600),
+                cacheHit: false
+            ),
+            samples: [
+                HrrrFieldSample(
+                    requestedLongitude: centroid.longitude,
+                    requestedLatitude: centroid.latitude,
+                    point: Wgrib2PointSample.parse(from: "1:0:d=2026060313:PRES:surface:9 hour fcst:lon=-104.47,lat=39.79,val=94000")
+                ),
+                HrrrFieldSample(
+                    requestedLongitude: centroid.longitude,
+                    requestedLatitude: centroid.latitude,
+                    point: Wgrib2PointSample.parse(from: "2:0:d=2026060313:HGT:surface:9 hour fcst:lon=-104.47,lat=39.79,val=1234")
+                ),
+                HrrrFieldSample(
+                    requestedLongitude: centroid.longitude,
+                    requestedLatitude: centroid.latitude,
+                    point: Wgrib2PointSample.parse(from: "3:0:d=2026060313:TMP:2 m above ground:9 hour fcst:lon=-104.47,lat=39.79,val=295.15")
+                ),
+                HrrrFieldSample(
+                    requestedLongitude: centroid.longitude,
+                    requestedLatitude: centroid.latitude,
+                    point: Wgrib2PointSample.parse(from: "4:0:d=2026060313:DPT:2 m above ground:9 hour fcst:lon=-104.47,lat=39.79,val=289.15")
+                ),
+                HrrrFieldSample(
+                    requestedLongitude: centroid.longitude,
+                    requestedLatitude: centroid.latitude,
+                    point: Wgrib2PointSample.parse(from: "5:0:d=2026060313:UGRD:10 m above ground:9 hour fcst:lon=-104.47,lat=39.79,val=-4.25")
+                ),
+                HrrrFieldSample(
+                    requestedLongitude: centroid.longitude,
+                    requestedLatitude: centroid.latitude,
+                    point: Wgrib2PointSample.parse(from: "6:0:d=2026060313:VGRD:10 m above ground:9 hour fcst:lon=-104.47,lat=39.79,val=6.5")
+                )
+            ]
+        )
+    }
 }

--- a/Sources/App/StormSetup/AnvilProfilePreviewProvider.swift
+++ b/Sources/App/StormSetup/AnvilProfilePreviewProvider.swift
@@ -2,16 +2,10 @@ import Foundation
 import Vapor
 
 protocol AnvilProfilePreviewProviding: Sendable {
-    func previewProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfilePreviewResponse
+    func previewProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfilePreviewResponse
 }
 
 extension AnvilProfilePreviewProviding {
-    func previewProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfilePreviewResponse {
-        try await previewProfile(for: h3Cell, surfaceHeightMslM: nil)
-    }
 }
 
 enum AnvilProfilePreviewError: Error, Sendable, CustomStringConvertible {
@@ -51,7 +45,6 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
     private let surfaceProfileLoader: any HrrrAnvilSurfaceProfileLoading
     private let pressureSourceResolver: any HrrrPressureDirectObjectResolving
     private let pressureProfileLoader: any HrrrPressureProfileLoading
-    private let surfaceHeightMslM: Double?
     private let requestBuilder: AnvilProfileRequestBuilder
 
     init(
@@ -61,8 +54,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         pressureArtifactCatalogLookupService: (any PressureArtifactCatalogLookupProviding)? = nil,
         surfaceProfileLoader: (any HrrrAnvilSurfaceProfileLoading)? = nil,
         pressureSourceResolver: any HrrrPressureDirectObjectResolving,
-        pressureProfileLoader: any HrrrPressureProfileLoading,
-        surfaceHeightMslM: Double? = nil
+        pressureProfileLoader: any HrrrPressureProfileLoading
     ) {
         self.h3Resolver = h3Resolver
         self.hrrrRunResolver = hrrrRunResolver ?? DefaultHrrrRunResolver(dateProvider: dateProvider)
@@ -70,7 +62,6 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         self.surfaceProfileLoader = surfaceProfileLoader ?? DefaultSyntheticAnvilSurfaceProfileLoader()
         self.pressureSourceResolver = pressureSourceResolver
         self.pressureProfileLoader = pressureProfileLoader
-        self.surfaceHeightMslM = surfaceHeightMslM
         self.requestBuilder = AnvilProfileRequestBuilder(h3Resolver: h3Resolver)
     }
 
@@ -125,10 +116,8 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
     }
 
     func previewProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double? = nil
+        for h3Cell: Int64
     ) async throws -> AnvilAnalyzeProfilePreviewResponse {
-        _ = surfaceHeightMslM
         let resolved = try h3Resolver.resolve(h3Cell: h3Cell)
         let runResolution = hrrrRunResolver.resolveRunCandidates()
 

--- a/Sources/App/StormSetup/AnvilProfilePreviewProvider.swift
+++ b/Sources/App/StormSetup/AnvilProfilePreviewProvider.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 import Vapor
 
 protocol AnvilProfilePreviewProviding: Sendable {
@@ -46,6 +47,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
     private let pressureSourceResolver: any HrrrPressureDirectObjectResolving
     private let pressureProfileLoader: any HrrrPressureProfileLoading
     private let requestBuilder: AnvilProfileRequestBuilder
+    private let logger: Logger
 
     init(
         h3Resolver: any StormSetupH3Resolving = DefaultStormSetupH3Resolver(),
@@ -54,7 +56,8 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         pressureArtifactCatalogLookupService: (any PressureArtifactCatalogLookupProviding)? = nil,
         surfaceProfileLoader: (any HrrrAnvilSurfaceProfileLoading)? = nil,
         pressureSourceResolver: any HrrrPressureDirectObjectResolving,
-        pressureProfileLoader: any HrrrPressureProfileLoading
+        pressureProfileLoader: any HrrrPressureProfileLoading,
+        logger: Logger = Logger(label: "anvil-profile-preview")
     ) {
         self.h3Resolver = h3Resolver
         self.hrrrRunResolver = hrrrRunResolver ?? DefaultHrrrRunResolver(dateProvider: dateProvider)
@@ -63,6 +66,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         self.pressureSourceResolver = pressureSourceResolver
         self.pressureProfileLoader = pressureProfileLoader
         self.requestBuilder = AnvilProfileRequestBuilder(h3Resolver: h3Resolver)
+        self.logger = logger
     }
 
     init(application: Application) {
@@ -111,7 +115,8 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
             pressureArtifactCatalogLookupService: pressureArtifactCatalogLookupService,
             surfaceProfileLoader: surfaceProfileLoader,
             pressureSourceResolver: pressureSourceResolver,
-            pressureProfileLoader: pressureProfileLoader
+            pressureProfileLoader: pressureProfileLoader,
+            logger: application.logger
         )
     }
 
@@ -275,7 +280,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
             for: candidate,
             targetValidTime: targetValidTime
         )
-        let surfaceLevel = try await loadSurfaceLevel(
+        let surfaceLevelLoadResult = try await loadSurfaceLevel(
             from: candidate,
             cycleRunTime: sourceResolution.source.runTime ?? candidate.runTime,
             cycleForecastHour: sourceResolution.source.forecastHour ?? candidate.forecastHour,
@@ -285,7 +290,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         let loadResult = try await loadPressureProfile(
             sourceResolution: sourceResolution,
             centroid: centroid,
-            surfaceHeightMslM: surfaceLevel.heightMslM
+            surfaceHeightMslM: surfaceLevelLoadResult.level.heightMslM
         )
         try Task.checkCancellation()
 
@@ -295,7 +300,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
                 h3Cell: h3Cell,
                 runTime: sourceResolution.source.runTime ?? candidate.runTime,
                 forecastHour: sourceResolution.source.forecastHour ?? candidate.forecastHour,
-                surfaceLevel: surfaceLevel,
+                surfaceLevel: surfaceLevelLoadResult.level,
                 groupedProfile: loadResult.groupedProfile
             )
         } catch let error as AnvilProfileRequestBuilderError {
@@ -319,6 +324,8 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
             ),
             selectedMessageCount: loadResult.selection.selectedMessages.count,
             selectedPressureLevels: uniquePressureLevels(from: loadResult.selection),
+            surfacePressureMb: surfaceLevelLoadResult.level.pressureMb,
+            surfaceSubsetCacheHit: surfaceLevelLoadResult.subsetCacheHit,
             rangeCount: loadResult.byteRangePlan.ranges.count,
             totalSelectedRangeBytes: loadResult.subsetCacheResult.byteSize,
             pressureLevelsRequested: loadResult.selection.requestedLevels.map { $0.pressureMb },
@@ -350,7 +357,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         centroid: StormSetupCentroid,
         staleWarning: String? = nil
     ) async throws -> AnvilAnalyzeProfilePreviewResponse {
-        let surfaceLevel = try await loadSurfaceLevel(
+        let surfaceLevelLoadResult = try await loadSurfaceLevel(
             from: sourceCandidate,
             cycleRunTime: readyArtifact.runTime,
             cycleForecastHour: readyArtifact.forecastHour,
@@ -360,7 +367,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         let loadResult = try await loadPressureProfile(
             readyArtifact: readyArtifact,
             centroid: centroid,
-            surfaceHeightMslM: surfaceLevel.heightMslM
+            surfaceHeightMslM: surfaceLevelLoadResult.level.heightMslM
         )
 
         let buildResult: AnvilProfileRequestBuildResult
@@ -369,7 +376,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
                 h3Cell: h3Cell,
                 runTime: readyArtifact.runTime,
                 forecastHour: readyArtifact.forecastHour,
-                surfaceLevel: surfaceLevel,
+                surfaceLevel: surfaceLevelLoadResult.level,
                 groupedProfile: loadResult.groupedProfile
             )
         } catch let error as AnvilProfileRequestBuilderError {
@@ -393,6 +400,8 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
             ),
             selectedMessageCount: loadResult.selection.selectedMessages.count,
             selectedPressureLevels: uniquePressureLevels(from: loadResult.selection),
+            surfacePressureMb: surfaceLevelLoadResult.level.pressureMb,
+            surfaceSubsetCacheHit: surfaceLevelLoadResult.subsetCacheHit,
             rangeCount: loadResult.byteRangePlan.ranges.count,
             totalSelectedRangeBytes: loadResult.subsetCacheResult.byteSize,
             pressureLevelsRequested: loadResult.selection.requestedLevels.map { $0.pressureMb },
@@ -481,25 +490,11 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         cycleForecastHour: Int,
         targetValidTime: Date,
         centroid: StormSetupCentroid
-    ) async throws -> StormSetupPressureProfileLevel {
+    ) async throws -> SurfaceLevelLoadResult {
         let inputResolution = HrrrRunResolution(
             targetValidTime: targetValidTime,
             candidates: [sourceCandidate]
         )
-
-        let loadResult: HrrrAnvilSurfaceProfileLoadResult
-        do {
-            loadResult = try await surfaceProfileLoader.loadSurfaceProfile(
-                for: inputResolution,
-                around: centroid
-            )
-        } catch let error as AnvilProfilePreviewError {
-            throw error
-        } catch {
-            try rethrowCancellationIfNeeded(error)
-            throw AnvilProfilePreviewError.upstreamUnavailable(reason: String(describing: error))
-        }
-
         let expectedSurfaceCandidate = HrrrRunCandidate(
             model: sourceCandidate.model,
             product: .wrfsfc,
@@ -513,20 +508,99 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
             candidates: [expectedSurfaceCandidate]
         )
 
+        logger.info(
+            "Anvil preview exact-cycle surface source selected.",
+            metadata: surfaceDiagnosticsMetadata(
+                pressureSource: sourceCandidate,
+                surfaceCandidate: expectedSurfaceCandidate,
+                surfaceStage: .selected
+            )
+        )
+
+        let loadResult: HrrrAnvilSurfaceProfileLoadResult
+        do {
+            loadResult = try await surfaceProfileLoader.loadSurfaceProfile(
+                for: inputResolution,
+                around: centroid
+            )
+        } catch let error as AnvilProfilePreviewError {
+            logger.warning(
+                "Anvil preview exact-cycle surface row rejected.",
+                metadata: surfaceDiagnosticsMetadata(
+                    pressureSource: sourceCandidate,
+                    surfaceCandidate: expectedSurfaceCandidate,
+                    surfaceStage: .unavailable,
+                    surfaceRowIncluded: false,
+                    reason: error.description
+                )
+            )
+            throw error
+        } catch {
+            try rethrowCancellationIfNeeded(error)
+            logger.warning(
+                "Anvil preview exact-cycle surface row rejected.",
+                metadata: surfaceDiagnosticsMetadata(
+                    pressureSource: sourceCandidate,
+                    surfaceCandidate: expectedSurfaceCandidate,
+                    surfaceStage: .unavailable,
+                    surfaceRowIncluded: false,
+                    reason: String(describing: error)
+                )
+            )
+            throw AnvilProfilePreviewError.upstreamUnavailable(reason: String(describing: error))
+        }
+
         guard loadResult.sourceResolution == expectedResolution else {
             let actualSurfaceCandidate = loadResult.sourceResolution.primaryCandidate?.fileName ?? "unknown"
+            logger.warning(
+                "Anvil preview exact-cycle surface row rejected.",
+                metadata: surfaceDiagnosticsMetadata(
+                    pressureSource: sourceCandidate,
+                    surfaceCandidate: expectedSurfaceCandidate,
+                    surfaceStage: .mismatched,
+                    surfaceSubsetCacheHit: loadResult.subsetCacheResult.cacheHit,
+                    surfaceRowIncluded: false,
+                    reason: "Matching surface source identity did not match the expected exact-cycle surface candidate. Expected \(expectedSurfaceCandidate.fileName), got \(actualSurfaceCandidate)."
+                )
+            )
             throw AnvilProfilePreviewError.unusableProfile(
                 reason: "Matching surface source identity did not match the expected exact-cycle surface candidate. Expected \(expectedSurfaceCandidate.fileName), got \(actualSurfaceCandidate)."
             )
         }
 
         guard let surfaceLevel = makeSurfaceLevel(from: loadResult.samples) else {
+            logger.warning(
+                "Anvil preview exact-cycle surface row rejected.",
+                metadata: surfaceDiagnosticsMetadata(
+                    pressureSource: sourceCandidate,
+                    surfaceCandidate: expectedSurfaceCandidate,
+                    surfaceStage: .incomplete,
+                    surfaceSubsetCacheHit: loadResult.subsetCacheResult.cacheHit,
+                    surfaceRowIncluded: false,
+                    reason: "Matching surface profile was incomplete. Missing or invalid surface fields were not reported."
+                )
+            )
             throw AnvilProfilePreviewError.unusableProfile(
                 reason: "Matching surface profile was incomplete. Missing or invalid surface fields were not reported."
             )
         }
 
-        return surfaceLevel
+        logger.info(
+            "Anvil preview exact-cycle surface row included.",
+            metadata: surfaceDiagnosticsMetadata(
+                pressureSource: sourceCandidate,
+                surfaceCandidate: expectedSurfaceCandidate,
+                surfaceStage: .included,
+                surfaceSubsetCacheHit: loadResult.subsetCacheResult.cacheHit,
+                surfacePressureMb: surfaceLevel.pressureMb,
+                surfaceRowIncluded: true
+            )
+        )
+
+        return SurfaceLevelLoadResult(
+            level: surfaceLevel,
+            subsetCacheHit: loadResult.subsetCacheResult.cacheHit
+        )
     }
 
     private func makeSurfaceLevel(
@@ -759,6 +833,59 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         return "Pressure artifact stale fallback selected: \(ageSeconds)s older than target valid time \(targetLabel)."
     }
 
+    private func surfaceDiagnosticsMetadata(
+        pressureSource: HrrrRunCandidate,
+        surfaceCandidate: HrrrRunCandidate,
+        surfaceStage: SurfaceDiagnosticsStage,
+        surfaceSubsetCacheHit: Bool? = nil,
+        surfacePressureMb: Int? = nil,
+        surfaceRowIncluded: Bool? = nil,
+        reason: String? = nil
+    ) -> Logger.Metadata {
+        var metadata: Logger.Metadata = [
+            "pressureSourceRunTime": .string(pressureSource.runTime.ISO8601Format()),
+            "pressureSourceForecastHour": .stringConvertible(pressureSource.forecastHour),
+            "pressureSourceValidTime": .string(pressureSource.validTime.ISO8601Format()),
+            "surfaceSourceRunTime": .string(surfaceCandidate.runTime.ISO8601Format()),
+            "surfaceSourceForecastHour": .stringConvertible(surfaceCandidate.forecastHour),
+            "surfaceSourceValidTime": .string(surfaceCandidate.validTime.ISO8601Format()),
+            "surfaceSourceProduct": .string(surfaceCandidate.product.rawValue),
+            "surfaceSourceFieldSetVersion": .string(surfaceCandidate.fieldSetVersion.rawValue),
+            "surfaceStage": .string(surfaceStage.rawValue)
+        ]
+
+        if let surfaceSubsetCacheHit {
+            metadata["surfaceSubsetCacheHit"] = .string("\(surfaceSubsetCacheHit)")
+        }
+
+        if let surfacePressureMb {
+            metadata["surfacePressureMb"] = .stringConvertible(surfacePressureMb)
+        }
+
+        if let surfaceRowIncluded {
+            metadata["surfaceRowIncluded"] = .string("\(surfaceRowIncluded)")
+        }
+
+        if let reason {
+            metadata["reason"] = .string(reason)
+        }
+
+        return metadata
+    }
+
+}
+
+private struct SurfaceLevelLoadResult: Sendable {
+    let level: StormSetupPressureProfileLevel
+    let subsetCacheHit: Bool
+}
+
+private enum SurfaceDiagnosticsStage: String, Sendable {
+    case selected
+    case included
+    case mismatched
+    case incomplete
+    case unavailable
 }
 
 extension Application {

--- a/Sources/App/StormSetup/AnvilProfileRequestBuilder.swift
+++ b/Sources/App/StormSetup/AnvilProfileRequestBuilder.swift
@@ -17,6 +17,7 @@ struct AnvilProfileRequestBuilder: Sendable {
         h3Cell: Int64,
         runTime: Date,
         forecastHour: Int,
+        surfaceLevel: StormSetupPressureProfileLevel? = nil,
         groupedProfile: StormSetupPressureProfileGroupingResult
     ) throws -> AnvilProfileRequestBuildResult {
         let resolved = try h3Resolver.resolve(h3Cell: h3Cell)
@@ -32,7 +33,10 @@ struct AnvilProfileRequestBuilder: Sendable {
             )
         }
 
-        let profileArrays = try ProfileArrays(levels: retainedLevels)
+        let profileArrays = try ProfileArrays(
+            levels: retainedLevels,
+            surfaceLevel: surfaceLevel
+        )
         let validTime = runTime.addingTimeInterval(TimeInterval(forecastHour) * 3600)
         let warnings = makeWarnings(for: groupedProfile, profileLevels: retainedLevels)
 
@@ -94,18 +98,26 @@ struct AnvilProfileRequestBuilder: Sendable {
         let vWindMs: [Double]
 
         init(levels: [StormSetupPressureProfileLevel]) throws {
-            guard let violation = Self.firstPressureViolation(
-                in: levels.map { Double($0.pressureMb) }
-            ) else {
-                let sortedLevels = levels.sorted(by: { $0.pressureMb > $1.pressureMb })
+            try self.init(levels: levels, surfaceLevel: nil)
+        }
 
-                self.levels = sortedLevels
-                self.pressureMb = sortedLevels.map { Double($0.pressureMb) }
-                self.heightMslM = sortedLevels.map(\.heightMslM)
-                self.temperatureC = sortedLevels.map(\.temperatureC)
-                self.dewpointC = sortedLevels.map(\.dewpointC)
-                self.uWindMs = sortedLevels.map(\.uWindMs)
-                self.vWindMs = sortedLevels.map(\.vWindMs)
+        init(
+            levels: [StormSetupPressureProfileLevel],
+            surfaceLevel: StormSetupPressureProfileLevel?
+        ) throws {
+            let assembledLevels = surfaceLevel.map { [$0] } ?? []
+            let orderedLevels = assembledLevels + levels
+
+            guard let violation = Self.firstPressureViolation(
+                in: orderedLevels.map { Double($0.pressureMb) }
+            ) else {
+                self.levels = orderedLevels
+                self.pressureMb = orderedLevels.map { Double($0.pressureMb) }
+                self.heightMslM = orderedLevels.map(\.heightMslM)
+                self.temperatureC = orderedLevels.map(\.temperatureC)
+                self.dewpointC = orderedLevels.map(\.dewpointC)
+                self.uWindMs = orderedLevels.map(\.uWindMs)
+                self.vWindMs = orderedLevels.map(\.vWindMs)
                 return
             }
 

--- a/Sources/App/StormSetup/AnvilProfileRequestBuilder.swift
+++ b/Sources/App/StormSetup/AnvilProfileRequestBuilder.swift
@@ -17,7 +17,7 @@ struct AnvilProfileRequestBuilder: Sendable {
         h3Cell: Int64,
         runTime: Date,
         forecastHour: Int,
-        surfaceLevel: StormSetupPressureProfileLevel? = nil,
+        surfaceLevel: StormSetupSurfaceProfileLevel,
         groupedProfile: StormSetupPressureProfileGroupingResult
     ) throws -> AnvilProfileRequestBuildResult {
         let resolved = try h3Resolver.resolve(h3Cell: h3Cell)
@@ -89,7 +89,6 @@ struct AnvilProfileRequestBuilder: Sendable {
     }
 
     struct ProfileArrays: Sendable, Equatable {
-        let levels: [StormSetupPressureProfileLevel]
         let pressureMb: [Double]
         let heightMslM: [Double]
         let temperatureC: [Double]
@@ -98,32 +97,37 @@ struct AnvilProfileRequestBuilder: Sendable {
         let vWindMs: [Double]
 
         init(levels: [StormSetupPressureProfileLevel]) throws {
-            try self.init(levels: levels, surfaceLevel: nil)
+            try self.init(
+                pressureMb: levels.map { Double($0.pressureMb) },
+                heightMslM: levels.map(\.heightMslM),
+                temperatureC: levels.map(\.temperatureC),
+                dewpointC: levels.map(\.dewpointC),
+                uWindMs: levels.map(\.uWindMs),
+                vWindMs: levels.map(\.vWindMs)
+            )
         }
 
         init(
             levels: [StormSetupPressureProfileLevel],
-            surfaceLevel: StormSetupPressureProfileLevel?
+            surfaceLevel: StormSetupSurfaceProfileLevel
         ) throws {
-            let assembledLevels = surfaceLevel.map { [$0] } ?? []
-            let orderedLevels = assembledLevels + levels
-
-            guard let violation = Self.firstPressureViolation(
-                in: orderedLevels.map { Double($0.pressureMb) }
-            ) else {
-                self.levels = orderedLevels
-                self.pressureMb = orderedLevels.map { Double($0.pressureMb) }
-                self.heightMslM = orderedLevels.map(\.heightMslM)
-                self.temperatureC = orderedLevels.map(\.temperatureC)
-                self.dewpointC = orderedLevels.map(\.dewpointC)
-                self.uWindMs = orderedLevels.map(\.uWindMs)
-                self.vWindMs = orderedLevels.map(\.vWindMs)
-                return
+            guard let firstLevel = levels.first else {
+                throw AnvilProfileRequestBuilderError.noRetainedLevels
+            }
+            guard surfaceLevel.heightMslM < firstLevel.heightMslM else {
+                throw AnvilProfileRequestBuilderError.surfaceHeightNotBelowFirstPressureLevel(
+                    surfaceHeightMslM: surfaceLevel.heightMslM,
+                    firstPressureLevelHeightMslM: firstLevel.heightMslM
+                )
             }
 
-            throw AnvilProfileRequestBuilderError.pressureNotStrictlyDescending(
-                previousPressureMb: violation.previous,
-                pressureMb: violation.current
+            try self.init(
+                pressureMb: [surfaceLevel.pressureMb] + levels.map { Double($0.pressureMb) },
+                heightMslM: [surfaceLevel.heightMslM] + levels.map(\.heightMslM),
+                temperatureC: [surfaceLevel.temperatureC] + levels.map(\.temperatureC),
+                dewpointC: [surfaceLevel.dewpointC] + levels.map(\.dewpointC),
+                uWindMs: [surfaceLevel.uWindMs] + levels.map(\.uWindMs),
+                vWindMs: [surfaceLevel.vWindMs] + levels.map(\.vWindMs)
             )
         }
 
@@ -144,7 +148,6 @@ struct AnvilProfileRequestBuilder: Sendable {
                 vWindMs: vWindMs
             )
             guard let violation = Self.firstPressureViolation(in: pressureMb) else {
-                self.levels = []
                 self.pressureMb = pressureMb
                 self.heightMslM = heightMslM
                 self.temperatureC = temperatureC
@@ -241,6 +244,10 @@ enum AnvilProfileRequestBuilderError: Error, Sendable, Equatable {
     case tooFewRetainedLevels(actual: Int, minimum: Int)
     case unequalArrayLengths(expected: Int, actual: Int)
     case pressureNotStrictlyDescending(previousPressureMb: Double, pressureMb: Double)
+    case surfaceHeightNotBelowFirstPressureLevel(
+        surfaceHeightMslM: Double,
+        firstPressureLevelHeightMslM: Double
+    )
 }
 
 private func zip6<A, B, C, D, E, F>(

--- a/Sources/App/StormSetup/AnvilSurfaceProfileNormalizer.swift
+++ b/Sources/App/StormSetup/AnvilSurfaceProfileNormalizer.swift
@@ -1,74 +1,82 @@
 import Foundation
 
 struct AnvilSurfaceProfileNormalizer: Sendable {
-    func normalize(
-        response: AnvilAnalyzeProfileResponse,
-        additionalWarnings: [String] = []
-    ) -> AnvilIngredientEvidence {
-        let combinedWarnings = response.quality.warnings + additionalWarnings
-        let diagnostics = AnvilIngredientDiagnostics(
-            hasEffectiveLayer: response.effectiveLayer.status.lowercased() == "found",
-            hasStormMotion: response.stormMotion.status.lowercased() == "computed",
-            qualityProfileLevelCount: response.quality.profileLevelCount,
-            warnings: combinedWarnings
+    func normalize(samples: [HrrrFieldSample]) throws -> StormSetupSurfaceProfileLevel {
+        struct Draft {
+            var pressurePa: Double?
+            var heightMslM: Double?
+            var temperatureK: Double?
+            var dewpointK: Double?
+            var uWindMs: Double?
+            var vWindMs: Double?
+        }
+
+        var draft = Draft()
+
+        for sample in samples {
+            guard let descriptor = sample.point.inventoryDescriptor,
+                  let value = sample.point.value else {
+                continue
+            }
+
+            let variable = descriptor.variable.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+            let level = descriptor.level.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+            switch (variable, level) {
+            case ("PRES", "surface") where draft.pressurePa == nil:
+                draft.pressurePa = value
+            case ("HGT", "surface") where draft.heightMslM == nil:
+                draft.heightMslM = value
+            case ("TMP", "2 m above ground") where draft.temperatureK == nil:
+                draft.temperatureK = value
+            case ("DPT", "2 m above ground") where draft.dewpointK == nil:
+                draft.dewpointK = value
+            case ("UGRD", "10 m above ground") where draft.uWindMs == nil:
+                draft.uWindMs = value
+            case ("VGRD", "10 m above ground") where draft.vWindMs == nil:
+                draft.vWindMs = value
+            default:
+                continue
+            }
+        }
+
+        let invalidFields = [
+            field(.pressure, value: draft.pressurePa, isValid: { $0 > 0 && $0 <= 200_000 }),
+            field(.height, value: draft.heightMslM),
+            field(.temperature, value: draft.temperatureK),
+            field(.dewpoint, value: draft.dewpointK),
+            field(.uWind, value: draft.uWindMs),
+            field(.vWind, value: draft.vWindMs)
+        ].compactMap { $0 }
+
+        guard invalidFields.isEmpty,
+              let pressurePa = draft.pressurePa,
+              let heightMslM = draft.heightMslM,
+              let temperatureK = draft.temperatureK,
+              let dewpointK = draft.dewpointK,
+              let uWindMs = draft.uWindMs,
+              let vWindMs = draft.vWindMs else {
+            throw AnvilSurfaceProfileNormalizationError(invalidFields: invalidFields)
+        }
+
+        return StormSetupSurfaceProfileLevel(
+            pressureMb: pressurePa / 100,
+            heightMslM: heightMslM,
+            temperatureC: temperatureK - 273.15,
+            dewpointC: dewpointK - 273.15,
+            uWindMs: uWindMs,
+            vWindMs: vWindMs
         )
-
-        let scp = response.scp.map { AnvilIngredientMetricEvidence(support: Self.supportBand(forSCP: $0)) }
-
-        let stpSupports = [response.stpCin, response.stpFixed]
-            .compactMap { $0 }
-            .map(Self.supportBand(forSTP:))
-        let stp = stpSupports.max().map { AnvilIngredientMetricEvidence(support: $0) }
-
-        let ship = response.ship.map { AnvilIngredientMetricEvidence(support: Self.supportBand(forSHIP: $0)) }
-        let supportCount = [scp, stp, ship].compactMap { $0 }.count
-
-        return AnvilIngredientEvidence(
-            status: diagnostics.isDegraded || supportCount == 0 ? .degraded : .available,
-            reason: nil,
-            scp: scp,
-            stp: stp,
-            ship: ship,
-            diagnostics: diagnostics
-        )
     }
 
-    private static func supportBand(forSCP value: Double) -> IngredientSupport {
-        switch value {
-        case ..<0.5:
-            return .weak
-        case ..<1.5:
-            return .conditional
-        case ..<3:
-            return .supportive
-        default:
-            return .strong
+    private func field(
+        _ field: AnvilSurfaceProfileField,
+        value: Double?,
+        isValid: (Double) -> Bool = { _ in true }
+    ) -> AnvilSurfaceProfileField? {
+        guard let value, value.isFinite, isValid(value) else {
+            return field
         }
-    }
-
-    private static func supportBand(forSTP value: Double) -> IngredientSupport {
-        switch value {
-        case ..<0.5:
-            return .weak
-        case ..<1.25:
-            return .conditional
-        case ..<2.5:
-            return .supportive
-        default:
-            return .strong
-        }
-    }
-
-    private static func supportBand(forSHIP value: Double) -> IngredientSupport {
-        switch value {
-        case ..<0.5:
-            return .weak
-        case ..<1:
-            return .conditional
-        case ..<2:
-            return .supportive
-        default:
-            return .strong
-        }
+        return nil
     }
 }

--- a/Sources/App/StormSetup/AnvilSurfaceProfileNormalizer.swift
+++ b/Sources/App/StormSetup/AnvilSurfaceProfileNormalizer.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+struct AnvilSurfaceProfileNormalizer: Sendable {
+    func normalize(
+        response: AnvilAnalyzeProfileResponse,
+        additionalWarnings: [String] = []
+    ) -> AnvilIngredientEvidence {
+        let combinedWarnings = response.quality.warnings + additionalWarnings
+        let diagnostics = AnvilIngredientDiagnostics(
+            hasEffectiveLayer: response.effectiveLayer.status.lowercased() == "found",
+            hasStormMotion: response.stormMotion.status.lowercased() == "computed",
+            qualityProfileLevelCount: response.quality.profileLevelCount,
+            warnings: combinedWarnings
+        )
+
+        let scp = response.scp.map { AnvilIngredientMetricEvidence(support: Self.supportBand(forSCP: $0)) }
+
+        let stpSupports = [response.stpCin, response.stpFixed]
+            .compactMap { $0 }
+            .map(Self.supportBand(forSTP:))
+        let stp = stpSupports.max().map { AnvilIngredientMetricEvidence(support: $0) }
+
+        let ship = response.ship.map { AnvilIngredientMetricEvidence(support: Self.supportBand(forSHIP: $0)) }
+        let supportCount = [scp, stp, ship].compactMap { $0 }.count
+
+        return AnvilIngredientEvidence(
+            status: diagnostics.isDegraded || supportCount == 0 ? .degraded : .available,
+            reason: nil,
+            scp: scp,
+            stp: stp,
+            ship: ship,
+            diagnostics: diagnostics
+        )
+    }
+
+    private static func supportBand(forSCP value: Double) -> IngredientSupport {
+        switch value {
+        case ..<0.5:
+            return .weak
+        case ..<1.5:
+            return .conditional
+        case ..<3:
+            return .supportive
+        default:
+            return .strong
+        }
+    }
+
+    private static func supportBand(forSTP value: Double) -> IngredientSupport {
+        switch value {
+        case ..<0.5:
+            return .weak
+        case ..<1.25:
+            return .conditional
+        case ..<2.5:
+            return .supportive
+        default:
+            return .strong
+        }
+    }
+
+    private static func supportBand(forSHIP value: Double) -> IngredientSupport {
+        switch value {
+        case ..<0.5:
+            return .weak
+        case ..<1:
+            return .conditional
+        case ..<2:
+            return .supportive
+        default:
+            return .strong
+        }
+    }
+}

--- a/Sources/App/StormSetup/HrrrAnvilSurfaceProfileLoading.swift
+++ b/Sources/App/StormSetup/HrrrAnvilSurfaceProfileLoading.swift
@@ -10,7 +10,7 @@ protocol HrrrAnvilSurfaceProfileLoading: Sendable {
 struct HrrrAnvilSurfaceProfileLoadResult: Sendable {
     let sourceResolution: HrrrRunResolution
     let subsetCacheResult: GribSubsetCacheResult
-    let samples: [HrrrFieldSample]
+    let surfaceLevel: StormSetupSurfaceProfileLevel
 }
 
 enum HrrrAnvilSurfaceProfileLoadingError: Error, Sendable, CustomStringConvertible {
@@ -53,11 +53,12 @@ struct DefaultHrrrAnvilSurfaceProfileLoader: HrrrAnvilSurfaceProfileLoading {
             around: centroid
         )
         try Task.checkCancellation()
+        let surfaceLevel = try AnvilSurfaceProfileNormalizer().normalize(samples: samples)
 
         return HrrrAnvilSurfaceProfileLoadResult(
             sourceResolution: surfaceResolution,
             subsetCacheResult: subset,
-            samples: samples
+            surfaceLevel: surfaceLevel
         )
     }
 

--- a/Sources/App/StormSetup/HrrrAnvilSurfaceProfileLoading.swift
+++ b/Sources/App/StormSetup/HrrrAnvilSurfaceProfileLoading.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+protocol HrrrAnvilSurfaceProfileLoading: Sendable {
+    func loadSurfaceProfile(
+        for resolution: HrrrRunResolution,
+        around centroid: StormSetupCentroid
+    ) async throws -> HrrrAnvilSurfaceProfileLoadResult
+}
+
+struct HrrrAnvilSurfaceProfileLoadResult: Sendable {
+    let sourceResolution: HrrrRunResolution
+    let subsetCacheResult: GribSubsetCacheResult
+    let samples: [HrrrFieldSample]
+}
+
+enum HrrrAnvilSurfaceProfileLoadingError: Error, Sendable, CustomStringConvertible {
+    case noSurfaceCandidate
+
+    var description: String {
+        switch self {
+        case .noSurfaceCandidate:
+            return "No HRRR surface candidate was available."
+        }
+    }
+}
+
+struct DefaultHrrrAnvilSurfaceProfileLoader: HrrrAnvilSurfaceProfileLoading {
+    private let subsetLoader: any StormSetupSubsetLoading
+    private let fieldSampler: any StormSetupFieldSampling
+
+    init(
+        subsetLoader: any StormSetupSubsetLoading,
+        fieldSampler: any StormSetupFieldSampling
+    ) {
+        self.subsetLoader = subsetLoader
+        self.fieldSampler = fieldSampler
+    }
+
+    func loadSurfaceProfile(
+        for resolution: HrrrRunResolution,
+        around centroid: StormSetupCentroid
+    ) async throws -> HrrrAnvilSurfaceProfileLoadResult {
+        let surfaceResolution = try makeSurfaceResolution(from: resolution)
+
+        let subset = try await loadSubset(
+            for: surfaceResolution,
+            around: centroid
+        )
+        try Task.checkCancellation()
+
+        let samples = try await loadSamples(
+            from: subset,
+            around: centroid
+        )
+        try Task.checkCancellation()
+
+        return HrrrAnvilSurfaceProfileLoadResult(
+            sourceResolution: surfaceResolution,
+            subsetCacheResult: subset,
+            samples: samples
+        )
+    }
+
+    private func makeSurfaceResolution(
+        from resolution: HrrrRunResolution
+    ) throws -> HrrrRunResolution {
+        guard let primaryCandidate = resolution.primaryCandidate else {
+            throw HrrrAnvilSurfaceProfileLoadingError.noSurfaceCandidate
+        }
+
+        let surfaceCandidate = HrrrRunCandidate(
+            model: primaryCandidate.model,
+            product: .wrfsfc,
+            domain: primaryCandidate.domain,
+            runTime: primaryCandidate.runTime,
+            forecastHour: primaryCandidate.forecastHour
+        )
+
+        return HrrrRunResolution(
+            targetValidTime: resolution.targetValidTime,
+            candidates: [surfaceCandidate]
+        )
+    }
+
+    private func loadSubset(
+        for resolution: HrrrRunResolution,
+        around centroid: StormSetupCentroid
+    ) async throws -> GribSubsetCacheResult {
+        do {
+            return try await subsetLoader.loadFirstAvailableSubset(
+                for: resolution,
+                around: centroid
+            )
+        } catch {
+            try rethrowCancellationIfNeeded(error)
+            throw error
+        }
+    }
+
+    private func loadSamples(
+        from subset: GribSubsetCacheResult,
+        around centroid: StormSetupCentroid
+    ) async throws -> [HrrrFieldSample] {
+        do {
+            return try await fieldSampler.sample(
+                from: subset,
+                around: centroid
+            )
+        } catch {
+            try rethrowCancellationIfNeeded(error)
+            throw error
+        }
+    }
+}

--- a/Sources/App/StormSetup/HrrrAnvilSurfaceProfileLoading.swift
+++ b/Sources/App/StormSetup/HrrrAnvilSurfaceProfileLoading.swift
@@ -73,7 +73,8 @@ struct DefaultHrrrAnvilSurfaceProfileLoader: HrrrAnvilSurfaceProfileLoading {
             product: .wrfsfc,
             domain: primaryCandidate.domain,
             runTime: primaryCandidate.runTime,
-            forecastHour: primaryCandidate.forecastHour
+            forecastHour: primaryCandidate.forecastHour,
+            fieldSetVersion: .anvilSurfaceV1
         )
 
         return HrrrRunResolution(

--- a/Sources/App/StormSetup/HrrrSourceModels.swift
+++ b/Sources/App/StormSetup/HrrrSourceModels.swift
@@ -39,6 +39,7 @@ enum HrrrDomain: String, Content, Sendable, Equatable {
 
 enum HrrrFieldSetVersion: String, Content, Sendable, Equatable {
     case tornadoV1 = "tornado-v1"
+    case anvilSurfaceV1 = "anvil-surface-v1"
     case tornadoPressureV1 = "tornado-pressure-v1"
     case tornadoPressureV2 = "tornado-pressure-v2"
 
@@ -56,6 +57,15 @@ enum HrrrFieldSetVersion: String, Content, Sendable, Equatable {
                 "var_HGT",
                 "var_DPT",
                 "var_TMP"
+            ]
+        case .anvilSurfaceV1:
+            return [
+                "var_PRES",
+                "var_HGT",
+                "var_TMP",
+                "var_DPT",
+                "var_UGRD",
+                "var_VGRD"
             ]
         case .tornadoPressureV1, .tornadoPressureV2:
             return [
@@ -81,6 +91,12 @@ enum HrrrFieldSetVersion: String, Content, Sendable, Equatable {
                 "lev_3000-0_m_above_ground",
                 "lev_0-6000_m_above_ground",
                 "lev_level_of_adiabatic_condensation_from_sfc"
+            ]
+        case .anvilSurfaceV1:
+            return [
+                "lev_surface",
+                "lev_2_m_above_ground",
+                "lev_10_m_above_ground"
             ]
         case .tornadoPressureV1:
             return [

--- a/Sources/App/StormSetup/StormSetupProvider.swift
+++ b/Sources/App/StormSetup/StormSetupProvider.swift
@@ -348,8 +348,7 @@ struct DefaultStormSetupProvider: StormSetupProviding {
 
     private func resolveAnvilEvidence(
         for h3Cell: Int64,
-        sourceMetadata: StormSetupSourceMetadata,
-        surfaceHeightMslM: Double?
+        sourceMetadata: StormSetupSourceMetadata
     ) async throws -> AnvilEvidenceResolution {
         guard let anvilProfileAnalysisProvider else {
             return .unavailable(reason: "Anvil analysis provider is not configured.")
@@ -361,10 +360,7 @@ struct DefaultStormSetupProvider: StormSetupProviding {
 
         do {
             try Task.checkCancellation()
-            let analysis = try await anvilProfileAnalysisProvider.analyzeProfile(
-                for: h3Cell,
-                surfaceHeightMslM: surfaceHeightMslM
-            )
+            let analysis = try await anvilProfileAnalysisProvider.analyzeProfile(for: h3Cell)
             try Task.checkCancellation()
 
             guard analysis.request.validTime == analysis.debug.validTime else {
@@ -421,8 +417,7 @@ struct DefaultStormSetupProvider: StormSetupProviding {
     ) async throws -> TornadoIngredientSnapshot {
         let resolution = try await resolveAnvilEvidence(
             for: snapshot.h3Cell,
-            sourceMetadata: snapshot.source,
-            surfaceHeightMslM: snapshot.surfaceHeightMslM
+            sourceMetadata: snapshot.source
         )
         try Task.checkCancellation()
 

--- a/Sources/App/StormSetup/StormSetupSurfaceProfileModels.swift
+++ b/Sources/App/StormSetup/StormSetupSurfaceProfileModels.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct StormSetupSurfaceProfileLevel: Sendable, Equatable {
+    let pressureMb: Double
+    let heightMslM: Double
+    let temperatureC: Double
+    let dewpointC: Double
+    let uWindMs: Double
+    let vWindMs: Double
+}
+
+enum AnvilSurfaceProfileField: String, CaseIterable, Sendable, Equatable {
+    case pressure = "PRES"
+    case height = "HGT"
+    case temperature = "TMP"
+    case dewpoint = "DPT"
+    case uWind = "UGRD"
+    case vWind = "VGRD"
+}
+
+struct AnvilSurfaceProfileNormalizationError: Error, Sendable, Equatable, CustomStringConvertible {
+    let invalidFields: [AnvilSurfaceProfileField]
+
+    var description: String {
+        "Matching surface profile was incomplete or invalid for fields: \(invalidFields.map(\.rawValue).joined(separator: ", "))."
+    }
+}

--- a/Tests/AppTests/AnvilProfileAnalysisControllerTests.swift
+++ b/Tests/AppTests/AnvilProfileAnalysisControllerTests.swift
@@ -92,12 +92,9 @@ struct AnvilProfileAnalysisControllerTests {
         }
     }
 
-    @Test("forwards the selected surface height from storm setup to analysis generation")
-    func forwardsSelectedSurfaceHeightToAnalysisProvider() async throws {
+    @Test("routes analysis requests to the provider without extra snapshot lookups")
+    func routesAnalysisRequestsToTheProvider() async throws {
         try await withApp(debugEndpointsEnabled: true) { app in
-            let snapshot = makeSnapshot(surfaceHeightMslM: 1675.14)
-            app.stormSetupProvider = StaticStormSetupProvider(snapshot: snapshot)
-
             let analysisProvider = CapturingAnvilProfileAnalysisProvider(
                 response: makeAnalysisResponse()
             )
@@ -107,7 +104,7 @@ struct AnvilProfileAnalysisControllerTests {
                 #expect(res.status == .ok)
             }
 
-            #expect(await analysisProvider.recordedSurfaceHeightMslM == 1675.14)
+            #expect(await analysisProvider.requestCount == 1)
         }
     }
 
@@ -225,80 +222,17 @@ private actor StaticStormSetupProvider: StormSetupProviding {
 
 private actor CapturingAnvilProfileAnalysisProvider: AnvilProfileAnalysisProviding {
     private let response: AnvilAnalyzeProfileAnalysisResponse
-    private(set) var recordedSurfaceHeightMslM: Double?
+    private(set) var requestCount = 0
 
     init(response: AnvilAnalyzeProfileAnalysisResponse) {
         self.response = response
     }
 
-    func analyzeProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfileAnalysisResponse {
+    func analyzeProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfileAnalysisResponse {
         _ = h3Cell
-        recordedSurfaceHeightMslM = surfaceHeightMslM
+        requestCount += 1
         return response
     }
-}
-
-private func makeSnapshot(surfaceHeightMslM: Double?) -> TornadoIngredientSnapshot {
-    TornadoIngredientSnapshot(
-        h3Cell: 617_700_169_958_293_503,
-        centroid: StormSetupCentroid(latitude: 39.7392, longitude: -104.9903),
-        source: StormSetupSourceMetadata(
-            model: .hrrr,
-            product: .wrfsfc,
-            domain: .conus,
-            runTime: previewMakeUTCDate(year: 2026, month: 6, day: 19, hour: 22),
-            forecastHour: 3,
-            validTime: previewMakeUTCDate(year: 2026, month: 6, day: 20, hour: 1),
-            fieldSetVersion: .tornadoV1
-        ),
-        raw: TornadoRawParameters(
-            sbcapeJkg: nil,
-            mlcapeJkg: nil,
-            mucapeJkg: nil,
-            mlcinJkg: nil,
-            dcapeJkg: nil,
-            mllclM: nil,
-            tempDewPtDeltaF: nil,
-            threeCapeJkg: nil,
-            lclLfcSeparationM: nil,
-            lapseRate03kmCkm: nil,
-            lapseRate700500mbCkm: nil,
-            shear06kmKt: nil,
-            shear03kmKt: nil,
-            shear01kmKt: nil,
-            effectiveShearKt: nil,
-            srh01kmM2s2: nil,
-            srh03kmM2s2: nil,
-            effectiveSrhM2s2: nil,
-            supercellComposite: nil,
-            significantTornadoFixed: nil,
-            significantTornadoEffective: nil,
-            significantHail: nil,
-            bunkersRightMotion: nil,
-            bunkersLeftMotion: nil,
-            stormRelativeWind46km: nil,
-            meanWind850300mb: nil,
-            diagnostics: nil
-        ),
-        surfaceHeightMslM: surfaceHeightMslM,
-        assessment: makeAssessment(),
-        freshness: IngredientFreshness.make(
-            source: StormSetupSourceMetadata(
-                model: .hrrr,
-                product: .wrfsfc,
-                domain: .conus,
-                runTime: previewMakeUTCDate(year: 2026, month: 6, day: 19, hour: 22),
-                forecastHour: 3,
-                validTime: previewMakeUTCDate(year: 2026, month: 6, day: 20, hour: 1),
-                fieldSetVersion: .tornadoV1
-            ),
-            fetchedAt: previewMakeUTCDate(year: 2026, month: 6, day: 20, hour: 1)
-        ),
-        anvilEvidence: nil
-    )
 }
 
 private func makeAssessment() -> TornadoIngredientAssessment {
@@ -324,12 +258,8 @@ private func makeAssessment() -> TornadoIngredientAssessment {
 private struct PreviewStubAnvilProfileAnalysisProvider: AnvilProfileAnalysisProviding {
     let result: Result<AnvilAnalyzeProfileAnalysisResponse, AnvilProfileAnalysisError>
 
-    func analyzeProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfileAnalysisResponse {
+    func analyzeProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfileAnalysisResponse {
         _ = h3Cell
-        _ = surfaceHeightMslM
         switch result {
         case .success(let response):
             return response

--- a/Tests/AppTests/AnvilProfileAnalysisControllerTests.swift
+++ b/Tests/AppTests/AnvilProfileAnalysisControllerTests.swift
@@ -183,6 +183,8 @@ struct AnvilProfileAnalysisControllerTests {
                 centroid: StormSetupCentroid(latitude: request.location.lat, longitude: request.location.lon),
                 selectedMessageCount: 5,
                 selectedPressureLevels: [1000, 925, 850],
+                surfacePressureMb: 940,
+                surfaceSubsetCacheHit: false,
                 rangeCount: 3,
                 totalSelectedRangeBytes: 1024,
                 pressureLevelsRequested: [1000, 925, 850],

--- a/Tests/AppTests/AnvilProfileAnalysisProviderTests.swift
+++ b/Tests/AppTests/AnvilProfileAnalysisProviderTests.swift
@@ -24,25 +24,6 @@ struct AnvilProfileAnalysisProviderTests {
         #expect(client.recordedRequests.first == previewResponse.request)
     }
 
-    @Test("analysis provider forwards the selected surface height to preview generation")
-    func analysisProviderForwardsSelectedSurfaceHeightToPreviewGeneration() async throws {
-        let previewResponse = makePreviewResponse()
-        let previewProvider = RecordingAnvilProfilePreviewProvider(result: .success(previewResponse))
-        let client = AnalysisStubAnvilProfileClient(response: makeAnvilResponse())
-        let provider = DefaultAnvilProfileAnalysisProvider(
-            previewProvider: previewProvider,
-            anvilClient: client
-        )
-
-        _ = try await provider.analyzeProfile(
-            for: 617_700_169_958_293_503,
-            surfaceHeightMslM: 1234
-        )
-
-        #expect(previewProvider.requestCount == 1)
-        #expect(previewProvider.recordedSurfaceHeightMslM == 1234)
-    }
-
     @Test("analysis provider propagates cancellation from preview generation")
     func analysisProviderPropagatesCancellationFromPreviewGeneration() async throws {
         let previewProvider = CancellationThrowingAnvilProfilePreviewProvider()
@@ -209,12 +190,8 @@ struct AnvilProfileAnalysisProviderTests {
 }
 
 private struct CancellationThrowingAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
-    func previewProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfilePreviewResponse {
+    func previewProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfilePreviewResponse {
         _ = h3Cell
-        _ = surfaceHeightMslM
         throw CancellationError()
     }
 }
@@ -248,19 +225,14 @@ private final class AnalysisStubAnvilProfileClient: AnvilProfileClient, @uncheck
 private final class RecordingAnvilProfilePreviewProvider: AnvilProfilePreviewProviding, @unchecked Sendable {
     let result: Result<AnvilAnalyzeProfilePreviewResponse, AnvilProfilePreviewError>
     private(set) var requestCount = 0
-    private(set) var recordedSurfaceHeightMslM: Double?
 
     init(result: Result<AnvilAnalyzeProfilePreviewResponse, AnvilProfilePreviewError>) {
         self.result = result
     }
 
-    func previewProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfilePreviewResponse {
+    func previewProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfilePreviewResponse {
         _ = h3Cell
         requestCount += 1
-        recordedSurfaceHeightMslM = surfaceHeightMslM
         switch result {
         case .success(let response):
             return response

--- a/Tests/AppTests/AnvilProfileAnalysisProviderTests.swift
+++ b/Tests/AppTests/AnvilProfileAnalysisProviderTests.swift
@@ -127,6 +127,8 @@ struct AnvilProfileAnalysisProviderTests {
                 centroid: StormSetupCentroid(latitude: request.location.lat, longitude: request.location.lon),
                 selectedMessageCount: 5,
                 selectedPressureLevels: [1000, 925, 850],
+                surfacePressureMb: 940,
+                surfaceSubsetCacheHit: true,
                 rangeCount: 3,
                 totalSelectedRangeBytes: 1024,
                 pressureLevelsRequested: [1000, 925, 850],

--- a/Tests/AppTests/AnvilProfilePreviewControllerTests.swift
+++ b/Tests/AppTests/AnvilProfilePreviewControllerTests.swift
@@ -149,12 +149,9 @@ struct AnvilProfilePreviewControllerTests {
         }
     }
 
-    @Test("forwards the selected surface height from storm setup to preview generation")
-    func forwardsSelectedSurfaceHeightToPreviewProvider() async throws {
+    @Test("routes preview requests to the provider without extra snapshot lookups")
+    func routesPreviewRequestsToTheProvider() async throws {
         try await withApp(debugEndpointsEnabled: true) { app in
-            let snapshot = makeSnapshot(surfaceHeightMslM: 1675.14)
-            app.stormSetupProvider = StaticStormSetupProvider(snapshot: snapshot)
-
             let previewProvider = CapturingAnvilProfilePreviewProvider(
                 response: makePreviewResponse()
             )
@@ -164,7 +161,7 @@ struct AnvilProfilePreviewControllerTests {
                 #expect(res.status == .ok)
             }
 
-            #expect(await previewProvider.recordedSurfaceHeightMslM == 1675.14)
+            #expect(await previewProvider.requestCount == 1)
         }
     }
 
@@ -284,80 +281,17 @@ private actor StaticStormSetupProvider: StormSetupProviding {
 
 private actor CapturingAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
     private let response: AnvilAnalyzeProfilePreviewResponse
-    private(set) var recordedSurfaceHeightMslM: Double?
+    private(set) var requestCount = 0
 
     init(response: AnvilAnalyzeProfilePreviewResponse) {
         self.response = response
     }
 
-    func previewProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfilePreviewResponse {
+    func previewProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfilePreviewResponse {
         _ = h3Cell
-        recordedSurfaceHeightMslM = surfaceHeightMslM
+        requestCount += 1
         return response
     }
-}
-
-private func makeSnapshot(surfaceHeightMslM: Double?) -> TornadoIngredientSnapshot {
-    TornadoIngredientSnapshot(
-        h3Cell: 617_700_169_958_293_503,
-        centroid: StormSetupCentroid(latitude: 39.7392, longitude: -104.9903),
-        source: StormSetupSourceMetadata(
-            model: .hrrr,
-            product: .wrfsfc,
-            domain: .conus,
-            runTime: previewMakeUTCDate(year: 2026, month: 6, day: 19, hour: 22),
-            forecastHour: 3,
-            validTime: previewMakeUTCDate(year: 2026, month: 6, day: 20, hour: 1),
-            fieldSetVersion: .tornadoV1
-        ),
-        raw: TornadoRawParameters(
-            sbcapeJkg: nil,
-            mlcapeJkg: nil,
-            mucapeJkg: nil,
-            mlcinJkg: nil,
-            dcapeJkg: nil,
-            mllclM: nil,
-            tempDewPtDeltaF: nil,
-            threeCapeJkg: nil,
-            lclLfcSeparationM: nil,
-            lapseRate03kmCkm: nil,
-            lapseRate700500mbCkm: nil,
-            shear06kmKt: nil,
-            shear03kmKt: nil,
-            shear01kmKt: nil,
-            effectiveShearKt: nil,
-            srh01kmM2s2: nil,
-            srh03kmM2s2: nil,
-            effectiveSrhM2s2: nil,
-            supercellComposite: nil,
-            significantTornadoFixed: nil,
-            significantTornadoEffective: nil,
-            significantHail: nil,
-            bunkersRightMotion: nil,
-            bunkersLeftMotion: nil,
-            stormRelativeWind46km: nil,
-            meanWind850300mb: nil,
-            diagnostics: nil
-        ),
-        surfaceHeightMslM: surfaceHeightMslM,
-        assessment: makeAssessment(),
-        freshness: IngredientFreshness.make(
-            source: StormSetupSourceMetadata(
-                model: .hrrr,
-                product: .wrfsfc,
-                domain: .conus,
-                runTime: previewMakeUTCDate(year: 2026, month: 6, day: 19, hour: 22),
-                forecastHour: 3,
-                validTime: previewMakeUTCDate(year: 2026, month: 6, day: 20, hour: 1),
-                fieldSetVersion: .tornadoV1
-            ),
-            fetchedAt: previewMakeUTCDate(year: 2026, month: 6, day: 20, hour: 1)
-        ),
-        anvilEvidence: nil
-    )
 }
 
 private func makeAssessment() -> TornadoIngredientAssessment {

--- a/Tests/AppTests/AnvilProfilePreviewControllerTests.swift
+++ b/Tests/AppTests/AnvilProfilePreviewControllerTests.swift
@@ -225,7 +225,7 @@ struct AnvilProfilePreviewControllerTests {
                 makeLevel(pressureMb: 400, heightMslM: 7100, temperatureC: -14.4, dewpointC: -20.8, uWindMs: -23.5, vWindMs: 27.8),
                 makeLevel(pressureMb: 300, heightMslM: 9300, temperatureC: -27.0, dewpointC: -32.8, uWindMs: -28.9, vWindMs: 31.4)
             ],
-            missingLevels: makeMissingLevels(excluding: [1000, 925, 850, 700, 600, 500, 400, 300])
+            surfaceHeightMslM: 1_234
         )
 
         let builder = AnvilProfileRequestBuilder()
@@ -233,6 +233,7 @@ struct AnvilProfilePreviewControllerTests {
             h3Cell: h3Cell,
             runTime: runTime,
             forecastHour: forecastHour,
+            surfaceLevel: makeLevel(pressureMb: 940, heightMslM: 1_234, temperatureC: 22.0, dewpointC: 16.0, uWindMs: -4.25, vWindMs: 6.5),
             groupedProfile: grouping
         ).request
         let debug = AnvilAnalyzeProfilePreviewDebugDTO(
@@ -244,11 +245,11 @@ struct AnvilProfilePreviewControllerTests {
             h3: request.location.h3,
             centroid: request.location.centroid,
             selectedMessageCount: 5,
-            selectedPressureLevels: [1000],
+            selectedPressureLevels: [925, 850, 700, 600, 500, 400, 300],
             rangeCount: 5,
             totalSelectedRangeBytes: 1024,
-            pressureLevelsRequested: [1000],
-            pressureLevelsRetained: grouping.retainedLevels.map(\.pressureMb),
+            pressureLevelsRequested: [1000, 925, 850, 700, 600, 500, 400, 300],
+            pressureLevelsRetained: grouping.retainedLevels.map { $0.pressureMb },
             missingLevels: [],
             warnings: [makeDroppedLevelsWarning(from: grouping.missingLevels)],
             subsetCacheHit: false,
@@ -381,18 +382,47 @@ private func makeAssessment() -> TornadoIngredientAssessment {
 
 private func makeGroupingResult(
     levels: [StormSetupPressureProfileLevel],
-    missingLevels: [StormSetupPressureProfileMissingLevel] = []
+    missingLevels: [StormSetupPressureProfileMissingLevel] = [],
+    surfaceHeightMslM: Double? = nil
 ) -> StormSetupPressureProfileGroupingResult {
-    let droppedLevels = missingLevels.map { missingLevel in
-        StormSetupPressureProfileDroppedLevel(
-            pressureMb: missingLevel.pressureMb,
-            reason: .incomplete(missingVariables: missingLevel.missingVariables)
-        )
+    let retainedLevels: [StormSetupPressureProfileLevel]
+    let droppedLevels: [StormSetupPressureProfileDroppedLevel]
+
+    if let surfaceHeightMslM {
+        let retained = levels.filter { $0.heightMslM > surfaceHeightMslM + 1 }
+        let dropped = levels
+            .filter { $0.heightMslM <= surfaceHeightMslM + 1 }
+            .map {
+                StormSetupPressureProfileDroppedLevel(
+                    pressureMb: $0.pressureMb,
+                    reason: .belowGround(
+                        surfaceHeightMslM: surfaceHeightMslM,
+                        levelHeightMslM: $0.heightMslM,
+                        toleranceM: 1
+                    )
+                )
+            }
+
+        retainedLevels = retained
+        droppedLevels = dropped + missingLevels.map { missingLevel in
+            StormSetupPressureProfileDroppedLevel(
+                pressureMb: missingLevel.pressureMb,
+                reason: .incomplete(missingVariables: missingLevel.missingVariables)
+            )
+        }
+    } else {
+        retainedLevels = levels
+        droppedLevels = missingLevels.map { missingLevel in
+            StormSetupPressureProfileDroppedLevel(
+                pressureMb: missingLevel.pressureMb,
+                reason: .incomplete(missingVariables: missingLevel.missingVariables)
+            )
+        }
     }
 
     return StormSetupPressureProfileGroupingResult(
         requestedLevels: StormSetupPressureLevel.preferredDescending,
-        retainedLevels: levels,
+        retainedLevels: retainedLevels,
         missingLevels: missingLevels,
         droppedLevels: droppedLevels,
         ignoredSamples: []

--- a/Tests/AppTests/AnvilProfilePreviewControllerTests.swift
+++ b/Tests/AppTests/AnvilProfilePreviewControllerTests.swift
@@ -232,7 +232,7 @@ struct AnvilProfilePreviewControllerTests {
             h3Cell: h3Cell,
             runTime: runTime,
             forecastHour: forecastHour,
-            surfaceLevel: makeLevel(pressureMb: 940, heightMslM: 1_234, temperatureC: 22.0, dewpointC: 16.0, uWindMs: -4.25, vWindMs: 6.5),
+            surfaceLevel: previewMakeSurfaceLevel(),
             groupedProfile: grouping
         ).request
         let debug = AnvilAnalyzeProfilePreviewDebugDTO(

--- a/Tests/AppTests/AnvilProfilePreviewControllerTests.swift
+++ b/Tests/AppTests/AnvilProfilePreviewControllerTests.swift
@@ -141,6 +141,8 @@ struct AnvilProfilePreviewControllerTests {
                     "selectedPressureLevels",
                     "sourceKind",
                     "subsetCacheHit",
+                    "surfacePressureMb",
+                    "surfaceSubsetCacheHit",
                     "totalSelectedRangeBytes",
                     "validTime",
                     "warnings"
@@ -243,6 +245,8 @@ struct AnvilProfilePreviewControllerTests {
             centroid: request.location.centroid,
             selectedMessageCount: 5,
             selectedPressureLevels: [925, 850, 700, 600, 500, 400, 300],
+            surfacePressureMb: 940,
+            surfaceSubsetCacheHit: false,
             rangeCount: 5,
             totalSelectedRangeBytes: 1024,
             pressureLevelsRequested: [1000, 925, 850, 700, 600, 500, 400, 300],

--- a/Tests/AppTests/AnvilProfilePreviewProviderTests.swift
+++ b/Tests/AppTests/AnvilProfilePreviewProviderTests.swift
@@ -71,6 +71,8 @@ struct AnvilProfilePreviewProviderTests {
         #expect(preview.debug.idxAvailable == nil)
         #expect(preview.debug.gribAvailable == nil)
         #expect(preview.debug.selectedPressureLevels == [925, 850, 700, 600, 500, 400, 300])
+        #expect(preview.debug.surfacePressureMb == 940)
+        #expect(preview.debug.surfaceSubsetCacheHit == false)
         #expect(preview.request.profile.pressureMb == [940, 925, 850, 700, 600, 500, 400, 300])
     }
 
@@ -234,6 +236,8 @@ struct AnvilProfilePreviewProviderTests {
         #expect(preview.request.forecastHour == staleArtifact.forecastHour)
         #expect(preview.request.validTime == staleArtifact.validTime)
         #expect(preview.debug.warnings.contains(staleWarning))
+        #expect(preview.debug.surfacePressureMb == 940)
+        #expect(preview.debug.surfaceSubsetCacheHit == false)
         #expect(preview.request.profile.pressureMb == [940, 925, 850, 700, 600, 500, 400, 300])
     }
 

--- a/Tests/AppTests/AnvilProfilePreviewProviderTests.swift
+++ b/Tests/AppTests/AnvilProfilePreviewProviderTests.swift
@@ -799,7 +799,8 @@ struct AnvilProfilePreviewProviderTests {
                         product: .wrfsfc,
                         domain: surfaceCandidate.domain,
                         runTime: surfaceCandidate.runTime,
-                        forecastHour: surfaceCandidate.forecastHour
+                        forecastHour: surfaceCandidate.forecastHour,
+                        fieldSetVersion: .anvilSurfaceV1
                     )]
                 ),
                 fetchedAt: now,

--- a/Tests/AppTests/AnvilProfilePreviewProviderTests.swift
+++ b/Tests/AppTests/AnvilProfilePreviewProviderTests.swift
@@ -39,12 +39,13 @@ struct AnvilProfilePreviewProviderTests {
             readyHandler: { artifact, centroid, surfaceHeightMslM in
                 #expect(artifact == readyArtifact)
                 #expect(centroid == expectedCentroid)
-                #expect(surfaceHeightMslM == nil)
+                #expect(surfaceHeightMslM == 1_234)
                 return previewMakeReadyPressureProfileLoadResult(
                     readyArtifact: artifact,
                     fetchedAt: now,
                     subsetCacheHit: true,
-                    samples: previewMakeEightLevelPressureSamples()
+                    samples: previewMakeEightLevelPressureSamples(),
+                    surfaceHeightMslM: surfaceHeightMslM
                 )
             }
         )
@@ -69,8 +70,8 @@ struct AnvilProfilePreviewProviderTests {
         #expect(preview.debug.idxURL == nil)
         #expect(preview.debug.idxAvailable == nil)
         #expect(preview.debug.gribAvailable == nil)
-        #expect(preview.debug.selectedPressureLevels == [1000, 925, 850, 700, 600, 500, 400, 300])
-        #expect(preview.request.profile.pressureMb == [1000, 925, 850, 700, 600, 500, 400, 300])
+        #expect(preview.debug.selectedPressureLevels == [925, 850, 700, 600, 500, 400, 300])
+        #expect(preview.request.profile.pressureMb == [940, 925, 850, 700, 600, 500, 400, 300])
     }
 
     @Test("provider prefers exact ready artifacts before stale fallback")
@@ -131,12 +132,13 @@ struct AnvilProfilePreviewProviderTests {
             readyHandler: { artifact, centroid, surfaceHeightMslM in
                 #expect(artifact == exactArtifact)
                 #expect(centroid == expectedCentroid)
-                #expect(surfaceHeightMslM == nil)
+                #expect(surfaceHeightMslM == 1_234)
                 return previewMakeReadyPressureProfileLoadResult(
                     readyArtifact: artifact,
                     fetchedAt: now,
                     subsetCacheHit: true,
-                    samples: previewMakeEightLevelPressureSamples()
+                    samples: previewMakeEightLevelPressureSamples(),
+                    surfaceHeightMslM: surfaceHeightMslM
                 )
             }
         )
@@ -160,6 +162,7 @@ struct AnvilProfilePreviewProviderTests {
         #expect(preview.request.forecastHour == exactArtifact.forecastHour)
         #expect(preview.request.validTime == exactArtifact.validTime)
         #expect(preview.debug.warnings.contains(where: { $0.contains("stale fallback selected") }) == false)
+        #expect(preview.request.profile.pressureMb == [940, 925, 850, 700, 600, 500, 400, 300])
     }
 
     @Test("provider uses stale pressure artifacts only after all exact candidates miss")
@@ -201,12 +204,13 @@ struct AnvilProfilePreviewProviderTests {
                 #expect(artifact == staleArtifact)
                 #expect(artifact.freshness == .stale(ageSeconds: 3_600))
                 #expect(centroid == expectedCentroid)
-                #expect(surfaceHeightMslM == nil)
+                #expect(surfaceHeightMslM == 1_234)
                 return previewMakeReadyPressureProfileLoadResult(
                     readyArtifact: artifact,
                     fetchedAt: now,
                     subsetCacheHit: true,
-                    samples: previewMakeEightLevelPressureSamples()
+                    samples: previewMakeEightLevelPressureSamples(),
+                    surfaceHeightMslM: surfaceHeightMslM
                 )
             }
         )
@@ -230,6 +234,7 @@ struct AnvilProfilePreviewProviderTests {
         #expect(preview.request.forecastHour == staleArtifact.forecastHour)
         #expect(preview.request.validTime == staleArtifact.validTime)
         #expect(preview.debug.warnings.contains(staleWarning))
+        #expect(preview.request.profile.pressureMb == [940, 925, 850, 700, 600, 500, 400, 300])
     }
 
     @Test("provider reports ready-artifact pressure evidence as unavailable when no catalog row is ready")
@@ -337,102 +342,69 @@ struct AnvilProfilePreviewProviderTests {
         }
     }
 
-    @Test("provider falls back to the next pressure candidate when the newest source is unavailable")
-    func providerFallsBackAcrossCandidates() async throws {
+    @Test("provider stops before pressure work when the surface source is unavailable")
+    func providerStopsBeforePressureWorkWhenSurfaceSourceIsUnavailable() async throws {
         let now = previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22, minute: 45)
         let h3Cell: Int64 = 617_700_169_958_293_503
-        let expected = try DefaultStormSetupH3Resolver().resolve(h3Cell: h3Cell)
         let firstCandidate = HrrrRunCandidate(
             runTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22),
             forecastHour: 0
         )
-        let secondCandidate = HrrrRunCandidate(
-            runTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 21),
-            forecastHour: 1
-        )
         let resolver = PreviewStaticHrrrRunResolver(
             resolution: HrrrRunResolution(
                 targetValidTime: now.truncatedToHour,
-                candidates: [firstCandidate, secondCandidate]
+                candidates: [firstCandidate]
             )
         )
-        let dateProvider = PreviewFixedStormSetupDateProvider(nowDate: now)
-        let pressureSourceResolver = PreviewStubPressureSourceResolver { callIndex, resolution in
+        let pressureSourceResolver = PreviewStubPressureSourceResolver { _, resolution in
             guard let candidate = resolution.candidates.first else {
                 throw AnvilProfilePreviewError.internalExecutionFailure(
                     reason: "missing pressure candidate"
                 )
             }
 
-            switch callIndex {
-            case 0:
-                throw AnvilProfilePreviewError.upstreamUnavailable(
-                    reason: "AWS pressure object unavailable for \(candidate.fileName)."
-                )
-            case 1:
-                return previewMakePressureSourceResolution(
-                    candidate: candidate,
-                    idxAvailable: true
-                )
-            default:
+            return previewMakePressureSourceResolution(
+                candidate: candidate,
+                idxAvailable: true
+            )
+        }
+        let surfaceProfileLoader = PreviewStubSurfaceProfileLoader { _, resolution, _ in
+            guard let candidate = resolution.candidates.first else {
                 throw AnvilProfilePreviewError.internalExecutionFailure(
-                    reason: "unexpected extra source-resolution call"
+                    reason: "missing surface candidate"
                 )
             }
-        }
-        let pressureProfileLoader = PreviewStubPressureProfileLoader { callIndex, sourceResolution, centroid, surfaceHeightMslM in
-            #expect(callIndex == 0)
-            #expect(sourceResolution.idxProbe.available == true)
-            #expect(centroid == expected.centroid)
-            #expect(surfaceHeightMslM == nil)
-            return previewMakePressureProfileLoadResult(
-                sourceResolution: sourceResolution,
-                fetchedAt: now,
-                subsetCacheHit: true,
-                samples: previewMakeEightLevelPressureSamples()
+
+            throw AnvilProfilePreviewError.upstreamUnavailable(
+                reason: "AWS surface object unavailable for \(candidate.fileName)."
             )
+        }
+        let pressureProfileLoader = PreviewStubPressureProfileLoader { _, _, _, _ in
+            Issue.record("Pressure profile loading should not have been reached after surface loading failed.")
+            throw AnvilProfilePreviewError.upstreamUnavailable(reason: "unexpected pressure load")
         }
 
         let provider = DefaultAnvilProfilePreviewProvider(
             h3Resolver: DefaultStormSetupH3Resolver(),
-            dateProvider: dateProvider,
+            dateProvider: PreviewFixedStormSetupDateProvider(nowDate: now),
             hrrrRunResolver: resolver,
+            surfaceProfileLoader: surfaceProfileLoader,
             pressureSourceResolver: pressureSourceResolver,
             pressureProfileLoader: pressureProfileLoader
         )
 
-        let preview = try await provider.previewProfile(for: h3Cell)
-        let expectedGrouping = StormSetupPressureProfileGrouper().group(
-            samples: previewMakeEightLevelPressureSamples()
-        )
-        let expectedRequest = try AnvilProfileRequestBuilder().build(
-            h3Cell: h3Cell,
-            runTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 20),
-            forecastHour: 2,
-            groupedProfile: expectedGrouping
-        ).request
-
-        #expect(preview.request == expectedRequest)
-        #expect(preview.debug.sourceKind == .directObject)
-        #expect(preview.debug.product == .wrfprsf)
-        #expect(preview.debug.runTime == previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 20))
-        #expect(preview.debug.forecastHour == 2)
-        #expect(preview.debug.validTime == previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22))
-        #expect(preview.debug.h3 == H3Cell(UInt64(bitPattern: expected.h3Cell)).description)
-        #expect(preview.debug.centroid == expected.centroid)
-        #expect(preview.debug.selectedMessageCount == 5)
-        #expect(preview.debug.selectedPressureLevels == [1000])
-        #expect(preview.debug.rangeCount == 5)
-        #expect(preview.debug.totalSelectedRangeBytes == 1024)
-        #expect(preview.debug.pressureLevelsRequested == [1000])
-        #expect(preview.debug.subsetCacheHit == true)
-        #expect(preview.debug.primaryDownloadURL?.absoluteString == "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.20260603/conus/hrrr.t20z.wrfprsf02.grib2")
-        #expect(preview.debug.idxURL?.absoluteString == "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.20260603/conus/hrrr.t20z.wrfprsf02.grib2.idx")
-        #expect(preview.debug.idxAvailable == true)
-        #expect(preview.debug.gribAvailable == nil)
-        #expect(preview.debug.pressureLevelsRetained == [1000, 925, 850, 700, 600, 500, 400, 300])
-        #expect(preview.debug.missingLevels.isEmpty)
-        #expect(preview.debug.warnings.contains(where: { $0.contains("Dropped incomplete pressure levels") }))
+        do {
+            _ = try await provider.previewProfile(for: h3Cell)
+            Issue.record("Expected the surface lookup failure to stop the preview before pressure work.")
+        } catch let error as AnvilProfilePreviewError {
+            if case .upstreamUnavailable(let reason) = error {
+                #expect(reason.contains("AWS surface object unavailable for hrrr.t21z.wrfprsf01.grib2."))
+                #expect(await pressureProfileLoader.callCount == 0)
+                #expect(await pressureSourceResolver.callCount == 1)
+                return
+            }
+            Issue.record("Expected upstream unavailable error but got \(error).")
+        }
     }
 
     @Test("provider propagates cancellation instead of trying another candidate")
@@ -510,6 +482,7 @@ struct AnvilProfilePreviewProviderTests {
             )
         }
         let pressureProfileLoader = PreviewStubPressureProfileLoader { _, sourceResolution, _, surfaceHeightMslM in
+            #expect(surfaceHeightMslM == 1_234)
             let result = previewMakePressureProfileLoadResult(
                 sourceResolution: sourceResolution,
                 fetchedAt: now,
@@ -594,14 +567,14 @@ struct AnvilProfilePreviewProviderTests {
 
         let preview = try await provider.previewProfile(for: h3Cell)
 
-        #expect(preview.request.profile.pressureMb == [925, 850, 700, 600, 500, 400, 300])
+        #expect(preview.request.profile.pressureMb == [940, 925, 850, 700, 600, 500, 400, 300])
         #expect(preview.debug.pressureLevelsRetained == [925, 850, 700, 600, 500, 400, 300])
         #expect(preview.debug.warnings.contains(where: { $0.contains("Dropped below-ground pressure levels") }))
-        #expect(preview.debug.warnings.contains(where: { $0.contains("1000 mb below selected surface height 1200.0m") }))
+        #expect(preview.debug.warnings.contains(where: { $0.contains("1000 mb below selected surface height 1234.0m") }))
     }
 
-    @Test("provider warns when the selected surface height is missing")
-    func providerWarnsWhenSelectedSurfaceHeightIsMissing() async throws {
+    @Test("provider ignores a missing caller surface height and still loads exact-cycle surface data")
+    func providerIgnoresMissingCallerSurfaceHeightAndStillLoadsExactCycleSurfaceData() async throws {
         let now = previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22, minute: 45)
         let h3Cell: Int64 = 617_700_169_958_293_503
         let firstCandidate = HrrrRunCandidate(
@@ -626,11 +599,12 @@ struct AnvilProfilePreviewProviderTests {
             )
         }
         let pressureProfileLoader = PreviewStubPressureProfileLoader { _, sourceResolution, _, surfaceHeightMslM in
-            #expect(surfaceHeightMslM == nil)
+            #expect(surfaceHeightMslM == 1_234)
             return previewMakePressureProfileLoadResult(
                 sourceResolution: sourceResolution,
                 fetchedAt: now,
-                samples: previewMakeEightLevelPressureSamples()
+                samples: previewMakeEightLevelPressureSamples(),
+                surfaceHeightMslM: surfaceHeightMslM
             )
         }
 
@@ -644,13 +618,11 @@ struct AnvilProfilePreviewProviderTests {
 
         let preview = try await provider.previewProfile(for: h3Cell)
 
-        #expect(preview.debug.warnings.contains(
-            "Below-ground pressure-level filtering unavailable because selected surface height was missing."
-        ))
+        #expect(preview.request.profile.pressureMb == [940, 925, 850, 700, 600, 500, 400, 300])
     }
 
-    @Test("provider warns when the selected surface height is invalid")
-    func providerWarnsWhenSelectedSurfaceHeightIsInvalid() async throws {
+    @Test("provider rejects mismatched exact-cycle surface data before pressure loading")
+    func providerRejectsMismatchedExactCycleSurfaceDataBeforePressureLoading() async throws {
         let now = previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22, minute: 45)
         let h3Cell: Int64 = 617_700_169_958_293_503
         let firstCandidate = HrrrRunCandidate(
@@ -675,11 +647,21 @@ struct AnvilProfilePreviewProviderTests {
             )
         }
         let pressureProfileLoader = PreviewStubPressureProfileLoader { _, sourceResolution, _, surfaceHeightMslM in
-            #expect(surfaceHeightMslM == nil)
-            return previewMakePressureProfileLoadResult(
-                sourceResolution: sourceResolution,
+            Issue.record("Pressure profile loading should not have been reached after mismatched surface data.")
+            throw AnvilProfilePreviewError.upstreamUnavailable(reason: "unexpected pressure load")
+        }
+        let surfaceProfileLoader = PreviewStubSurfaceProfileLoader { _, resolution, centroid in
+            let mismatchCandidate = HrrrRunCandidate(
+                runTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 21),
+                forecastHour: 1
+            )
+            return previewMakeSurfaceProfileLoadResult(
+                sourceResolution: HrrrRunResolution(
+                    targetValidTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 21),
+                    candidates: [mismatchCandidate]
+                ),
                 fetchedAt: now,
-                samples: previewMakeEightLevelPressureSamples()
+                samples: previewMakeSurfaceSamples()
             )
         }
 
@@ -687,16 +669,22 @@ struct AnvilProfilePreviewProviderTests {
             h3Resolver: DefaultStormSetupH3Resolver(),
             dateProvider: PreviewFixedStormSetupDateProvider(nowDate: now),
             hrrrRunResolver: resolver,
+            surfaceProfileLoader: surfaceProfileLoader,
             pressureSourceResolver: pressureSourceResolver,
             pressureProfileLoader: pressureProfileLoader,
             surfaceHeightMslM: Double.infinity
         )
 
-        let preview = try await provider.previewProfile(for: h3Cell)
-
-        #expect(preview.debug.warnings.contains(
-            "Below-ground pressure-level filtering unavailable because selected surface height was invalid."
-        ))
+        do {
+            _ = try await provider.previewProfile(for: h3Cell)
+            Issue.record("Expected mismatched exact-cycle surface data to fail.")
+        } catch let error as AnvilProfilePreviewError {
+            if case .unusableProfile(let reason) = error {
+                #expect(reason.contains("Matching surface source identity"))
+                return
+            }
+            Issue.record("Expected unusable profile error but got \(error).")
+        }
     }
 
     @Test("provider surfaces an unusable profile when filtering leaves too few above-ground levels")
@@ -725,6 +713,7 @@ struct AnvilProfilePreviewProviderTests {
             )
         }
         let pressureProfileLoader = PreviewStubPressureProfileLoader { _, sourceResolution, _, surfaceHeightMslM in
+            #expect(surfaceHeightMslM == 2_450)
             let result = previewMakePressureProfileLoadResult(
                 sourceResolution: sourceResolution,
                 fetchedAt: now,
@@ -797,11 +786,34 @@ struct AnvilProfilePreviewProviderTests {
                 groupedProfile: result.groupedProfile
             )
         }
+        let surfaceProfileLoader = PreviewStubSurfaceProfileLoader { _, resolution, centroid in
+            let surfaceCandidate = resolution.candidates.first ?? HrrrRunCandidate(
+                runTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22),
+                forecastHour: 0
+            )
+            return previewMakeSurfaceProfileLoadResult(
+                sourceResolution: HrrrRunResolution(
+                    targetValidTime: resolution.targetValidTime,
+                    candidates: [HrrrRunCandidate(
+                        model: surfaceCandidate.model,
+                        product: .wrfsfc,
+                        domain: surfaceCandidate.domain,
+                        runTime: surfaceCandidate.runTime,
+                        forecastHour: surfaceCandidate.forecastHour
+                    )]
+                ),
+                fetchedAt: now,
+                samples: previewMakeSurfaceSamples(
+                    heightMslM: 2_450
+                )
+            )
+        }
 
         let provider = DefaultAnvilProfilePreviewProvider(
             h3Resolver: DefaultStormSetupH3Resolver(),
             dateProvider: PreviewFixedStormSetupDateProvider(nowDate: now),
             hrrrRunResolver: resolver,
+            surfaceProfileLoader: surfaceProfileLoader,
             pressureSourceResolver: pressureSourceResolver,
             pressureProfileLoader: pressureProfileLoader,
             surfaceHeightMslM: 2450
@@ -878,7 +890,8 @@ struct AnvilProfilePreviewProviderTests {
                     dpt: 274.15,
                     ugrd: -12.5,
                     vgrd: 14.2
-                )
+                ),
+                surfaceHeightMslM: 1_234
             )
             return HrrrPressureProfileLoadResult(
                 sourceResolution: result.sourceResolution,
@@ -904,7 +917,7 @@ struct AnvilProfilePreviewProviderTests {
             Issue.record("Expected the preview provider to fail with unusable profile data.")
         } catch let error as AnvilProfilePreviewError {
             if case .unusableProfile(let reason) = error {
-                #expect(reason.contains("Only 4 retained levels"))
+                #expect(reason.contains("Only 3 retained levels"))
                 #expect(reason.contains("Missing or incomplete levels"))
                 return
             }

--- a/Tests/AppTests/AnvilProfilePreviewProviderTests.swift
+++ b/Tests/AppTests/AnvilProfilePreviewProviderTests.swift
@@ -55,6 +55,7 @@ struct AnvilProfilePreviewProviderTests {
                 resolution: HrrrRunResolution(targetValidTime: now.truncatedToHour, candidates: [surfaceCandidate])
             ),
             pressureArtifactCatalogLookupService: lookupService,
+            surfaceProfileLoader: previewMakeExactCycleSurfaceProfileLoader(fetchedAt: now),
             pressureSourceResolver: pressureSourceResolver,
             pressureProfileLoader: pressureProfileLoader
         )
@@ -150,6 +151,7 @@ struct AnvilProfilePreviewProviderTests {
                 resolution: HrrrRunResolution(targetValidTime: now.truncatedToHour, candidates: [firstCandidate, secondCandidate])
             ),
             pressureArtifactCatalogLookupService: lookupService,
+            surfaceProfileLoader: previewMakeExactCycleSurfaceProfileLoader(fetchedAt: now),
             pressureSourceResolver: pressureSourceResolver,
             pressureProfileLoader: pressureProfileLoader
         )
@@ -222,6 +224,7 @@ struct AnvilProfilePreviewProviderTests {
                 resolution: HrrrRunResolution(targetValidTime: now.truncatedToHour, candidates: [surfaceCandidate])
             ),
             pressureArtifactCatalogLookupService: lookupService,
+            surfaceProfileLoader: previewMakeExactCycleSurfaceProfileLoader(fetchedAt: now),
             pressureSourceResolver: pressureSourceResolver,
             pressureProfileLoader: pressureProfileLoader
         )
@@ -270,6 +273,7 @@ struct AnvilProfilePreviewProviderTests {
                 resolution: HrrrRunResolution(targetValidTime: now.truncatedToHour, candidates: [surfaceCandidate])
             ),
             pressureArtifactCatalogLookupService: lookupService,
+            surfaceProfileLoader: previewMakeExactCycleSurfaceProfileLoader(fetchedAt: now),
             pressureSourceResolver: pressureSourceResolver,
             pressureProfileLoader: pressureProfileLoader
         )
@@ -328,6 +332,7 @@ struct AnvilProfilePreviewProviderTests {
                 resolution: HrrrRunResolution(targetValidTime: now.truncatedToHour, candidates: [surfaceCandidate])
             ),
             pressureArtifactCatalogLookupService: lookupService,
+            surfaceProfileLoader: previewMakeExactCycleSurfaceProfileLoader(fetchedAt: now),
             pressureSourceResolver: pressureSourceResolver,
             pressureProfileLoader: pressureProfileLoader
         )
@@ -448,6 +453,7 @@ struct AnvilProfilePreviewProviderTests {
             hrrrRunResolver: PreviewStaticHrrrRunResolver(
                 resolution: HrrrRunResolution(targetValidTime: now.truncatedToHour, candidates: [firstCandidate, secondCandidate])
             ),
+            surfaceProfileLoader: previewMakeExactCycleSurfaceProfileLoader(fetchedAt: now),
             pressureSourceResolver: pressureSourceResolver,
             pressureProfileLoader: pressureProfileLoader
         )
@@ -564,6 +570,7 @@ struct AnvilProfilePreviewProviderTests {
             h3Resolver: DefaultStormSetupH3Resolver(),
             dateProvider: PreviewFixedStormSetupDateProvider(nowDate: now),
             hrrrRunResolver: resolver,
+            surfaceProfileLoader: previewMakeExactCycleSurfaceProfileLoader(fetchedAt: now),
             pressureSourceResolver: pressureSourceResolver,
             pressureProfileLoader: pressureProfileLoader
         )
@@ -615,6 +622,7 @@ struct AnvilProfilePreviewProviderTests {
             h3Resolver: DefaultStormSetupH3Resolver(),
             dateProvider: PreviewFixedStormSetupDateProvider(nowDate: now),
             hrrrRunResolver: resolver,
+            surfaceProfileLoader: previewMakeExactCycleSurfaceProfileLoader(fetchedAt: now),
             pressureSourceResolver: pressureSourceResolver,
             pressureProfileLoader: pressureProfileLoader
         )
@@ -664,7 +672,7 @@ struct AnvilProfilePreviewProviderTests {
                     candidates: [mismatchCandidate]
                 ),
                 fetchedAt: now,
-                samples: previewMakeSurfaceSamples()
+                surfaceLevel: previewMakeSurfaceLevel()
             )
         }
 
@@ -806,7 +814,7 @@ struct AnvilProfilePreviewProviderTests {
                     )]
                 ),
                 fetchedAt: now,
-                samples: previewMakeSurfaceSamples(
+                surfaceLevel: previewMakeSurfaceLevel(
                     heightMslM: 2_450
                 )
             )
@@ -910,6 +918,7 @@ struct AnvilProfilePreviewProviderTests {
             h3Resolver: DefaultStormSetupH3Resolver(),
             dateProvider: PreviewFixedStormSetupDateProvider(nowDate: now),
             hrrrRunResolver: resolver,
+            surfaceProfileLoader: previewMakeExactCycleSurfaceProfileLoader(fetchedAt: now),
             pressureSourceResolver: pressureSourceResolver,
             pressureProfileLoader: pressureProfileLoader
         )
@@ -994,6 +1003,7 @@ struct AnvilProfilePreviewProviderTests {
             hrrrRunResolver: PreviewStaticHrrrRunResolver(
                 resolution: HrrrRunResolution(targetValidTime: now.truncatedToHour, candidates: [candidate])
             ),
+            surfaceProfileLoader: previewMakeExactCycleSurfaceProfileLoader(fetchedAt: now),
             pressureSourceResolver: PreviewStubPressureSourceResolver { _, resolution in
                 guard let candidate = resolution.candidates.first else {
                     throw AnvilProfilePreviewError.internalExecutionFailure(

--- a/Tests/AppTests/AnvilProfilePreviewProviderTests.swift
+++ b/Tests/AppTests/AnvilProfilePreviewProviderTests.swift
@@ -561,8 +561,7 @@ struct AnvilProfilePreviewProviderTests {
             dateProvider: PreviewFixedStormSetupDateProvider(nowDate: now),
             hrrrRunResolver: resolver,
             pressureSourceResolver: pressureSourceResolver,
-            pressureProfileLoader: pressureProfileLoader,
-            surfaceHeightMslM: 1200
+            pressureProfileLoader: pressureProfileLoader
         )
 
         let preview = try await provider.previewProfile(for: h3Cell)
@@ -671,8 +670,7 @@ struct AnvilProfilePreviewProviderTests {
             hrrrRunResolver: resolver,
             surfaceProfileLoader: surfaceProfileLoader,
             pressureSourceResolver: pressureSourceResolver,
-            pressureProfileLoader: pressureProfileLoader,
-            surfaceHeightMslM: Double.infinity
+            pressureProfileLoader: pressureProfileLoader
         )
 
         do {
@@ -816,8 +814,7 @@ struct AnvilProfilePreviewProviderTests {
             hrrrRunResolver: resolver,
             surfaceProfileLoader: surfaceProfileLoader,
             pressureSourceResolver: pressureSourceResolver,
-            pressureProfileLoader: pressureProfileLoader,
-            surfaceHeightMslM: 2450
+            pressureProfileLoader: pressureProfileLoader
         )
 
         do {

--- a/Tests/AppTests/AnvilProfilePreviewProviderTests.swift
+++ b/Tests/AppTests/AnvilProfilePreviewProviderTests.swift
@@ -351,6 +351,104 @@ struct AnvilProfilePreviewProviderTests {
         }
     }
 
+    @Test("provider does not fall back after an exact surface load failure")
+    func providerDoesNotFallBackAfterExactSurfaceLoadFailure() async throws {
+        let now = previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22, minute: 45)
+        let h3Cell: Int64 = 617_700_169_958_293_503
+        let firstCandidate = HrrrRunCandidate(
+            runTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22),
+            forecastHour: 0
+        )
+        let secondCandidate = HrrrRunCandidate(
+            runTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 21),
+            forecastHour: 1
+        )
+        let firstPressureCandidate = makePressureCandidate(from: firstCandidate)
+        let secondPressureCandidate = makePressureCandidate(from: secondCandidate)
+        let exactArtifact = previewMakeReadyPressureArtifact(
+            runTime: firstPressureCandidate.runTime,
+            forecastHour: firstPressureCandidate.forecastHour,
+            validTime: firstPressureCandidate.validTime
+        )
+        let lookupService = PreviewStubPressureArtifactCatalogLookupService(
+            handler: { lookedUpCandidate in
+                if lookedUpCandidate == firstPressureCandidate {
+                    return exactArtifact
+                }
+
+                if lookedUpCandidate == secondPressureCandidate {
+                    return nil
+                }
+
+                Issue.record("Unexpected exact lookup candidate \(lookedUpCandidate.fileName).")
+                return nil
+            },
+            staleHandler: { _ in
+                Issue.record("Stale lookup should not be used after an exact surface load failure.")
+                return nil
+            }
+        )
+        let pressureSourceResolver = PreviewStubPressureSourceResolver { _, resolution in
+            guard let candidate = resolution.candidates.first else {
+                throw AnvilProfilePreviewError.internalExecutionFailure(reason: "missing pressure candidate")
+            }
+
+            return previewMakePressureSourceResolution(candidate: candidate, idxAvailable: true)
+        }
+        let pressureProfileLoader = PreviewStubPressureProfileLoader { _, sourceResolution, _, surfaceHeightMslM in
+            #expect(surfaceHeightMslM == 1_234)
+            return previewMakePressureProfileLoadResult(
+                sourceResolution: sourceResolution,
+                fetchedAt: now,
+                samples: previewMakeEightLevelPressureSamples(),
+                surfaceHeightMslM: surfaceHeightMslM
+            )
+        }
+        let surfaceProfileLoader = PreviewStubSurfaceProfileLoader { callIndex, resolution, _ in
+            guard let candidate = resolution.primaryCandidate else {
+                throw AnvilProfilePreviewError.internalExecutionFailure(reason: "missing surface candidate")
+            }
+
+            if callIndex == 0 {
+                throw AnvilProfilePreviewError.upstreamUnavailable(
+                    reason: "AWS surface object unavailable for \(candidate.fileName)."
+                )
+            }
+
+            return previewMakeSurfaceProfileLoadResult(
+                sourceResolution: resolution,
+                fetchedAt: now,
+                surfaceLevel: previewMakeSurfaceLevel()
+            )
+        }
+        let provider = DefaultAnvilProfilePreviewProvider(
+            dateProvider: PreviewFixedStormSetupDateProvider(nowDate: now),
+            hrrrRunResolver: PreviewStaticHrrrRunResolver(
+                resolution: HrrrRunResolution(targetValidTime: now.truncatedToHour, candidates: [firstCandidate, secondCandidate])
+            ),
+            pressureArtifactCatalogLookupService: lookupService,
+            surfaceProfileLoader: surfaceProfileLoader,
+            pressureSourceResolver: pressureSourceResolver,
+            pressureProfileLoader: pressureProfileLoader
+        )
+
+        do {
+            _ = try await provider.previewProfile(for: h3Cell)
+            Issue.record("Expected the exact surface load failure to stop the preview before fallback.")
+        } catch let error as AnvilProfilePreviewError {
+            if case .upstreamUnavailable(let reason) = error {
+                #expect(reason.contains("AWS surface object unavailable for \(firstPressureCandidate.fileName)."))
+                #expect(await lookupService.callCount == 1)
+                #expect(await lookupService.staleCallCount == 0)
+                #expect(await surfaceProfileLoader.callCount == 1)
+                #expect(await pressureSourceResolver.callCount == 0)
+                #expect(await pressureProfileLoader.callCount == 0)
+                return
+            }
+            Issue.record("Expected upstream unavailable error but got \(error).")
+        }
+    }
+
     @Test("provider stops before pressure work when the surface source is unavailable")
     func providerStopsBeforePressureWorkWhenSurfaceSourceIsUnavailable() async throws {
         let now = previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22, minute: 45)
@@ -630,6 +728,77 @@ struct AnvilProfilePreviewProviderTests {
         let preview = try await provider.previewProfile(for: h3Cell)
 
         #expect(preview.request.profile.pressureMb == [940, 925, 850, 700, 600, 500, 400, 300])
+    }
+
+    @Test("provider uses the resolved pressure candidate for cold-path surface loading")
+    func providerUsesTheResolvedPressureCandidateForColdPathSurfaceLoading() async throws {
+        let now = previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22, minute: 45)
+        let h3Cell: Int64 = 617_700_169_958_293_503
+        let surfaceCandidate = HrrrRunCandidate(
+            runTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22),
+            forecastHour: 0
+        )
+        let pressureCandidate = makePressureCandidate(from: surfaceCandidate)
+        let resolvedPressureCandidate = makePressureCandidate(from: pressureCandidate)
+        let pressureSourceResolver = PreviewStubPressureSourceResolver { _, resolution in
+            guard let candidate = resolution.candidates.first else {
+                throw AnvilProfilePreviewError.internalExecutionFailure(reason: "missing pressure candidate")
+            }
+
+            #expect(candidate == pressureCandidate)
+            return previewMakePressureSourceResolution(candidate: resolvedPressureCandidate, idxAvailable: true)
+        }
+        let surfaceProfileLoader = PreviewStubSurfaceProfileLoader { _, resolution, _ in
+            guard let candidate = resolution.primaryCandidate else {
+                throw AnvilProfilePreviewError.internalExecutionFailure(reason: "missing surface candidate")
+            }
+
+            guard candidate == resolvedPressureCandidate else {
+                throw AnvilProfilePreviewError.internalExecutionFailure(
+                    reason: "surface loader saw \(candidate.fileName) instead of resolved \(resolvedPressureCandidate.fileName)"
+                )
+            }
+
+            let surfaceCandidate = HrrrRunCandidate(
+                model: candidate.model,
+                product: .wrfsfc,
+                domain: candidate.domain,
+                runTime: candidate.runTime,
+                forecastHour: candidate.forecastHour,
+                fieldSetVersion: .anvilSurfaceV1
+            )
+            return previewMakeSurfaceProfileLoadResult(
+                sourceResolution: HrrrRunResolution(
+                    targetValidTime: resolution.targetValidTime,
+                    candidates: [surfaceCandidate]
+                ),
+                fetchedAt: now,
+                surfaceLevel: previewMakeSurfaceLevel()
+            )
+        }
+        let pressureProfileLoader = PreviewStubPressureProfileLoader { _, sourceResolution, _, surfaceHeightMslM in
+            #expect(sourceResolution.candidate == resolvedPressureCandidate)
+            return previewMakePressureProfileLoadResult(
+                sourceResolution: sourceResolution,
+                fetchedAt: now,
+                samples: previewMakeEightLevelPressureSamples(),
+                surfaceHeightMslM: surfaceHeightMslM
+            )
+        }
+        let provider = DefaultAnvilProfilePreviewProvider(
+            dateProvider: PreviewFixedStormSetupDateProvider(nowDate: now),
+            hrrrRunResolver: PreviewStaticHrrrRunResolver(
+                resolution: HrrrRunResolution(targetValidTime: now.truncatedToHour, candidates: [surfaceCandidate])
+            ),
+            surfaceProfileLoader: surfaceProfileLoader,
+            pressureSourceResolver: pressureSourceResolver,
+            pressureProfileLoader: pressureProfileLoader
+        )
+
+        let preview = try await provider.previewProfile(for: h3Cell)
+
+        #expect(preview.request.runTime == resolvedPressureCandidate.runTime)
+        #expect(preview.request.forecastHour == resolvedPressureCandidate.forecastHour)
     }
 
     @Test("provider rejects mismatched exact-cycle surface data before pressure loading")

--- a/Tests/AppTests/AnvilProfilePreviewTestSupport.swift
+++ b/Tests/AppTests/AnvilProfilePreviewTestSupport.swift
@@ -250,12 +250,8 @@ actor PreviewStubStormSetupFieldSampler: StormSetupFieldSampling {
 struct PreviewStubAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
     let result: Result<AnvilAnalyzeProfilePreviewResponse, AnvilProfilePreviewError>
 
-    func previewProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfilePreviewResponse {
+    func previewProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfilePreviewResponse {
         _ = h3Cell
-        _ = surfaceHeightMslM
         switch result {
         case .success(let response):
             return response

--- a/Tests/AppTests/AnvilProfilePreviewTestSupport.swift
+++ b/Tests/AppTests/AnvilProfilePreviewTestSupport.swift
@@ -183,6 +183,26 @@ actor PreviewStubPressureProfileLoader: HrrrPressureProfileLoading {
     }
 }
 
+actor PreviewStubSurfaceProfileLoader: HrrrAnvilSurfaceProfileLoading {
+    private let handler: @Sendable (Int, HrrrRunResolution, StormSetupCentroid) async throws -> HrrrAnvilSurfaceProfileLoadResult
+    private(set) var callCount = 0
+
+    init(
+        handler: @escaping @Sendable (Int, HrrrRunResolution, StormSetupCentroid) async throws -> HrrrAnvilSurfaceProfileLoadResult
+    ) {
+        self.handler = handler
+    }
+
+    func loadSurfaceProfile(
+        for resolution: HrrrRunResolution,
+        around centroid: StormSetupCentroid
+    ) async throws -> HrrrAnvilSurfaceProfileLoadResult {
+        let index = callCount
+        callCount += 1
+        return try await handler(index, resolution, centroid)
+    }
+}
+
 actor PreviewStubStormSetupFieldSampler: StormSetupFieldSampling {
     private let handler: @Sendable (GribSubsetCacheResult, StormSetupCentroid) async throws -> [HrrrFieldSample]
 
@@ -308,6 +328,31 @@ func previewMakePressureProfileLoadResult(
     )
 }
 
+func previewMakeSurfaceProfileLoadResult(
+    sourceResolution: HrrrRunResolution,
+    fetchedAt: Date,
+    cacheHit: Bool = false,
+    samples: [HrrrFieldSample]? = nil
+) -> HrrrAnvilSurfaceProfileLoadResult {
+    let subsetCacheResult = previewMakeSubsetResult(
+        source: HrrrNomadsURLBuilder().makeSourceMetadata(
+            for: sourceResolution.primaryCandidate ?? HrrrRunCandidate(
+                runTime: fetchedAt,
+                forecastHour: 0
+            ),
+            around: StormSetupCentroid(latitude: 39.7825, longitude: -104.4661)
+        ),
+        fetchedAt: fetchedAt,
+        cacheHit: cacheHit
+    )
+
+    return HrrrAnvilSurfaceProfileLoadResult(
+        sourceResolution: sourceResolution,
+        subsetCacheResult: subsetCacheResult,
+        samples: samples ?? previewMakeSurfaceSamples()
+    )
+}
+
 func previewMakeReadyPressureProfileLoadResult(
     readyArtifact: PressureArtifactCatalogReadyArtifact,
     fetchedAt: Date,
@@ -393,6 +438,42 @@ func previewMakePressureSubsetCacheResult(
         fetchedAt: fetchedAt,
         expiresAt: fetchedAt.addingTimeInterval(3600),
         cacheHit: cacheHit
+    )
+}
+
+func previewMakeSurfaceSamples(
+    pressurePa: Double = 94_000,
+    heightMslM: Double = 1_234,
+    temperatureK: Double = 295.15,
+    dewpointK: Double = 289.15,
+    uWindMs: Double = -4.25,
+    vWindMs: Double = 6.5
+) -> [HrrrFieldSample] {
+    [
+        previewSample("1:0:d=2026060313:PRES:surface:9 hour fcst:lon=-104.47,lat=39.79,val=\(pressurePa)"),
+        previewSample("2:0:d=2026060313:HGT:surface:9 hour fcst:lon=-104.47,lat=39.79,val=\(heightMslM)"),
+        previewSample("3:0:d=2026060313:TMP:2 m above ground:9 hour fcst:lon=-104.47,lat=39.79,val=\(temperatureK)"),
+        previewSample("4:0:d=2026060313:DPT:2 m above ground:9 hour fcst:lon=-104.47,lat=39.79,val=\(dewpointK)"),
+        previewSample("5:0:d=2026060313:UGRD:10 m above ground:9 hour fcst:lon=-104.47,lat=39.79,val=\(uWindMs)"),
+        previewSample("6:0:d=2026060313:VGRD:10 m above ground:9 hour fcst:lon=-104.47,lat=39.79,val=\(vWindMs)")
+    ]
+}
+
+func previewMakeSurfaceLevel(
+    pressurePa: Double = 94_000,
+    heightMslM: Double = 1_234,
+    temperatureK: Double = 295.15,
+    dewpointK: Double = 289.15,
+    uWindMs: Double = -4.25,
+    vWindMs: Double = 6.5
+) -> StormSetupPressureProfileLevel {
+    StormSetupPressureProfileLevel(
+        pressureMb: Int((pressurePa / 100).rounded()),
+        heightMslM: heightMslM,
+        temperatureC: temperatureK - 273.15,
+        dewpointC: dewpointK - 273.15,
+        uWindMs: uWindMs,
+        vWindMs: vWindMs
     )
 }
 

--- a/Tests/AppTests/AnvilProfilePreviewTestSupport.swift
+++ b/Tests/AppTests/AnvilProfilePreviewTestSupport.swift
@@ -203,6 +203,33 @@ actor PreviewStubSurfaceProfileLoader: HrrrAnvilSurfaceProfileLoading {
     }
 }
 
+func previewMakeExactCycleSurfaceProfileLoader(
+    fetchedAt: Date,
+    surfaceLevel: StormSetupSurfaceProfileLevel = previewMakeSurfaceLevel()
+) -> PreviewStubSurfaceProfileLoader {
+    PreviewStubSurfaceProfileLoader { _, resolution, _ in
+        guard let sourceCandidate = resolution.primaryCandidate else {
+            throw AnvilProfilePreviewError.internalExecutionFailure(reason: "missing surface source candidate")
+        }
+        let surfaceCandidate = HrrrRunCandidate(
+            model: sourceCandidate.model,
+            product: .wrfsfc,
+            domain: sourceCandidate.domain,
+            runTime: sourceCandidate.runTime,
+            forecastHour: sourceCandidate.forecastHour,
+            fieldSetVersion: .anvilSurfaceV1
+        )
+        return previewMakeSurfaceProfileLoadResult(
+            sourceResolution: HrrrRunResolution(
+                targetValidTime: resolution.targetValidTime,
+                candidates: [surfaceCandidate]
+            ),
+            fetchedAt: fetchedAt,
+            surfaceLevel: surfaceLevel
+        )
+    }
+}
+
 actor PreviewStubStormSetupFieldSampler: StormSetupFieldSampling {
     private let handler: @Sendable (GribSubsetCacheResult, StormSetupCentroid) async throws -> [HrrrFieldSample]
 
@@ -328,7 +355,7 @@ func previewMakeSurfaceProfileLoadResult(
     sourceResolution: HrrrRunResolution,
     fetchedAt: Date,
     cacheHit: Bool = false,
-    samples: [HrrrFieldSample]? = nil
+    surfaceLevel: StormSetupSurfaceProfileLevel = previewMakeSurfaceLevel()
 ) -> HrrrAnvilSurfaceProfileLoadResult {
     let subsetCacheResult = previewMakeSubsetResult(
         source: HrrrNomadsURLBuilder().makeSourceMetadata(
@@ -345,7 +372,7 @@ func previewMakeSurfaceProfileLoadResult(
     return HrrrAnvilSurfaceProfileLoadResult(
         sourceResolution: sourceResolution,
         subsetCacheResult: subsetCacheResult,
-        samples: samples ?? previewMakeSurfaceSamples()
+        surfaceLevel: surfaceLevel
     )
 }
 
@@ -462,9 +489,9 @@ func previewMakeSurfaceLevel(
     dewpointK: Double = 289.15,
     uWindMs: Double = -4.25,
     vWindMs: Double = 6.5
-) -> StormSetupPressureProfileLevel {
-    StormSetupPressureProfileLevel(
-        pressureMb: Int((pressurePa / 100).rounded()),
+) -> StormSetupSurfaceProfileLevel {
+    StormSetupSurfaceProfileLevel(
+        pressureMb: pressurePa / 100,
         heightMslM: heightMslM,
         temperatureC: temperatureK - 273.15,
         dewpointC: dewpointK - 273.15,

--- a/Tests/AppTests/AnvilProfileRequestBuilderTests.swift
+++ b/Tests/AppTests/AnvilProfileRequestBuilderTests.swift
@@ -26,6 +26,7 @@ struct AnvilProfileRequestBuilderTests {
             h3Cell: h3Cell,
             runTime: runTime,
             forecastHour: forecastHour,
+            surfaceLevel: makeSurfaceLevel(),
             groupedProfile: grouping
         )
         let expectedCentroid = try DefaultStormSetupH3Resolver().resolve(h3Cell: h3Cell)
@@ -36,12 +37,12 @@ struct AnvilProfileRequestBuilderTests {
         #expect(result.request.location.lat.isApproximatelyEqual(to: expectedCentroid.centroid.latitude))
         #expect(result.request.location.lon.isApproximatelyEqual(to: expectedCentroid.centroid.longitude))
         #expect(result.request.location.h3 == h3String(for: h3Cell))
-        #expect(result.request.profile.pressureMb == [1000, 925, 850, 700, 500])
-        #expect(result.request.profile.heightMslM == [1200, 1500, 1800, 2450, 5600])
-        #expect(result.request.profile.temperatureC == [28.4, 22.8, 17.5, 10.0, -4.2])
-        #expect(result.request.profile.dewpointC == [12.3, 10.1, 11.2, 1.0, -12.0])
-        #expect(result.request.profile.uWindMs == [-2.1, -5.4, -6.25, -12.5, -18.75])
-        #expect(result.request.profile.vWindMs == [4.6, 7.9, 8.75, 14.2, 22.0])
+        #expect(result.request.profile.pressureMb == [1012.4, 1000, 925, 850, 700, 500])
+        #expect(result.request.profile.heightMslM == [320, 1200, 1500, 1800, 2450, 5600])
+        #expect(result.request.profile.temperatureC == [29.6, 28.4, 22.8, 17.5, 10.0, -4.2])
+        #expect(result.request.profile.dewpointC == [16.4, 12.3, 10.1, 11.2, 1.0, -12.0])
+        #expect(result.request.profile.uWindMs == [-1.4, -2.1, -5.4, -6.25, -12.5, -18.75])
+        #expect(result.request.profile.vWindMs == [3.8, 4.6, 7.9, 8.75, 14.2, 22.0])
         #expect(result.warnings.isEmpty)
     }
 
@@ -54,6 +55,7 @@ struct AnvilProfileRequestBuilderTests {
             h3Cell: 617_700_169_958_293_503,
             runTime: runTime,
             forecastHour: forecastHour,
+            surfaceLevel: makeSurfaceLevel(),
             groupedProfile: makeGroupingResult(levels: makeFiveLevelProfile())
         )
 
@@ -74,6 +76,7 @@ struct AnvilProfileRequestBuilderTests {
             h3Cell: 123,
             runTime: makeUTCDate(year: 2026, month: 6, day: 19, hour: 22),
             forecastHour: 1,
+            surfaceLevel: makeSurfaceLevel(),
             groupedProfile: makeGroupingResult(levels: makeFiveLevelProfile())
         )
 
@@ -101,6 +104,7 @@ struct AnvilProfileRequestBuilderTests {
                 h3Cell: 617_700_169_958_293_503,
                 runTime: makeUTCDate(year: 2026, month: 6, day: 19, hour: 22),
                 forecastHour: 3,
+                surfaceLevel: makeSurfaceLevel(),
                 groupedProfile: grouping
             )
         }
@@ -129,6 +133,7 @@ struct AnvilProfileRequestBuilderTests {
                 h3Cell: 617_700_169_958_293_503,
                 runTime: makeUTCDate(year: 2026, month: 6, day: 19, hour: 22),
                 forecastHour: 3,
+                surfaceLevel: makeSurfaceLevel(),
                 groupedProfile: makeGroupingResult(levels: Array(makeFiveLevelProfile().prefix(4)))
             )
         }
@@ -137,7 +142,7 @@ struct AnvilProfileRequestBuilderTests {
     @Test("surface row is prepended without interpolation")
     func surfaceRowIsPrependedWithoutInterpolation() throws {
         let builder = makeBuilder()
-        let surfaceLevel = makeLevel(
+        let surfaceLevel = makeSurfaceLevel(
             pressureMb: 1012,
             heightMslM: 320,
             temperatureC: 29.6,
@@ -165,7 +170,7 @@ struct AnvilProfileRequestBuilderTests {
     @Test("surface row still requires five retained pressure levels")
     func surfaceRowStillRequiresFiveRetainedPressureLevels() {
         let builder = makeBuilder()
-        let surfaceLevel = makeLevel(
+        let surfaceLevel = makeSurfaceLevel(
             pressureMb: 1012,
             heightMslM: 320,
             temperatureC: 29.6,
@@ -188,7 +193,7 @@ struct AnvilProfileRequestBuilderTests {
     @Test("invalid surface ordering is rejected instead of being sorted away")
     func invalidSurfaceOrderingIsRejectedInsteadOfBeingSortedAway() {
         let builder = makeBuilder()
-        let surfaceLevel = makeLevel(
+        let surfaceLevel = makeSurfaceLevel(
             pressureMb: 990,
             heightMslM: 320,
             temperatureC: 29.6,
@@ -208,6 +213,24 @@ struct AnvilProfileRequestBuilderTests {
         }
     }
 
+    @Test("surface height must be below the first retained pressure level")
+    func invalidSurfaceHeightIsRejected() {
+        let surfaceLevel = makeSurfaceLevel(
+            pressureMb: 1_012,
+            heightMslM: 1_200
+        )
+
+        #expect(throws: AnvilProfileRequestBuilderError.self) {
+            _ = try makeBuilder().build(
+                h3Cell: 617_700_169_958_293_503,
+                runTime: makeUTCDate(year: 2026, month: 6, day: 19, hour: 22),
+                forecastHour: 3,
+                surfaceLevel: surfaceLevel,
+                groupedProfile: makeGroupingResult(levels: makeFiveLevelProfile())
+            )
+        }
+    }
+
     @Test("invalid H3 cells fail through the existing resolver")
     func invalidH3CellsFailThroughExistingResolver() {
         let builder = makeBuilder()
@@ -217,6 +240,7 @@ struct AnvilProfileRequestBuilderTests {
                 h3Cell: 0,
                 runTime: makeUTCDate(year: 2026, month: 6, day: 19, hour: 22),
                 forecastHour: 3,
+                surfaceLevel: makeSurfaceLevel(),
                 groupedProfile: makeGroupingResult(levels: makeFiveLevelProfile())
             )
         }
@@ -239,6 +263,7 @@ struct AnvilProfileRequestBuilderTests {
             h3Cell: 617_700_169_958_293_503,
             runTime: makeUTCDate(year: 2026, month: 6, day: 19, hour: 22),
             forecastHour: 3,
+            surfaceLevel: makeSurfaceLevel(),
             groupedProfile: grouping
         )
 
@@ -255,7 +280,7 @@ struct AnvilProfileRequestBuilderTests {
                 return false
             }
         }))
-        #expect(result.request.profile.pressureMb.count == 5)
+        #expect(result.request.profile.pressureMb.count == 6)
     }
 
     @Test("dropped levels are surfaced as quality warnings")
@@ -275,6 +300,7 @@ struct AnvilProfileRequestBuilderTests {
             h3Cell: 617_700_169_958_293_503,
             runTime: makeUTCDate(year: 2026, month: 6, day: 19, hour: 22),
             forecastHour: 3,
+            surfaceLevel: makeSurfaceLevel(),
             groupedProfile: grouping
         )
 
@@ -313,10 +339,14 @@ struct AnvilProfileRequestBuilderTests {
             h3Cell: 617_700_169_958_293_503,
             runTime: makeUTCDate(year: 2026, month: 6, day: 19, hour: 22),
             forecastHour: 3,
+            surfaceLevel: makeSurfaceLevel(
+                pressureMb: 940,
+                heightMslM: 1_300
+            ),
             groupedProfile: grouping
         )
 
-        #expect(result.request.profile.pressureMb == [925, 850, 700, 600, 500])
+        #expect(result.request.profile.pressureMb == [940, 925, 850, 700, 600, 500])
         #expect(result.warnings.contains(where: { warning in
             if case .droppedLevels(let levels) = warning {
                 return levels == grouping.droppedLevels
@@ -327,6 +357,24 @@ struct AnvilProfileRequestBuilderTests {
 
     private func makeBuilder() -> AnvilProfileRequestBuilder {
         AnvilProfileRequestBuilder()
+    }
+
+    private func makeSurfaceLevel(
+        pressureMb: Double = 1_012.4,
+        heightMslM: Double = 320,
+        temperatureC: Double = 29.6,
+        dewpointC: Double = 16.4,
+        uWindMs: Double = -1.4,
+        vWindMs: Double = 3.8
+    ) -> StormSetupSurfaceProfileLevel {
+        StormSetupSurfaceProfileLevel(
+            pressureMb: pressureMb,
+            heightMslM: heightMslM,
+            temperatureC: temperatureC,
+            dewpointC: dewpointC,
+            uWindMs: uWindMs,
+            vWindMs: vWindMs
+        )
     }
 
     private func makeFiveLevelProfile() -> [StormSetupPressureProfileLevel] {

--- a/Tests/AppTests/AnvilProfileRequestBuilderTests.swift
+++ b/Tests/AppTests/AnvilProfileRequestBuilderTests.swift
@@ -134,6 +134,80 @@ struct AnvilProfileRequestBuilderTests {
         }
     }
 
+    @Test("surface row is prepended without interpolation")
+    func surfaceRowIsPrependedWithoutInterpolation() throws {
+        let builder = makeBuilder()
+        let surfaceLevel = makeLevel(
+            pressureMb: 1012,
+            heightMslM: 320,
+            temperatureC: 29.6,
+            dewpointC: 16.4,
+            uWindMs: -1.4,
+            vWindMs: 3.8
+        )
+
+        let result = try builder.build(
+            h3Cell: 617_700_169_958_293_503,
+            runTime: makeUTCDate(year: 2026, month: 6, day: 19, hour: 22),
+            forecastHour: 3,
+            surfaceLevel: surfaceLevel,
+            groupedProfile: makeGroupingResult(levels: makeFiveLevelProfile())
+        )
+
+        #expect(result.request.profile.pressureMb == [1012, 1000, 925, 850, 700, 500])
+        #expect(result.request.profile.heightMslM == [320, 1200, 1500, 1800, 2450, 5600])
+        #expect(result.request.profile.temperatureC == [29.6, 28.4, 22.8, 17.5, 10.0, -4.2])
+        #expect(result.request.profile.dewpointC == [16.4, 12.3, 10.1, 11.2, 1.0, -12.0])
+        #expect(result.request.profile.uWindMs == [-1.4, -2.1, -5.4, -6.25, -12.5, -18.75])
+        #expect(result.request.profile.vWindMs == [3.8, 4.6, 7.9, 8.75, 14.2, 22.0])
+    }
+
+    @Test("surface row still requires five retained pressure levels")
+    func surfaceRowStillRequiresFiveRetainedPressureLevels() {
+        let builder = makeBuilder()
+        let surfaceLevel = makeLevel(
+            pressureMb: 1012,
+            heightMslM: 320,
+            temperatureC: 29.6,
+            dewpointC: 16.4,
+            uWindMs: -1.4,
+            vWindMs: 3.8
+        )
+
+        #expect(throws: AnvilProfileRequestBuilderError.self) {
+            _ = try builder.build(
+                h3Cell: 617_700_169_958_293_503,
+                runTime: makeUTCDate(year: 2026, month: 6, day: 19, hour: 22),
+                forecastHour: 3,
+                surfaceLevel: surfaceLevel,
+                groupedProfile: makeGroupingResult(levels: Array(makeFiveLevelProfile().prefix(4)))
+            )
+        }
+    }
+
+    @Test("invalid surface ordering is rejected instead of being sorted away")
+    func invalidSurfaceOrderingIsRejectedInsteadOfBeingSortedAway() {
+        let builder = makeBuilder()
+        let surfaceLevel = makeLevel(
+            pressureMb: 990,
+            heightMslM: 320,
+            temperatureC: 29.6,
+            dewpointC: 16.4,
+            uWindMs: -1.4,
+            vWindMs: 3.8
+        )
+
+        #expect(throws: AnvilProfileRequestBuilderError.self) {
+            _ = try builder.build(
+                h3Cell: 617_700_169_958_293_503,
+                runTime: makeUTCDate(year: 2026, month: 6, day: 19, hour: 22),
+                forecastHour: 3,
+                surfaceLevel: surfaceLevel,
+                groupedProfile: makeGroupingResult(levels: makeFiveLevelProfile())
+            )
+        }
+    }
+
     @Test("invalid H3 cells fail through the existing resolver")
     func invalidH3CellsFailThroughExistingResolver() {
         let builder = makeBuilder()

--- a/Tests/AppTests/AnvilSurfaceProfileNormalizerTests.swift
+++ b/Tests/AppTests/AnvilSurfaceProfileNormalizerTests.swift
@@ -1,0 +1,125 @@
+@testable import App
+import Foundation
+import Testing
+
+@Suite("Anvil surface profile normalizer", .serialized)
+struct AnvilSurfaceProfileNormalizerTests {
+    @Test("response values normalize into stable evidence bands and diagnostics")
+    func responseValuesNormalizeIntoStableEvidenceBandsAndDiagnostics() {
+        let evidence = AnvilSurfaceProfileNormalizer().normalize(response: makeResponse(
+            scp: 0.2130911716615775,
+            stpCin: 0.0,
+            stpFixed: 2.4,
+            ship: 0.6,
+            profileLevelCount: 20,
+            warnings: []
+        ))
+
+        #expect(evidence.scp?.support == .weak)
+        #expect(evidence.stp?.support == .supportive)
+        #expect(evidence.ship?.support == .conditional)
+        #expect(evidence.status == .available)
+        #expect(evidence.reason == nil)
+        #expect(evidence.diagnostics.hasEffectiveLayer)
+        #expect(evidence.diagnostics.hasStormMotion)
+        #expect(evidence.diagnostics.qualityProfileLevelCount == 20)
+        #expect(evidence.diagnostics.warnings.isEmpty)
+        #expect(!evidence.isDegraded)
+        #expect(evidence.strongestSupport == .supportive)
+    }
+
+    @Test("additional warnings keep the same bands but mark evidence degraded")
+    func additionalWarningsMarkEvidenceDegraded() {
+        let evidence = AnvilSurfaceProfileNormalizer().normalize(
+            response: makeResponse(
+                scp: 4.2,
+                stpCin: 0.0,
+                stpFixed: 3.4,
+                ship: 1.5,
+                profileLevelCount: 20,
+                warnings: []
+            ),
+            additionalWarnings: ["profile cache stale"]
+        )
+
+        #expect(evidence.scp?.support == .strong)
+        #expect(evidence.stp?.support == .strong)
+        #expect(evidence.ship?.support == .supportive)
+        #expect(evidence.status == .degraded)
+        #expect(evidence.reason == nil)
+        #expect(evidence.diagnostics.warnings == ["profile cache stale"])
+        #expect(evidence.isDegraded)
+    }
+
+    @Test("missing values and degraded diagnostics remain visible as degraded evidence")
+    func missingValuesAndDegradedDiagnosticsRemainVisibleAsDegradedEvidence() {
+        let evidence = AnvilSurfaceProfileNormalizer().normalize(response: makeResponse(
+            scp: nil,
+            stpCin: nil,
+            stpFixed: nil,
+            ship: nil,
+            effectiveLayerStatus: "notFound",
+            stormMotionStatus: "notComputed",
+            profileLevelCount: 3,
+            warnings: ["profile incomplete"]
+        ))
+
+        #expect(evidence.scp == nil)
+        #expect(evidence.stp == nil)
+        #expect(evidence.ship == nil)
+        #expect(evidence.status == .degraded)
+        #expect(evidence.supportCount == 0)
+        #expect(evidence.strongestSupport == nil)
+        #expect(evidence.isDegraded)
+        #expect(!evidence.diagnostics.hasEffectiveLayer)
+        #expect(!evidence.diagnostics.hasStormMotion)
+        #expect(evidence.diagnostics.isDegraded)
+    }
+
+    private func makeResponse(
+        scp: Double?,
+        stpCin: Double?,
+        stpFixed: Double?,
+        ship: Double?,
+        effectiveLayerStatus: String = "found",
+        stormMotionStatus: String = "computed",
+        profileLevelCount: Int,
+        warnings: [String]
+    ) -> AnvilAnalyzeProfileResponse {
+        AnvilAnalyzeProfileResponse(
+            effectiveLayer: AnvilEffectiveLayerDTO(
+                status: effectiveLayerStatus,
+                basePressureMb: 1000,
+                topPressureMb: 925,
+                baseMetersAgl: 0,
+                topMetersAgl: 690
+            ),
+            stormMotion: AnvilStormMotionDTO(
+                status: stormMotionStatus,
+                bunkersRight: AnvilBunkersRightStormMotionDTO(
+                    uKt: 36.80394762849837,
+                    vKt: 13.53066796460426,
+                    speedKt: 39.21236458834915,
+                    directionTowardDeg: 69.81446460119884,
+                    uMs: 18.933570033795217,
+                    vMs: 6.960770950382875,
+                    speedMs: 20.172565688288692
+                )
+            ),
+            mucape: 362.1018454649957,
+            mlcape: 191.7304143918497,
+            mlcin: -221.93726424748172,
+            mllclMetersAgl: 1179.4130766012365,
+            effectiveSrh: 29.42420403684148,
+            effectiveBulkShearMs: 30.134722226263612,
+            scp: scp,
+            stpCin: stpCin,
+            stpFixed: stpFixed,
+            ship: ship,
+            quality: AnvilQualityDTO(
+                profileLevelCount: profileLevelCount,
+                warnings: warnings
+            )
+        )
+    }
+}

--- a/Tests/AppTests/AnvilSurfaceProfileNormalizerTests.swift
+++ b/Tests/AppTests/AnvilSurfaceProfileNormalizerTests.swift
@@ -4,122 +4,67 @@ import Testing
 
 @Suite("Anvil surface profile normalizer", .serialized)
 struct AnvilSurfaceProfileNormalizerTests {
-    @Test("response values normalize into stable evidence bands and diagnostics")
-    func responseValuesNormalizeIntoStableEvidenceBandsAndDiagnostics() {
-        let evidence = AnvilSurfaceProfileNormalizer().normalize(response: makeResponse(
-            scp: 0.2130911716615775,
-            stpCin: 0.0,
-            stpFixed: 2.4,
-            ship: 0.6,
-            profileLevelCount: 20,
-            warnings: []
-        ))
-
-        #expect(evidence.scp?.support == .weak)
-        #expect(evidence.stp?.support == .supportive)
-        #expect(evidence.ship?.support == .conditional)
-        #expect(evidence.status == .available)
-        #expect(evidence.reason == nil)
-        #expect(evidence.diagnostics.hasEffectiveLayer)
-        #expect(evidence.diagnostics.hasStormMotion)
-        #expect(evidence.diagnostics.qualityProfileLevelCount == 20)
-        #expect(evidence.diagnostics.warnings.isEmpty)
-        #expect(!evidence.isDegraded)
-        #expect(evidence.strongestSupport == .supportive)
-    }
-
-    @Test("additional warnings keep the same bands but mark evidence degraded")
-    func additionalWarningsMarkEvidenceDegraded() {
-        let evidence = AnvilSurfaceProfileNormalizer().normalize(
-            response: makeResponse(
-                scp: 4.2,
-                stpCin: 0.0,
-                stpFixed: 3.4,
-                ship: 1.5,
-                profileLevelCount: 20,
-                warnings: []
-            ),
-            additionalWarnings: ["profile cache stale"]
-        )
-
-        #expect(evidence.scp?.support == .strong)
-        #expect(evidence.stp?.support == .strong)
-        #expect(evidence.ship?.support == .supportive)
-        #expect(evidence.status == .degraded)
-        #expect(evidence.reason == nil)
-        #expect(evidence.diagnostics.warnings == ["profile cache stale"])
-        #expect(evidence.isDegraded)
-    }
-
-    @Test("missing values and degraded diagnostics remain visible as degraded evidence")
-    func missingValuesAndDegradedDiagnosticsRemainVisibleAsDegradedEvidence() {
-        let evidence = AnvilSurfaceProfileNormalizer().normalize(response: makeResponse(
-            scp: nil,
-            stpCin: nil,
-            stpFixed: nil,
-            ship: nil,
-            effectiveLayerStatus: "notFound",
-            stormMotionStatus: "notComputed",
-            profileLevelCount: 3,
-            warnings: ["profile incomplete"]
-        ))
-
-        #expect(evidence.scp == nil)
-        #expect(evidence.stp == nil)
-        #expect(evidence.ship == nil)
-        #expect(evidence.status == .degraded)
-        #expect(evidence.supportCount == 0)
-        #expect(evidence.strongestSupport == nil)
-        #expect(evidence.isDegraded)
-        #expect(!evidence.diagnostics.hasEffectiveLayer)
-        #expect(!evidence.diagnostics.hasStormMotion)
-        #expect(evidence.diagnostics.isDegraded)
-    }
-
-    private func makeResponse(
-        scp: Double?,
-        stpCin: Double?,
-        stpFixed: Double?,
-        ship: Double?,
-        effectiveLayerStatus: String = "found",
-        stormMotionStatus: String = "computed",
-        profileLevelCount: Int,
-        warnings: [String]
-    ) -> AnvilAnalyzeProfileResponse {
-        AnvilAnalyzeProfileResponse(
-            effectiveLayer: AnvilEffectiveLayerDTO(
-                status: effectiveLayerStatus,
-                basePressureMb: 1000,
-                topPressureMb: 925,
-                baseMetersAgl: 0,
-                topMetersAgl: 690
-            ),
-            stormMotion: AnvilStormMotionDTO(
-                status: stormMotionStatus,
-                bunkersRight: AnvilBunkersRightStormMotionDTO(
-                    uKt: 36.80394762849837,
-                    vKt: 13.53066796460426,
-                    speedKt: 39.21236458834915,
-                    directionTowardDeg: 69.81446460119884,
-                    uMs: 18.933570033795217,
-                    vMs: 6.960770950382875,
-                    speedMs: 20.172565688288692
-                )
-            ),
-            mucape: 362.1018454649957,
-            mlcape: 191.7304143918497,
-            mlcin: -221.93726424748172,
-            mllclMetersAgl: 1179.4130766012365,
-            effectiveSrh: 29.42420403684148,
-            effectiveBulkShearMs: 30.134722226263612,
-            scp: scp,
-            stpCin: stpCin,
-            stpFixed: stpFixed,
-            ship: ship,
-            quality: AnvilQualityDTO(
-                profileLevelCount: profileLevelCount,
-                warnings: warnings
+    @Test("complete samples normalize units and preserve fractional surface pressure")
+    func completeSamplesNormalizeUnits() throws {
+        let level = try AnvilSurfaceProfileNormalizer().normalize(
+            samples: previewMakeSurfaceSamples(
+                pressurePa: 94_040,
+                heightMslM: 1_234,
+                temperatureK: 295.15,
+                dewpointK: 289.15,
+                uWindMs: -4.25,
+                vWindMs: 6.5
             )
         )
+
+        #expect(level.pressureMb == 940.4)
+        #expect(level.heightMslM == 1_234)
+        #expect(level.temperatureC.isApproximatelyEqual(to: 22))
+        #expect(level.dewpointC.isApproximatelyEqual(to: 16))
+        #expect(level.uWindMs == -4.25)
+        #expect(level.vWindMs == 6.5)
+    }
+
+    @Test("first matching value is selected deterministically")
+    func firstMatchingValueIsSelected() throws {
+        let samples = previewMakeSurfaceSamples(pressurePa: 94_000)
+            + [previewSample("7:0:d=2026060313:PRES:surface:9 hour fcst:lon=-104.47,lat=39.79,val=95000")]
+
+        let level = try AnvilSurfaceProfileNormalizer().normalize(samples: samples)
+
+        #expect(level.pressureMb == 940)
+    }
+
+    @Test("missing and nonfinite fields are reported by name")
+    func missingAndNonfiniteFieldsAreReported() {
+        let samples = previewMakeSurfaceSamples().filter {
+            !["TMP", "VGRD"].contains($0.point.inventoryDescriptor?.variable)
+        }
+        + [previewSample("7:0:d=2026060313:TMP:2 m above ground:9 hour fcst:lon=-104.47,lat=39.79,val=nan")]
+
+        do {
+            _ = try AnvilSurfaceProfileNormalizer().normalize(samples: samples)
+            Issue.record("Expected incomplete surface profile rejection.")
+        } catch let error as AnvilSurfaceProfileNormalizationError {
+            #expect(error.invalidFields == [.temperature, .vWind])
+            #expect(error.description.contains("TMP"))
+            #expect(error.description.contains("VGRD"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test("out-of-range pressure is rejected without integer conversion")
+    func outOfRangePressureIsRejected() {
+        do {
+            _ = try AnvilSurfaceProfileNormalizer().normalize(
+                samples: previewMakeSurfaceSamples(pressurePa: 9.999e20)
+            )
+            Issue.record("Expected invalid surface pressure rejection.")
+        } catch let error as AnvilSurfaceProfileNormalizationError {
+            #expect(error.invalidFields == [.pressure])
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
     }
 }

--- a/Tests/AppTests/HrrrAnvilSurfaceProfileLoadingTests.swift
+++ b/Tests/AppTests/HrrrAnvilSurfaceProfileLoadingTests.swift
@@ -1,0 +1,176 @@
+@testable import App
+import Foundation
+import Testing
+
+@Suite("HRRR Anvil surface profile loading", .serialized)
+struct HrrrAnvilSurfaceProfileLoadingTests {
+    @Test("loader constructs exactly one matching wrfsfc candidate")
+    func loaderConstructsExactlyOneMatchingWrfsfcCandidate() async throws {
+        let centroid = StormSetupCentroid(latitude: 39.7825, longitude: -104.4661)
+        let sourceResolution = HrrrRunResolution(
+            targetValidTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22),
+            candidates: [
+                HrrrRunCandidate(
+                    product: .wrfprsf,
+                    runTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22),
+                    forecastHour: 0,
+                    fieldSetVersion: .tornadoPressureV2
+                ),
+                HrrrRunCandidate(
+                    product: .wrfprsf,
+                    runTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 21),
+                    forecastHour: 1,
+                    fieldSetVersion: .tornadoPressureV2
+                )
+            ]
+        )
+        let expectedSurfaceCandidate = HrrrRunCandidate(
+            runTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22),
+            forecastHour: 0
+        )
+        let subsetLoader = SurfaceProfileStubSubsetLoading { resolution, requestCentroid in
+            #expect(resolution.targetValidTime == sourceResolution.targetValidTime)
+            #expect(resolution.candidates == [expectedSurfaceCandidate])
+            #expect(resolution.candidates.allSatisfy { $0.product == .wrfsfc })
+            #expect(requestCentroid == centroid)
+
+            return GribSubsetCacheResult(
+                source: HrrrNomadsURLBuilder().makeSourceMetadata(
+                    for: expectedSurfaceCandidate,
+                    around: requestCentroid
+                ),
+                localFileURL: URL(fileURLWithPath: "/private/tmp/surface-profile.grib2"),
+                byteSize: 1_024,
+                fetchedAt: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22),
+                expiresAt: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 34),
+                cacheHit: false
+            )
+        }
+        let sampler = SurfaceProfileStubFieldSampling { subset, requestCentroid in
+            #expect(subset.source.product == .wrfsfc)
+            #expect(subset.byteSize == 1_024)
+            #expect(requestCentroid == centroid)
+            return [
+                previewSample("1:0:d=2026060313:HGT:1000 mb:9 hour fcst:lon=-104.47,lat=39.79,val=100")
+            ]
+        }
+        let loader = DefaultHrrrAnvilSurfaceProfileLoader(
+            subsetLoader: subsetLoader,
+            fieldSampler: sampler
+        )
+
+        let result = try await loader.loadSurfaceProfile(
+            for: sourceResolution,
+            around: centroid
+        )
+
+        #expect(result.sourceResolution.candidates == [expectedSurfaceCandidate])
+        #expect(result.subsetCacheResult.cacheHit == false)
+        #expect(result.samples.count == 1)
+    }
+
+    @Test("loader preserves cancellation and does not advance to another cycle")
+    func loaderPreservesCancellationAndDoesNotAdvanceToAnotherCycle() async throws {
+        let centroid = StormSetupCentroid(latitude: 39.7825, longitude: -104.4661)
+        let sourceResolution = HrrrRunResolution(
+            targetValidTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22),
+            candidates: [
+                HrrrRunCandidate(
+                    product: .wrfprsf,
+                    runTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22),
+                    forecastHour: 0,
+                    fieldSetVersion: .tornadoPressureV2
+                ),
+                HrrrRunCandidate(
+                    product: .wrfprsf,
+                    runTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 21),
+                    forecastHour: 1,
+                    fieldSetVersion: .tornadoPressureV2
+                )
+            ]
+        )
+        let subsetLoader = SurfaceProfileStubSubsetLoading { _, _ in
+            throw CancellationError()
+        }
+        let sampler = SurfaceProfileStubFieldSampling { _, _ in
+            Issue.record("Field sampling should not run after cancellation.")
+            throw AnvilProfilePreviewError.internalExecutionFailure(reason: "unexpected sampler call")
+        }
+        let loader = DefaultHrrrAnvilSurfaceProfileLoader(
+            subsetLoader: subsetLoader,
+            fieldSampler: sampler
+        )
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await loader.loadSurfaceProfile(
+                for: sourceResolution,
+                around: centroid
+            )
+        }
+
+        #expect(subsetLoader.requestCount == 1)
+        #expect(sampler.requestCount == 0)
+    }
+}
+
+private final class SurfaceProfileStubSubsetLoading: StormSetupSubsetLoading, @unchecked Sendable {
+    typealias Handler = @Sendable (HrrrRunResolution, StormSetupCentroid) throws -> GribSubsetCacheResult
+
+    private let handler: Handler
+    private(set) var requestCount = 0
+
+    init(handler: @escaping Handler) {
+        self.handler = handler
+    }
+
+    func loadFirstAvailableSubset(
+        for resolution: HrrrRunResolution,
+        around centroid: StormSetupCentroid
+    ) async throws -> GribSubsetCacheResult {
+        requestCount += 1
+        return try handler(resolution, centroid)
+    }
+}
+
+private final class SurfaceProfileStubFieldSampling: StormSetupFieldSampling, @unchecked Sendable {
+    typealias Handler = @Sendable (GribSubsetCacheResult, StormSetupCentroid) throws -> [HrrrFieldSample]
+
+    private let handler: Handler
+    private(set) var requestCount = 0
+
+    init(handler: @escaping Handler) {
+        self.handler = handler
+    }
+
+    func sample(
+        from subset: GribSubsetCacheResult,
+        around centroid: StormSetupCentroid
+    ) async throws -> [HrrrFieldSample] {
+        requestCount += 1
+        return try handler(subset, centroid)
+    }
+
+    func sample(
+        localFileURL: URL,
+        around centroid: StormSetupCentroid
+    ) async throws -> [HrrrFieldSample] {
+        requestCount += 1
+        return try handler(
+            GribSubsetCacheResult(
+                source: HrrrNomadsURLBuilder().makeSourceMetadata(
+                    for: HrrrRunCandidate(
+                        runTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22),
+                        forecastHour: 0
+                    ),
+                    around: centroid
+                ),
+                localFileURL: localFileURL,
+                byteSize: 0,
+                fetchedAt: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22),
+                expiresAt: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 34),
+                cacheHit: true
+            ),
+            centroid
+        )
+    }
+}

--- a/Tests/AppTests/HrrrAnvilSurfaceProfileLoadingTests.swift
+++ b/Tests/AppTests/HrrrAnvilSurfaceProfileLoadingTests.swift
@@ -52,9 +52,7 @@ struct HrrrAnvilSurfaceProfileLoadingTests {
             #expect(subset.source.fieldSetVersion == .anvilSurfaceV1)
             #expect(subset.byteSize == 1_024)
             #expect(requestCentroid == centroid)
-            return [
-                previewSample("1:0:d=2026060313:HGT:1000 mb:9 hour fcst:lon=-104.47,lat=39.79,val=100")
-            ]
+            return previewMakeSurfaceSamples(pressurePa: 94_040)
         }
         let loader = DefaultHrrrAnvilSurfaceProfileLoader(
             subsetLoader: subsetLoader,
@@ -68,7 +66,8 @@ struct HrrrAnvilSurfaceProfileLoadingTests {
 
         #expect(result.sourceResolution.candidates == [expectedSurfaceCandidate])
         #expect(result.subsetCacheResult.cacheHit == false)
-        #expect(result.samples.count == 1)
+        #expect(result.surfaceLevel.pressureMb == 940.4)
+        #expect(result.surfaceLevel.heightMslM == 1_234)
     }
 
     @Test("loader preserves cancellation and does not advance to another cycle")

--- a/Tests/AppTests/HrrrAnvilSurfaceProfileLoadingTests.swift
+++ b/Tests/AppTests/HrrrAnvilSurfaceProfileLoadingTests.swift
@@ -26,7 +26,8 @@ struct HrrrAnvilSurfaceProfileLoadingTests {
         )
         let expectedSurfaceCandidate = HrrrRunCandidate(
             runTime: previewMakeUTCDate(year: 2026, month: 6, day: 3, hour: 22),
-            forecastHour: 0
+            forecastHour: 0,
+            fieldSetVersion: .anvilSurfaceV1
         )
         let subsetLoader = SurfaceProfileStubSubsetLoading { resolution, requestCentroid in
             #expect(resolution.targetValidTime == sourceResolution.targetValidTime)
@@ -48,6 +49,7 @@ struct HrrrAnvilSurfaceProfileLoadingTests {
         }
         let sampler = SurfaceProfileStubFieldSampling { subset, requestCentroid in
             #expect(subset.source.product == .wrfsfc)
+            #expect(subset.source.fieldSetVersion == .anvilSurfaceV1)
             #expect(subset.byteSize == 1_024)
             #expect(requestCentroid == centroid)
             return [

--- a/Tests/AppTests/PressureArtifactDiagnosticsTests.swift
+++ b/Tests/AppTests/PressureArtifactDiagnosticsTests.swift
@@ -567,6 +567,175 @@ struct PressureArtifactDiagnosticsTests {
         assertNoRequestPathSensitiveMetadata(in: [exactEvent, staleEvent, unavailableEvent, mismatchEvent, missingProviderEvent])
         assertNoSensitiveMetadata(in: [exactEvent, staleEvent, unavailableEvent, mismatchEvent, missingProviderEvent])
     }
+
+    @Test("preview diagnostics include surface pressure and surface cache state")
+    func previewDiagnosticsIncludeSurfacePressureAndSurfaceCacheState() async throws {
+        let now = makeUTCDate(year: 2026, month: 6, day: 3, hour: 22, minute: 45)
+        let h3Cell: Int64 = 617_700_169_958_293_503
+        let surfaceCandidate = HrrrRunCandidate(
+            runTime: makeTruncatedToHour(now),
+            forecastHour: 0
+        )
+        let pressureCandidate = makePressureCandidate(from: surfaceCandidate)
+        let expectedSurfaceCandidate = HrrrRunCandidate(
+            model: pressureCandidate.model,
+            product: .wrfsfc,
+            domain: pressureCandidate.domain,
+            runTime: pressureCandidate.runTime,
+            forecastHour: pressureCandidate.forecastHour,
+            fieldSetVersion: .anvilSurfaceV1
+        )
+        let expectedCentroid = try DefaultStormSetupH3Resolver().resolve(h3Cell: h3Cell).centroid
+        let loggerContext = makeCapturingLogger(label: "preview-surface-success")
+        let pressureSourceResolver = PreviewStubPressureSourceResolver { _, _ in
+            makePreviewPressureSourceResolution(
+                candidate: pressureCandidate,
+                idxAvailable: true
+            )
+        }
+        let surfaceProfileLoader = PreviewStubSurfaceProfileLoader { _, resolution, centroid in
+            #expect(resolution.targetValidTime == makeTruncatedToHour(now))
+            #expect(resolution.candidates == [pressureCandidate])
+            #expect(centroid == expectedCentroid)
+            return previewMakeSurfaceProfileLoadResult(
+                sourceResolution: HrrrRunResolution(
+                    targetValidTime: makeTruncatedToHour(now),
+                    candidates: [expectedSurfaceCandidate]
+                ),
+                fetchedAt: now,
+                cacheHit: true,
+                samples: previewMakeSurfaceSamples()
+            )
+        }
+        let pressureProfileLoader = PreviewStubPressureProfileLoader { _, sourceResolution, centroid, surfaceHeightMslM in
+            #expect(sourceResolution.candidate == pressureCandidate)
+            #expect(sourceResolution.source.runTime == pressureCandidate.runTime)
+            #expect(sourceResolution.source.forecastHour == pressureCandidate.forecastHour)
+            #expect(sourceResolution.source.validTime == pressureCandidate.validTime)
+            #expect(centroid == expectedCentroid)
+            #expect(surfaceHeightMslM == 1_234)
+            return previewMakePressureProfileLoadResult(
+                sourceResolution: sourceResolution,
+                fetchedAt: now,
+                subsetCacheHit: false,
+                samples: previewMakeEightLevelPressureSamples(),
+                surfaceHeightMslM: surfaceHeightMslM
+            )
+        }
+        let provider = DefaultAnvilProfilePreviewProvider(
+            h3Resolver: DefaultStormSetupH3Resolver(),
+            dateProvider: makeFixedStormSetupDateProvider(nowDate: now),
+            hrrrRunResolver: PreviewStaticHrrrRunResolver(
+                resolution: HrrrRunResolution(targetValidTime: makeTruncatedToHour(now), candidates: [surfaceCandidate])
+            ),
+            surfaceProfileLoader: surfaceProfileLoader,
+            pressureSourceResolver: pressureSourceResolver,
+            pressureProfileLoader: pressureProfileLoader,
+            logger: loggerContext.logger
+        )
+
+        let preview = try await provider.previewProfile(for: h3Cell)
+        let sourceSelected = try #require(try loggerContext.event(matching: "Anvil preview exact-cycle surface source selected."))
+        let rowIncluded = try #require(try loggerContext.event(matching: "Anvil preview exact-cycle surface row included."))
+
+        #expect(metadataString(sourceSelected.metadata, "pressureSourceRunTime") == pressureCandidate.runTime.ISO8601Format())
+        #expect(metadataString(sourceSelected.metadata, "pressureSourceForecastHour") == String(pressureCandidate.forecastHour))
+        #expect(metadataString(sourceSelected.metadata, "pressureSourceValidTime") == pressureCandidate.validTime.ISO8601Format())
+        #expect(metadataString(sourceSelected.metadata, "surfaceSourceRunTime") == expectedSurfaceCandidate.runTime.ISO8601Format())
+        #expect(metadataString(sourceSelected.metadata, "surfaceSourceForecastHour") == String(expectedSurfaceCandidate.forecastHour))
+        #expect(metadataString(sourceSelected.metadata, "surfaceSourceValidTime") == expectedSurfaceCandidate.validTime.ISO8601Format())
+        #expect(metadataString(sourceSelected.metadata, "surfaceStage") == "selected")
+        #expect(metadataString(rowIncluded.metadata, "surfacePressureMb") == "940")
+        #expect(metadataString(rowIncluded.metadata, "surfaceSubsetCacheHit") == "true")
+        #expect(metadataString(rowIncluded.metadata, "surfaceRowIncluded") == "true")
+        #expect(preview.debug.surfacePressureMb == 940)
+        #expect(preview.debug.surfaceSubsetCacheHit == true)
+        #expect(preview.request.profile.pressureMb.first == 940)
+        #expect(preview.request.profile.pressureMb.count == 8)
+        #expect(await pressureProfileLoader.callCount == 1)
+        #expect(await surfaceProfileLoader.callCount == 1)
+        assertNoSensitiveMetadata(in: loggerContext.events)
+        assertNoRequestPathSensitiveMetadata(in: loggerContext.events)
+        for event in loggerContext.events {
+            #expect(event.metadata.keys.contains("selectedPressureLevels") == false)
+            #expect(event.metadata.keys.contains("pressureLevelsRequested") == false)
+            #expect(event.metadata.keys.contains("pressureLevelsRetained") == false)
+        }
+    }
+
+    @Test("preview diagnostics report a concise surface rejection reason")
+    func previewDiagnosticsReportConciseSurfaceRejectionReason() async throws {
+        let now = makeUTCDate(year: 2026, month: 6, day: 3, hour: 22, minute: 45)
+        let h3Cell: Int64 = 617_700_169_958_293_503
+        let surfaceCandidate = HrrrRunCandidate(
+            runTime: makeTruncatedToHour(now),
+            forecastHour: 0
+        )
+        let pressureCandidate = makePressureCandidate(from: surfaceCandidate)
+        let mismatchCandidate = HrrrRunCandidate(
+            product: .wrfsfc,
+            runTime: pressureCandidate.runTime.addingTimeInterval(-3_600),
+            forecastHour: pressureCandidate.forecastHour
+        )
+        let loggerContext = makeCapturingLogger(label: "preview-surface-rejection")
+        let pressureSourceResolver = PreviewStubPressureSourceResolver { _, _ in
+            makePreviewPressureSourceResolution(
+                candidate: pressureCandidate,
+                idxAvailable: true
+            )
+        }
+        let surfaceProfileLoader = PreviewStubSurfaceProfileLoader { _, _, _ in
+            previewMakeSurfaceProfileLoadResult(
+                sourceResolution: HrrrRunResolution(
+                    targetValidTime: makeTruncatedToHour(now),
+                    candidates: [mismatchCandidate]
+                ),
+                fetchedAt: now,
+                cacheHit: false,
+                samples: previewMakeSurfaceSamples()
+            )
+        }
+        let pressureProfileLoader = PreviewStubPressureProfileLoader { _, _, _, _ in
+            Issue.record("Pressure profile loading should not have been reached after a surface mismatch.")
+            throw AnvilProfilePreviewError.upstreamUnavailable(reason: "unexpected pressure load")
+        }
+        let provider = DefaultAnvilProfilePreviewProvider(
+            h3Resolver: DefaultStormSetupH3Resolver(),
+            dateProvider: makeFixedStormSetupDateProvider(nowDate: now),
+            hrrrRunResolver: PreviewStaticHrrrRunResolver(
+                resolution: HrrrRunResolution(targetValidTime: makeTruncatedToHour(now), candidates: [surfaceCandidate])
+            ),
+            surfaceProfileLoader: surfaceProfileLoader,
+            pressureSourceResolver: pressureSourceResolver,
+            pressureProfileLoader: pressureProfileLoader,
+            logger: loggerContext.logger
+        )
+
+        do {
+            _ = try await provider.previewProfile(for: h3Cell)
+            Issue.record("Expected a surface source mismatch to fail.")
+        } catch let error as AnvilProfilePreviewError {
+            if case .unusableProfile(let reason) = error {
+                #expect(reason.contains("Matching surface source identity"))
+            } else {
+                Issue.record("Expected unusable profile error but got \(error).")
+            }
+        }
+
+        let rejected = try #require(try loggerContext.event(matching: "Anvil preview exact-cycle surface row rejected."))
+        #expect(metadataString(rejected.metadata, "surfaceStage") == "mismatched")
+        #expect(metadataString(rejected.metadata, "surfaceRowIncluded") == "false")
+        #expect(metadataString(rejected.metadata, "reason")?.contains("Matching surface source identity") == true)
+        #expect(rejected.metadata.keys.contains("selectedPressureLevels") == false)
+        #expect(rejected.metadata.keys.contains("pressureLevelsRequested") == false)
+        #expect(rejected.metadata.keys.contains("pressureLevelsRetained") == false)
+        #expect(rejected.metadata.keys.contains("h3") == false)
+        #expect(rejected.metadata.keys.contains("latitude") == false)
+        #expect(rejected.metadata.keys.contains("longitude") == false)
+        #expect(await pressureProfileLoader.callCount == 0)
+        assertNoSensitiveMetadata(in: loggerContext.events)
+        assertNoRequestPathSensitiveMetadata(in: loggerContext.events)
+    }
 }
 
 private extension PressureArtifactDiagnosticsTests {
@@ -763,6 +932,38 @@ private extension PressureArtifactDiagnosticsTests {
         }
 
         return date
+    }
+
+    func makeTruncatedToHour(_ date: Date) -> Date {
+        StormSetupUTC.calendar.date(
+            from: DateComponents(
+                timeZone: TimeZone(secondsFromGMT: 0),
+                year: StormSetupUTC.calendar.component(.year, from: date),
+                month: StormSetupUTC.calendar.component(.month, from: date),
+                day: StormSetupUTC.calendar.component(.day, from: date),
+                hour: StormSetupUTC.calendar.component(.hour, from: date)
+            )
+        ) ?? date
+    }
+
+    func makePreviewPressureSourceResolution(
+        candidate: HrrrRunCandidate,
+        idxAvailable: Bool
+    ) -> HrrrPressureDirectObjectResolution {
+        let builder = HrrrPressureDirectObjectURLBuilder()
+        let source = builder.makeSourceMetadata(for: candidate)
+        let idxURL = source.idxURL ?? builder.makeIdxURL(for: candidate)
+
+        return HrrrPressureDirectObjectResolution(
+            candidate: candidate,
+            source: source,
+            idxProbe: HrrrRemoteObjectProbeResult(
+                url: idxURL,
+                available: idxAvailable,
+                status: idxAvailable ? 200 : 404
+            ),
+            gribProbe: nil
+        )
     }
 
     func makeCapturingLogger(label: String) -> CapturingLoggerContext {
@@ -988,6 +1189,8 @@ private extension PressureArtifactDiagnosticsTests {
             centroid: StormSetupCentroid(latitude: 39.78, longitude: -104.46),
             selectedMessageCount: 0,
             selectedPressureLevels: [],
+            surfacePressureMb: 940,
+            surfaceSubsetCacheHit: false,
             rangeCount: 0,
             totalSelectedRangeBytes: 0,
             pressureLevelsRequested: [],

--- a/Tests/AppTests/PressureArtifactDiagnosticsTests.swift
+++ b/Tests/AppTests/PressureArtifactDiagnosticsTests.swift
@@ -604,7 +604,7 @@ struct PressureArtifactDiagnosticsTests {
                 ),
                 fetchedAt: now,
                 cacheHit: true,
-                samples: previewMakeSurfaceSamples()
+                surfaceLevel: previewMakeSurfaceLevel()
             )
         }
         let pressureProfileLoader = PreviewStubPressureProfileLoader { _, sourceResolution, centroid, surfaceHeightMslM in
@@ -645,7 +645,7 @@ struct PressureArtifactDiagnosticsTests {
         #expect(metadataString(sourceSelected.metadata, "surfaceSourceForecastHour") == String(expectedSurfaceCandidate.forecastHour))
         #expect(metadataString(sourceSelected.metadata, "surfaceSourceValidTime") == expectedSurfaceCandidate.validTime.ISO8601Format())
         #expect(metadataString(sourceSelected.metadata, "surfaceStage") == "selected")
-        #expect(metadataString(rowIncluded.metadata, "surfacePressureMb") == "940")
+        #expect(metadataString(rowIncluded.metadata, "surfacePressureMb") == "940.0")
         #expect(metadataString(rowIncluded.metadata, "surfaceSubsetCacheHit") == "true")
         #expect(metadataString(rowIncluded.metadata, "surfaceRowIncluded") == "true")
         #expect(preview.debug.surfacePressureMb == 940)
@@ -692,7 +692,7 @@ struct PressureArtifactDiagnosticsTests {
                 ),
                 fetchedAt: now,
                 cacheHit: false,
-                samples: previewMakeSurfaceSamples()
+                surfaceLevel: previewMakeSurfaceLevel()
             )
         }
         let pressureProfileLoader = PreviewStubPressureProfileLoader { _, _, _, _ in

--- a/Tests/AppTests/PressureArtifactDiagnosticsTests.swift
+++ b/Tests/AppTests/PressureArtifactDiagnosticsTests.swift
@@ -1312,12 +1312,8 @@ private struct StubStormSetupNormalizer: StormSetupIngredientNormalizing {
 private struct StaticAnvilProfileAnalysisProvider: AnvilProfileAnalysisProviding, @unchecked Sendable {
     let response: AnvilAnalyzeProfileAnalysisResponse
 
-    func analyzeProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfileAnalysisResponse {
+    func analyzeProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfileAnalysisResponse {
         _ = h3Cell
-        _ = surfaceHeightMslM
         return response
     }
 }
@@ -1333,12 +1329,8 @@ private struct FixedStormSetupDateProvider: StormSetupDateProviding {
 private struct ThrowingAnvilProfileAnalysisProvider: AnvilProfileAnalysisProviding, @unchecked Sendable {
     let error: any Error
 
-    func analyzeProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfileAnalysisResponse {
+    func analyzeProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfileAnalysisResponse {
         _ = h3Cell
-        _ = surfaceHeightMslM
         throw error
     }
 }
@@ -1346,12 +1338,8 @@ private struct ThrowingAnvilProfileAnalysisProvider: AnvilProfileAnalysisProvidi
 private struct SuspendedAnvilProfileAnalysisProvider: AnvilProfileAnalysisProviding, @unchecked Sendable {
     let response: AnvilAnalyzeProfileAnalysisResponse
 
-    func analyzeProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfileAnalysisResponse {
+    func analyzeProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfileAnalysisResponse {
         _ = h3Cell
-        _ = surfaceHeightMslM
         try await Task.sleep(for: .seconds(10))
         return response
     }

--- a/Tests/AppTests/StormSetupHrrrSourceTests.swift
+++ b/Tests/AppTests/StormSetupHrrrSourceTests.swift
@@ -120,6 +120,35 @@ struct StormSetupHrrrSourceTests {
         #expect(!urlString.contains("latest"))
     }
 
+    @Test("NOMADS URL builder includes the Anvil surface row field set")
+    func urlBuilderIncludesAnvilSurfaceFieldSet() throws {
+        let candidate = HrrrRunCandidate(
+            runTime: makeUTCDate(year: 2026, month: 6, day: 3, hour: 13),
+            forecastHour: 9,
+            fieldSetVersion: .anvilSurfaceV1
+        )
+        let centroid = StormSetupCentroid(latitude: 39.7825, longitude: -104.4661)
+        let builder = HrrrNomadsURLBuilder()
+
+        let metadata = builder.makeSourceMetadata(for: candidate, around: centroid)
+        let urlString = metadata.primaryDownloadURL?.absoluteString ?? ""
+
+        #expect(metadata.fieldSetVersion == .anvilSurfaceV1)
+        #expect(urlString.contains("/cgi-bin/filter_hrrr_2d.pl"))
+        #expect(urlString.contains("file=hrrr.t13z.wrfsfcf09.grib2"))
+        #expect(urlString.contains("var_PRES=on"))
+        #expect(urlString.contains("var_HGT=on"))
+        #expect(urlString.contains("var_TMP=on"))
+        #expect(urlString.contains("var_DPT=on"))
+        #expect(urlString.contains("var_UGRD=on"))
+        #expect(urlString.contains("var_VGRD=on"))
+        #expect(urlString.contains("lev_surface=on"))
+        #expect(urlString.contains("lev_2_m_above_ground=on"))
+        #expect(urlString.contains("lev_10_m_above_ground=on"))
+        #expect(!urlString.contains("var_CAPE=on"))
+        #expect(!urlString.contains("lev_90-0_mb_above_ground=on"))
+    }
+
     @Test("NOMADS URL builder includes pressure-level variables and levels")
     func urlBuilderIncludesPressureFieldSet() throws {
         let candidate = HrrrRunCandidate(

--- a/Tests/AppTests/StormSetupProviderTests.swift
+++ b/Tests/AppTests/StormSetupProviderTests.swift
@@ -209,7 +209,6 @@ struct StormSetupProviderTests {
 
         #expect(snapshot.surfaceHeightMslM == 1234)
         #expect(snapshot.anvilEvidence?.status == .available)
-        #expect(await anvilProvider.recordedSurfaceHeightMslM == 1234)
         #expect(await anvilProvider.requestCount == 1)
     }
 
@@ -1399,12 +1398,8 @@ private struct StubStormSetupAssessor: StormSetupIngredientAssessing, @unchecked
 private struct StubAnvilProfileAnalysisProvider: AnvilProfileAnalysisProviding, @unchecked Sendable {
     let response: AnvilAnalyzeProfileAnalysisResponse
 
-    func analyzeProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfileAnalysisResponse {
+    func analyzeProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfileAnalysisResponse {
         _ = h3Cell
-        _ = surfaceHeightMslM
         return response
     }
 }
@@ -1417,12 +1412,8 @@ private actor CountingAnvilProfileAnalysisProvider: AnvilProfileAnalysisProvidin
         self.response = response
     }
 
-    func analyzeProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfileAnalysisResponse {
+    func analyzeProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfileAnalysisResponse {
         _ = h3Cell
-        _ = surfaceHeightMslM
         requestCount += 1
         return response
     }
@@ -1431,19 +1422,14 @@ private actor CountingAnvilProfileAnalysisProvider: AnvilProfileAnalysisProvidin
 private actor CapturingAnvilProfileAnalysisProvider: AnvilProfileAnalysisProviding {
     private let response: AnvilAnalyzeProfileAnalysisResponse
     private(set) var requestCount = 0
-    private(set) var recordedSurfaceHeightMslM: Double?
 
     init(response: AnvilAnalyzeProfileAnalysisResponse) {
         self.response = response
     }
 
-    func analyzeProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfileAnalysisResponse {
+    func analyzeProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfileAnalysisResponse {
         _ = h3Cell
         requestCount += 1
-        recordedSurfaceHeightMslM = surfaceHeightMslM
         return response
     }
 }
@@ -1451,12 +1437,8 @@ private actor CapturingAnvilProfileAnalysisProvider: AnvilProfileAnalysisProvidi
 private struct ThrowingAnvilProfileAnalysisProvider: AnvilProfileAnalysisProviding, @unchecked Sendable {
     let error: any Error
 
-    func analyzeProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfileAnalysisResponse {
+    func analyzeProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfileAnalysisResponse {
         _ = h3Cell
-        _ = surfaceHeightMslM
         throw error
     }
 }
@@ -1659,12 +1641,8 @@ func makeStormSetupRouteProvider(now: Date) -> DefaultStormSetupProvider {
 private struct StubStormSetupRouteAnvilProfileAnalysisProvider: AnvilProfileAnalysisProviding, @unchecked Sendable {
     let response: AnvilAnalyzeProfileAnalysisResponse
 
-    func analyzeProfile(
-        for h3Cell: Int64,
-        surfaceHeightMslM: Double?
-    ) async throws -> AnvilAnalyzeProfileAnalysisResponse {
+    func analyzeProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfileAnalysisResponse {
         _ = h3Cell
-        _ = surfaceHeightMslM
         return response
     }
 }

--- a/Tests/AppTests/StormSetupProviderTests.swift
+++ b/Tests/AppTests/StormSetupProviderTests.swift
@@ -1588,6 +1588,8 @@ func makeStormSetupRouteProvider(now: Date) -> DefaultStormSetupProvider {
                 centroid: StormSetupCentroid(latitude: 39.7825, longitude: -104.4661),
                 selectedMessageCount: 5,
                 selectedPressureLevels: [1000, 925, 850],
+                surfacePressureMb: 940,
+                surfaceSubsetCacheHit: false,
                 rangeCount: 3,
                 totalSelectedRangeBytes: 1024,
                 pressureLevelsRequested: [1000, 925, 850],

--- a/docs/Sql/Device.sql
+++ b/docs/Sql/Device.sql
@@ -1,7 +1,7 @@
 -- Use these queries to get device specific details about
 -- presence and installation
 
-SELECT * FROM device_installations where installation_id =  '131c8480-c74a-47c2-8cec-8d10ee6dc19f';
+SELECT * FROM device_installations; --where installation_id =  '131c8480-c74a-47c2-8cec-8d10ee6dc19f';
 SELECT * FROM device_presence;
 
 SELECT d.location_auth, d.app_version,p.*

--- a/docs/Sql/Device.sql
+++ b/docs/Sql/Device.sql
@@ -1,7 +1,7 @@
 -- Use these queries to get device specific details about
 -- presence and installation
 
-SELECT * FROM device_installations; --where installation_id =  '131c8480-c74a-47c2-8cec-8d10ee6dc19f';
+SELECT * FROM device_installations where installation_id =  '131c8480-c74a-47c2-8cec-8d10ee6dc19f';
 SELECT * FROM device_presence;
 
 SELECT d.location_auth, d.app_version,p.*

--- a/docs/Sql/_scratch.sql
+++ b/docs/Sql/_scratch.sql
@@ -164,4 +164,4 @@ SELECT run_time, forecast_hour, valid_time, status, local_path, byte_size, error
    ORDER BY valid_time DESC, updated_at DESC
    LIMIT 10;
 
-DELETE FROM pressure_artifact_catalog where status = 'failed'
+DELETE FROM pressure_artifact_catalog

--- a/docs/Sql/_scratch.sql
+++ b/docs/Sql/_scratch.sql
@@ -164,4 +164,4 @@ SELECT run_time, forecast_hour, valid_time, status, local_path, byte_size, error
    ORDER BY valid_time DESC, updated_at DESC
    LIMIT 10;
 
-DELETE FROM pressure_artifact_catalog
+DELETE FROM pressure_artifact_catalog where status = 'failed'

--- a/docs/hrrr-pressure-profile.md
+++ b/docs/hrrr-pressure-profile.md
@@ -25,6 +25,20 @@ It is not a new design proposal. It records the finished byte-range implementati
 - The server does not store raw user lat/lon for this path.
 - The Anvil result is used as supporting evidence inside Storm Setup, not as a separate prediction product.
 
+## Exact-Cycle Surface Row
+
+Every Anvil profile begins with one surface row sampled from the HRRR `wrfsfc` product. The surface source must match the selected pressure artifact's model, domain, run time, forecast hour, and valid time. Arcus Signal does not substitute another cycle.
+
+The dedicated `anvil-surface-v1` field set selects:
+
+- `PRES` and `HGT` at `surface`
+- `TMP` and `DPT` at `2 m above ground`
+- `UGRD` and `VGRD` at `10 m above ground`
+
+The loader deterministically selects the first matching value for each field, converts pressure from Pa to mb and temperature/dewpoint from K to Celsius, and requires all six values to be finite. Invalid pressure sentinel values are rejected. The normalized surface pressure remains a `Double`; it is not rounded to a standard pressure level.
+
+The request builder requires this complete surface row in addition to at least five retained pressure levels. Surface pressure must be greater than the first pressure-level pressure, and surface height must be lower than the first pressure-level height.
+
 ## Runtime Configuration
 
 ### Shared Storm Setup
@@ -71,6 +85,8 @@ When the path fails, the useful signals are:
   - Reported as upstream unavailability.
 - Missing required pressure levels
   - Reported as an unusable profile, not a fabricated profile.
+- Missing or invalid exact-cycle surface fields
+  - Reported as an unusable profile with the affected `PRES`, `HGT`, `TMP`, `DPT`, `UGRD`, or `VGRD` field names.
 - Partial-content download problems
   - The byte-range downloader expects valid partial-content responses and rejects ignored-range behavior.
 - `wgrib2` execution failure
@@ -89,6 +105,8 @@ The preview and analysis debug payloads should be used to inspect selected messa
 
 - No live HRRR, NOMADS, or Anvil calls should be used in unit tests.
 - There is no fallback from byte-range downloads to whole-file pressure downloads.
+- There is no cross-cycle or fabricated fallback for a missing exact-cycle surface row.
+- Surface-row failure stops profile assembly before Anvil dispatch.
 - Pressure-level tuning remains a product decision, not a transport contract.
 - Anvil severe-weather values are internal ingredient evidence, not user-facing tornado prediction language.
 - Anvil profile-analysis POSTs are intentionally non-retrying to avoid duplicate upstream compute.

--- a/docs/hrrr-pressure-profile.md
+++ b/docs/hrrr-pressure-profile.md
@@ -79,8 +79,11 @@ When the path fails, the useful signals are:
   - Surface as absent evidence or degraded confidence, not zeroes.
 - Transient Anvil POST transport failure
   - Surface the failure directly; Arcus Signal does not retry the request inside Storm Setup.
+- Development-only preview diagnostics
+  - Report `surfacePressureMb` and `surfaceSubsetCacheHit` for exact-cycle surface inspection.
+  - Keep those diagnostics out of `storm-setup/current`; the synthesized surface row stays internal to preview assembly and Anvil request construction.
 
-The preview and analysis debug payloads should be used to inspect selected message counts, ranges, cache state, and missing levels.
+The preview and analysis debug payloads should be used to inspect selected message counts, ranges, cache state, surface pressure/cache state, and missing levels.
 
 ## Degraded and Deferred Modes
 

--- a/docs/plans/hrrr-pressure-profile-progress.md
+++ b/docs/plans/hrrr-pressure-profile-progress.md
@@ -566,11 +566,44 @@ Deferred scope:
 - Any future tuning of Anvil evidence thresholds or semantics.
 - Networking, transport, and provider wiring remain out of scope for this slice.
 
+### Issue #125 - 10: Add a pure Anvil surface-profile loading seam
+
+Status: Completed
+
+Scope:
+- Add a narrow loader that builds one matching `wrfsfc` candidate from the current surface-cycle resolution.
+- Reuse the existing subset-loading and field-sampling seams.
+- Preserve cancellation and avoid fallback to another cycle.
+
+Files changed:
+- `Sources/App/StormSetup/HrrrAnvilSurfaceProfileLoading.swift`
+- `Tests/AppTests/HrrrAnvilSurfaceProfileLoadingTests.swift`
+- `docs/plans/hrrr-pressure-profile-progress.md`
+
+Tests and commands run:
+- `swift test --filter HrrrAnvilSurfaceProfileLoadingTests`
+- `swift build -Xswiftc -strict-concurrency=complete`
+- `git diff --check`
+
+Local verification notes:
+- The loader now constructs a single `wrfsfc` candidate and passes exactly one resolution into the subset loader.
+- Cancellation short-circuits the load path before any second cycle or sampler work can run.
+- The new tests stay offline and deterministic; they only use local stubs and fixture samples.
+
+Deferred scope:
+- Wiring the surface-profile loader into any provider or controller.
+- Any Anvil contract or response changes beyond the loader seam itself.
+
+Handoff notes for `#126`:
+- Reuse the new surface loader instead of rebuilding the `wrfsfc` candidate logic again.
+- Keep any provider wiring pointed at the injected subset/cache/sampler seams so the offline tests remain deterministic.
+
 ---
 
 ## Final Completion Summary
 
 - Epic `#85` is complete.
+- Follow-on surface-profile seams `#124` and `#125` are complete.
 - Sub-issues `#91`, `#99`, `#98`, `#92`, `#103`, `#101`, `#102`, and `#100` are all complete.
 - The completed implementation path is byte-range `.idx` selection, partial-content pressure subset download, preview wiring, Anvil profile transport, and ingredient-evidence mapping.
 - The final verification record is `swift build --target App` passing and the two filtered test commands above surfacing concrete failures that should be tracked separately from this documentation pass.

--- a/docs/plans/hrrr-pressure-profile-progress.md
+++ b/docs/plans/hrrr-pressure-profile-progress.md
@@ -598,15 +598,50 @@ Handoff notes for `#126`:
 - Reuse the new surface loader instead of rebuilding the `wrfsfc` candidate logic again.
 - Keep any provider wiring pointed at the injected subset/cache/sampler seams so the offline tests remain deterministic.
 
+### Issue #126 - 11: Prepend the explicit Anvil surface row without changing the DTO
+
+Status: Completed
+
+Scope:
+- Extend the frozen Anvil profile-request builder with an optional explicit surface row.
+- Prepend the surface row without interpolation while preserving the existing request DTO shape.
+- Keep the five retained pressure-level minimum independent of the surface row.
+- Reject invalid pressure ordering instead of sorting the profile rows into a valid-looking sequence.
+
+Files changed:
+- `Sources/App/StormSetup/AnvilProfileRequestBuilder.swift`
+- `Tests/AppTests/AnvilProfileRequestBuilderTests.swift`
+- `docs/plans/hrrr-pressure-profile-progress.md`
+
+Tests and commands run:
+- `swift test --filter AnvilProfileRequestBuilderTests`
+- `swift build -Xswiftc -strict-concurrency=complete`
+- `git diff --check`
+
+Local verification notes:
+- The builder now accepts an optional `surfaceLevel` seam and prepends it directly to the frozen profile arrays.
+- The request DTO remains unchanged, so downstream consumers still see the same nested `profile` shape.
+- The retained pressure-level minimum is still enforced before the surface row is attached.
+- Invalid pressure ordering now fails fast instead of being normalized by sorting.
+
+Deferred scope:
+- Provider/controller wiring for the new surface-row seam.
+- Any follow-on issue that consumes the seam from the preview or analysis paths.
+
+Handoff notes for `#127`:
+- Thread the new surface row through the provider layer instead of reconstructing the request assembly rules again.
+- Preserve the builder’s explicit ordering rules so downstream wiring does not reintroduce silent sorting.
+
 ---
 
 ## Final Completion Summary
 
 - Epic `#85` is complete.
 - Follow-on surface-profile seams `#124` and `#125` are complete.
+- Follow-on Anvil request-builder seam `#126` is complete.
 - Sub-issues `#91`, `#99`, `#98`, `#92`, `#103`, `#101`, `#102`, and `#100` are all complete.
-- The completed implementation path is byte-range `.idx` selection, partial-content pressure subset download, preview wiring, Anvil profile transport, and ingredient-evidence mapping.
-- The final verification record is `swift build --target App` passing and the two filtered test commands above surfacing concrete failures that should be tracked separately from this documentation pass.
+- The completed implementation path is byte-range `.idx` selection, partial-content pressure subset download, preview wiring, Anvil profile transport, ingredient-evidence mapping, and the explicit Anvil surface-row builder seam.
+- The #126 verification record is `swift test --filter AnvilProfileRequestBuilderTests`, `swift build -Xswiftc -strict-concurrency=complete`, and `git diff --check` all passing.
 - Known remaining risks are environmental only:
   - the filtered test suites still have outstanding failures in the current working tree or fixtures
   - live HRRR, NOMADS, and Anvil verification was not part of this docs-only finalization pass

--- a/docs/plans/hrrr-pressure-profile-progress.md
+++ b/docs/plans/hrrr-pressure-profile-progress.md
@@ -666,6 +666,42 @@ Local verification notes:
 - The old `surfaceHeightMslM` surface preview seam remains in place but is ignored by the provider.
 - Pressure artifact lookup, stale selection, and Anvil transport wiring were left untouched.
 
+### Issue #128 - 13: Remove obsolete surface-height handoff from Anvil preview and analysis wiring
+
+Status: Completed
+
+Scope:
+- Remove controller-side snapshot lookups for selected surface height.
+- Remove the temporary surface-height argument from the preview and analysis provider contracts.
+- Preserve the existing routes, response DTOs, HTTP mappings, degradation behavior, ingredient interpretation, and exact-cycle surface ownership inside the preview provider.
+
+Files changed:
+- `Sources/App/Controllers/AnvilProfilePreviewController.swift`
+- `Sources/App/Controllers/AnvilProfileAnalysisController.swift`
+- `Sources/App/StormSetup/AnvilProfilePreviewProvider.swift`
+- `Sources/App/StormSetup/AnvilProfileAnalysisProvider.swift`
+- `Sources/App/StormSetup/StormSetupProvider.swift`
+- `Tests/AppTests/AnvilProfilePreviewControllerTests.swift`
+- `Tests/AppTests/AnvilProfileAnalysisControllerTests.swift`
+- `Tests/AppTests/AnvilProfilePreviewProviderTests.swift`
+- `Tests/AppTests/AnvilProfileAnalysisProviderTests.swift`
+- `Tests/AppTests/AnvilProfilePreviewTestSupport.swift`
+- `Tests/AppTests/PressureArtifactDiagnosticsTests.swift`
+- `Tests/AppTests/StormSetupProviderTests.swift`
+
+Tests and commands run:
+- `swift test --filter AnvilProfilePreviewControllerTests`
+- `swift test --filter AnvilProfileAnalysisControllerTests`
+- `swift test --filter AnvilProfilePreviewProviderTests`
+- `swift test --filter AnvilProfileAnalysisProviderTests`
+- `swift build -Xswiftc -strict-concurrency=complete`
+
+Local verification notes:
+- The controllers now route directly to the providers without resolving selected surface height from Storm Setup snapshots.
+- The preview provider still resolves exact-cycle surface data internally and keeps below-ground filtering and degradation behavior intact.
+- The analysis provider now consumes the simplified preview contract without a temporary height seam.
+- Remaining risk is limited to unrelated warning debt already present in the tree.
+
 ### Issue #130 - Build the exact Anvil surface profile before shipping to Anvil
 
 Status: Completed

--- a/docs/plans/hrrr-pressure-profile-progress.md
+++ b/docs/plans/hrrr-pressure-profile-progress.md
@@ -536,18 +536,18 @@ Handoff outcome:
 - The pressure-profile epic is complete and the progress ledger is now the durable handoff record.
 - Future maintenance should treat `docs/hrrr-pressure-profile.md` and this progress log as the current reference, and the historical pressure-level plan as superseded.
 
-### Issue #124 - 09: Add a pure Anvil surface-profile normalization seam
+### Issue #124 - 09: Define and normalize the Anvil surface profile field set
 
 Status: Completed
 
 Scope:
-- Introduce a pure normalizer for `AnvilAnalyzeProfileResponse` to `AnvilIngredientEvidence`.
-- Keep the existing support-band thresholds, degraded-state rules, and missing-value handling unchanged.
-- Add focused tests for the normalization seam.
+- Introduce a dedicated surface profile level with fractional pressure.
+- Normalize exact `PRES`, `HGT`, `TMP`, `DPT`, `UGRD`, and `VGRD` samples into one complete row.
+- Reject missing, nonfinite, and invalid pressure values with field-specific diagnostics.
 
 Files changed:
 - `Sources/App/StormSetup/AnvilSurfaceProfileNormalizer.swift`
-- `Sources/App/StormSetup/AnvilIngredientEvidence.swift`
+- `Sources/App/StormSetup/StormSetupSurfaceProfileModels.swift`
 - `Tests/AppTests/AnvilSurfaceProfileNormalizerTests.swift`
 - `docs/plans/hrrr-pressure-profile-progress.md`
 
@@ -558,12 +558,12 @@ Tests and commands run:
 - `git diff --check`
 
 Local verification notes:
-- The normalization path remains pure and deterministic.
-- Existing surface and pressure defaults were left unchanged.
+- The normalization path remains pure and deterministically selects the first matching value.
+- Pressure remains a `Double`; temperatures are converted from K to Celsius.
+- Existing HRRR surface and pressure field-set defaults were left unchanged.
 - No networking, provider wiring, or `TornadoIngredientNormalizer` changes were introduced.
 
 Deferred scope:
-- Any future tuning of Anvil evidence thresholds or semantics.
 - Networking, transport, and provider wiring remain out of scope for this slice.
 
 ### Issue #125 - 10: Add a pure Anvil surface-profile loading seam
@@ -587,6 +587,7 @@ Tests and commands run:
 
 Local verification notes:
 - The loader now constructs a single `wrfsfc` candidate and passes exactly one resolution into the subset loader.
+- The loader returns a normalized surface row rather than unchecked raw samples.
 - Cancellation short-circuits the load path before any second cycle or sampler work can run.
 - The new tests stay offline and deterministic; they only use local stubs and fixture samples.
 
@@ -603,10 +604,11 @@ Handoff notes for `#126`:
 Status: Completed
 
 Scope:
-- Extend the frozen Anvil profile-request builder with an optional explicit surface row.
+- Extend the frozen Anvil profile-request builder with a required explicit surface row.
 - Prepend the surface row without interpolation while preserving the existing request DTO shape.
 - Keep the five retained pressure-level minimum independent of the surface row.
 - Reject invalid pressure ordering instead of sorting the profile rows into a valid-looking sequence.
+- Reject a surface height that is not below the first retained pressure-level height.
 
 Files changed:
 - `Sources/App/StormSetup/AnvilProfileRequestBuilder.swift`
@@ -619,7 +621,7 @@ Tests and commands run:
 - `git diff --check`
 
 Local verification notes:
-- The builder now accepts an optional `surfaceLevel` seam and prepends it directly to the frozen profile arrays.
+- The builder requires `surfaceLevel` and prepends it directly to the frozen profile arrays.
 - The request DTO remains unchanged, so downstream consumers still see the same nested `profile` shape.
 - The retained pressure-level minimum is still enforced before the surface row is attached.
 - Invalid pressure ordering now fails fast instead of being normalized by sorting.
@@ -781,7 +783,29 @@ Local verification notes:
 - The completed implementation path is byte-range `.idx` selection, partial-content pressure subset download, preview wiring, Anvil profile transport, ingredient-evidence mapping, the explicit Anvil surface-row builder seam, and the final development-only surface-layer diagnostics.
 - Issue `#130` completes the dedicated Anvil surface-row path so previews no longer rely on the tornado surface field set, and issue `#129` adds the final preview diagnostics and documentation reconciliation around that path.
 - The #126 verification record is `swift test --filter AnvilProfileRequestBuilderTests`, `swift build -Xswiftc -strict-concurrency=complete`, and `git diff --check` all passing.
-- Known remaining risks are environmental only:
-  - the filtered test suites still have outstanding failures in the current working tree or fixtures
-  - live HRRR, NOMADS, and Anvil verification was not part of this docs-only finalization pass
-- Deferred work from the epic is intentionally closed out; the remaining changes are development-only diagnostics and documentation reconciliation, not new user-facing behavior.
+- Known remaining validation constraints:
+  - the repository-wide suite still has pre-existing `HRRRPressureArtifactProbeServiceTests` failures
+  - live HRRR, NOMADS, and Anvil verification was not part of this finalization pass
+- Deferred work from the epic is intentionally closed out.
+
+### Post-review surface-row correction
+
+Status: Completed
+
+- Replaced the misnamed Anvil-response evidence normalizer with the required raw HRRR surface-sample normalizer.
+- Restored ingredient-evidence mapping to `AnvilIngredientEvidence`.
+- Preserved fractional surface pressure and removed the trapping `Double`-to-`Int` conversion.
+- Made the normalized surface row part of the loader result.
+- Required the surface row in request assembly and added strict surface-height ordering.
+- Replaced the synthetic default surface loader with an explicit failure when no loader is configured.
+- Updated tests to inject exact-cycle surface fixtures instead of relying on fabricated production defaults.
+
+Validation:
+- `swift test --filter AnvilSurfaceProfileNormalizerTests` passed.
+- `swift test --filter HrrrAnvilSurfaceProfileLoadingTests` passed.
+- `swift test --filter AnvilProfileRequestBuilderTests` passed.
+- `swift test --filter AnvilProfilePreviewProviderTests` passed.
+- `swift test --filter PressureArtifactDiagnosticsTests` passed.
+- `swift test --filter AnvilProfileAnalysisControllerTests` passed.
+- `swift build -Xswiftc -strict-concurrency=complete` passed with the pre-existing `ArcusEvent.title` deprecation warning.
+- `swift test --no-parallel --quiet` still fails only in the previously recorded pressure-artifact probe tests.

--- a/docs/plans/hrrr-pressure-profile-progress.md
+++ b/docs/plans/hrrr-pressure-profile-progress.md
@@ -666,6 +666,36 @@ Local verification notes:
 - The old `surfaceHeightMslM` surface preview seam remains in place but is ignored by the provider.
 - Pressure artifact lookup, stale selection, and Anvil transport wiring were left untouched.
 
+### Issue #130 - Build the exact Anvil surface profile before shipping to Anvil
+
+Status: Completed
+
+Scope:
+- Add a dedicated HRRR surface field set for Anvil surface sampling.
+- Wire the surface loader and preview provider to that field set instead of the tornado surface set.
+- Preserve the existing pressure lookup and Anvil transport behavior.
+
+Files changed:
+- `Sources/App/StormSetup/HrrrSourceModels.swift`
+- `Sources/App/StormSetup/HrrrAnvilSurfaceProfileLoading.swift`
+- `Sources/App/StormSetup/AnvilProfilePreviewProvider.swift`
+- `Tests/AppTests/HrrrAnvilSurfaceProfileLoadingTests.swift`
+- `Tests/AppTests/StormSetupHrrrSourceTests.swift`
+- `Tests/AppTests/AnvilProfilePreviewProviderTests.swift`
+- `docs/plans/hrrr-pressure-profile-progress.md`
+
+Tests and commands run:
+- `swift test --filter HrrrAnvilSurfaceProfileLoadingTests`
+- `swift test --filter AnvilProfilePreviewProviderTests`
+- `swift test --filter StormSetupHrrrSourceTests`
+- `swift build -Xswiftc -strict-concurrency=complete`
+- `git diff --check`
+
+Local verification notes:
+- The Anvil surface loader now requests a dedicated surface row with `PRES`, `HGT`, `TMP`, `DPT`, `UGRD`, and `VGRD` at the surface and low-level rows the preview logic expects.
+- Preview paths now fail fast if matching exact-cycle surface data is missing or incomplete, before pressure sampling starts.
+- Pressure artifact lookup and Anvil transport remain unchanged.
+
 ---
 
 ## Final Completion Summary
@@ -675,6 +705,7 @@ Local verification notes:
 - Follow-on Anvil request-builder seam `#126` is complete.
 - Sub-issues `#91`, `#99`, `#98`, `#92`, `#103`, `#101`, `#102`, and `#100` are all complete.
 - The completed implementation path is byte-range `.idx` selection, partial-content pressure subset download, preview wiring, Anvil profile transport, ingredient-evidence mapping, and the explicit Anvil surface-row builder seam.
+- Issue `#130` completes the dedicated Anvil surface-row path so previews no longer rely on the tornado surface field set.
 - The #126 verification record is `swift test --filter AnvilProfileRequestBuilderTests`, `swift build -Xswiftc -strict-concurrency=complete`, and `git diff --check` all passing.
 - Known remaining risks are environmental only:
   - the filtered test suites still have outstanding failures in the current working tree or fixtures

--- a/docs/plans/hrrr-pressure-profile-progress.md
+++ b/docs/plans/hrrr-pressure-profile-progress.md
@@ -536,6 +536,36 @@ Handoff outcome:
 - The pressure-profile epic is complete and the progress ledger is now the durable handoff record.
 - Future maintenance should treat `docs/hrrr-pressure-profile.md` and this progress log as the current reference, and the historical pressure-level plan as superseded.
 
+### Issue #124 - 09: Add a pure Anvil surface-profile normalization seam
+
+Status: Completed
+
+Scope:
+- Introduce a pure normalizer for `AnvilAnalyzeProfileResponse` to `AnvilIngredientEvidence`.
+- Keep the existing support-band thresholds, degraded-state rules, and missing-value handling unchanged.
+- Add focused tests for the normalization seam.
+
+Files changed:
+- `Sources/App/StormSetup/AnvilSurfaceProfileNormalizer.swift`
+- `Sources/App/StormSetup/AnvilIngredientEvidence.swift`
+- `Tests/AppTests/AnvilSurfaceProfileNormalizerTests.swift`
+- `docs/plans/hrrr-pressure-profile-progress.md`
+
+Tests and commands run:
+- `swift test --filter AnvilSurfaceProfileNormalizerTests`
+- `swift test --filter StormSetupHrrrSourceTests`
+- `swift build -Xswiftc -strict-concurrency=complete`
+- `git diff --check`
+
+Local verification notes:
+- The normalization path remains pure and deterministic.
+- Existing surface and pressure defaults were left unchanged.
+- No networking, provider wiring, or `TornadoIngredientNormalizer` changes were introduced.
+
+Deferred scope:
+- Any future tuning of Anvil evidence thresholds or semantics.
+- Networking, transport, and provider wiring remain out of scope for this slice.
+
 ---
 
 ## Final Completion Summary

--- a/docs/plans/hrrr-pressure-profile-progress.md
+++ b/docs/plans/hrrr-pressure-profile-progress.md
@@ -732,6 +732,44 @@ Local verification notes:
 - Preview paths now fail fast if matching exact-cycle surface data is missing or incomplete, before pressure sampling starts.
 - Pressure artifact lookup and Anvil transport remain unchanged.
 
+### Issue #129 - 06: Add surface-layer diagnostics, documentation, and final verification
+
+Status: Completed
+
+Scope:
+- Extend the development-only preview diagnostics with exact-cycle surface pressure and surface-subset cache state.
+- Add concise structured logs for exact-cycle surface source selection, inclusion, and rejection.
+- Reconcile the pressure-profile docs to reflect the final exact-cycle surface layer behavior.
+- Run the final verification set for the surface-layer slice.
+
+Files changed:
+- `Sources/App/Models/API/AnvilAnalyzeProfilePreviewResponse.swift`
+- `Sources/App/StormSetup/AnvilProfilePreviewProvider.swift`
+- `Tests/AppTests/AnvilProfileAnalysisControllerTests.swift`
+- `Tests/AppTests/AnvilProfileAnalysisProviderTests.swift`
+- `Tests/AppTests/AnvilProfilePreviewControllerTests.swift`
+- `Tests/AppTests/AnvilProfilePreviewProviderTests.swift`
+- `Tests/AppTests/PressureArtifactDiagnosticsTests.swift`
+- `Tests/AppTests/StormSetupProviderTests.swift`
+- `docs/hrrr-pressure-profile.md`
+- `docs/plans/hrrr-pressure-profile-runbook.md`
+- `docs/plans/hrrr-pressure-profile-progress.md`
+
+Tests and commands run:
+- `swift test --filter AnvilProfilePreviewProviderTests` passed
+- `swift test --filter AnvilProfilePreviewControllerTests` passed
+- `swift test --filter PressureArtifactDiagnosticsTests` passed
+- `swift build -Xswiftc -strict-concurrency=complete` passed
+- `swift test --no-parallel --quiet` failed in `HRRRPressureArtifactProbeServiceTests` with 4 pre-existing issues
+- `swift test --parallel --num-workers 8 --quiet` failed in `HRRRPressureArtifactProbeServiceTests` with 4 pre-existing issues
+- `git diff --check` passed
+
+Local verification notes:
+- The preview debug payload now reports `surfacePressureMb` and `surfaceSubsetCacheHit` without exposing the exact-cycle surface row through `storm-setup/current`.
+- Exact-cycle surface source selection and final inclusion now emit concise structured logs that stay clear of full array dumps and raw location logging.
+- Failure logs remain focused on the surface loading stage and the rejection reason, which keeps the diagnostics useful without widening the public contract.
+- The repo-wide quiet test gates still surface two unrelated `HRRRPressureArtifactProbeServiceTests` regressions; they are outside this diagnostics/documentation slice.
+
 ---
 
 ## Final Completion Summary
@@ -739,11 +777,11 @@ Local verification notes:
 - Epic `#85` is complete.
 - Follow-on surface-profile seams `#124` and `#125` are complete.
 - Follow-on Anvil request-builder seam `#126` is complete.
-- Sub-issues `#91`, `#99`, `#98`, `#92`, `#103`, `#101`, `#102`, and `#100` are all complete.
-- The completed implementation path is byte-range `.idx` selection, partial-content pressure subset download, preview wiring, Anvil profile transport, ingredient-evidence mapping, and the explicit Anvil surface-row builder seam.
-- Issue `#130` completes the dedicated Anvil surface-row path so previews no longer rely on the tornado surface field set.
+- Sub-issues `#91`, `#99`, `#98`, `#92`, `#103`, `#101`, `#102`, `#100`, `#129`, and `#130` are all complete.
+- The completed implementation path is byte-range `.idx` selection, partial-content pressure subset download, preview wiring, Anvil profile transport, ingredient-evidence mapping, the explicit Anvil surface-row builder seam, and the final development-only surface-layer diagnostics.
+- Issue `#130` completes the dedicated Anvil surface-row path so previews no longer rely on the tornado surface field set, and issue `#129` adds the final preview diagnostics and documentation reconciliation around that path.
 - The #126 verification record is `swift test --filter AnvilProfileRequestBuilderTests`, `swift build -Xswiftc -strict-concurrency=complete`, and `git diff --check` all passing.
 - Known remaining risks are environmental only:
   - the filtered test suites still have outstanding failures in the current working tree or fixtures
   - live HRRR, NOMADS, and Anvil verification was not part of this docs-only finalization pass
-- Deferred work from the epic is intentionally closed out; no new runtime behavior was added in this documentation pass.
+- Deferred work from the epic is intentionally closed out; the remaining changes are development-only diagnostics and documentation reconciliation, not new user-facing behavior.

--- a/docs/plans/hrrr-pressure-profile-progress.md
+++ b/docs/plans/hrrr-pressure-profile-progress.md
@@ -634,6 +634,40 @@ Handoff notes for `#127`:
 
 ---
 
+### Issue #127 - 12: Load matching surface data before pressure sampling in preview wiring
+
+Status: Completed
+
+Scope:
+- Inject the Anvil surface-profile loader into the preview provider.
+- Load exact-cycle surface data before pressure sampling for ready, stale, and direct/manual preview paths.
+- Ignore caller-supplied preview surface height for now, while keeping the temporary seam in place.
+- Feed the loaded surface row into the frozen Anvil request builder and below-ground pressure filtering.
+
+Deferred:
+- Any change to pressure artifact lookup rules.
+- Any change to the Anvil transport client or request transport behavior.
+- Removing the temporary `surfaceHeightMslM` preview seam.
+
+Files changed:
+- `Sources/App/StormSetup/AnvilProfilePreviewProvider.swift`
+- `Tests/AppTests/AnvilProfilePreviewTestSupport.swift`
+- `Tests/AppTests/AnvilProfilePreviewProviderTests.swift`
+- `Tests/AppTests/AnvilProfilePreviewControllerTests.swift`
+
+Tests and commands run:
+- `swift test --filter AnvilProfilePreviewProviderTests`
+- `swift build -Xswiftc -strict-concurrency=complete`
+- `git diff --check`
+
+Local verification notes:
+- Ready and stale preview paths now load matching surface data before pressure profile grouping.
+- Surface identity is validated on the exact cycle, and surface-source failures stop before pressure profile loading.
+- The old `surfaceHeightMslM` surface preview seam remains in place but is ignored by the provider.
+- Pressure artifact lookup, stale selection, and Anvil transport wiring were left untouched.
+
+---
+
 ## Final Completion Summary
 
 - Epic `#85` is complete.

--- a/docs/plans/hrrr-pressure-profile-runbook.md
+++ b/docs/plans/hrrr-pressure-profile-runbook.md
@@ -127,6 +127,7 @@ Implement only the current issue's scope.
 - Add offline deterministic tests for each slice.
 - Run the narrowest meaningful verification before finishing.
 - Update `docs/plans/hrrr-pressure-profile-progress.md` before finishing.
+- Any development-only preview diagnostics for exact-cycle surface data must stay out of `storm-setup/current` and must not dump full arrays or raw coordinates.
 
 ### Forbidden
 

--- a/docs/plans/hrrr-pressure-profile-runbook.md
+++ b/docs/plans/hrrr-pressure-profile-runbook.md
@@ -118,6 +118,8 @@ Implement only the current issue's scope.
 - Resolve H3 to centroid latitude/longitude internally before sampling.
 - Use `wgrib2 -s -lon` through the existing wrapper for point decoding.
 - Return missing/unavailable fields as missing diagnostics, not fake zeroes.
+- Build one exact-cycle `wrfsfc` surface row matching the pressure source run time, forecast hour, and valid time.
+- Require finite `PRES`, `HGT`, `TMP`, `DPT`, `UGRD`, and `VGRD` values before Anvil request assembly.
 - Normalize units explicitly:
   - temperature/dewpoint in Celsius for Anvil profile DTOs
   - wind components in meters per second unless Anvil contract says otherwise
@@ -140,6 +142,7 @@ Implement only the current issue's scope.
 - Do not describe outputs as tornado prediction, hail prediction, probability, or risk score.
 - Do not add a broad NOAA provider framework.
 - Do not use live HRRR, live NOMADS, live AWS, or live Anvil calls in unit tests.
+- Do not fabricate a surface row or substitute another HRRR run when exact-cycle surface data is unavailable.
 - Do not close or rewrite unrelated notification/APNs/NWS issues as part of pressure-profile work.
 
 If a future-facing seam is required, keep it:


### PR DESCRIPTION
# Summary
This branch adds exact-cycle HRRR surface profile loading for Anvil request assembly and threads that surface data through the preview and analysis paths. It also updates the request builder, response models, and test coverage so the surface row is assembled from live surface GRIB data instead of being inferred.

# What Changed
- Added surface-layer HRRR loading and normalization for Anvil request assembly.
- Updated Anvil request construction to prepend the surface row alongside retained pressure levels.
- Wired the preview and analysis providers/controllers to use the exact-cycle surface profile path.
- Extended the request/response models and diagnostics to carry the surface profile data.
- Added and updated tests for surface normalization, request assembly, preview behavior, and diagnostics.
- Updated the pressure-profile docs and progress notes to reflect the completed surface-loading path.

# User Impact
Users get Anvil profile requests built with a real exact-cycle surface layer, which makes preview and analysis behavior match the intended HRRR surface data path more closely. There is no direct UI change beyond more accurate upstream profile handling.

# Testing
- `swift test --filter StormSetupHrrrSourceTests` passed.

# Notes
- This branch also includes documentation updates under `docs/hrrr-pressure-profile.md` and `docs/plans/hrrr-pressure-profile-*.md`.
- The change set is mostly internal plumbing, but it touches both request assembly and the surface-loading normalization layer.
