### PR TITLE
Add current AirNow AQI endpoint

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5f5cae60650e47925200216b748041ebd824b0f02e4f029ea613e112ae307903",
+  "originHash" : "aa315d5dbc5ab681fe849bedd73f1275bfd5c635a9f82d03732c86407ee7e1dc",
   "pins" : [
     {
       "identity" : "apns",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/justinrooks/ArcusCore.git",
       "state" : {
-        "revision" : "145cdd44468b0ec6c96c4147ab3290b6b2e1a24f",
-        "version" : "0.4.2"
+        "revision" : "977945d87d6c54b6c4a861da3fc2d1cb66b0aaac",
+        "version" : "0.4.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -56,6 +56,7 @@ let package = Package(
                 "Infrastructure/Cancellation.swift",
                 "Services",
                 "StormSetup",
+                "AirQuality",
                 "Worker",
                 "lib",
                 "apiRoutes.swift",

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Optional tuning:
 - `REDIS_POOL_CONNECTION_TIMEOUT_SECONDS` (default `30`)
 - `WORKER_STARTUP_GRACE_SECONDS` (default `5`)
 
+Current AQI endpoint configuration:
+
+- `AIRNOW_API_KEY` (EPA AirNow API key; required on the API service to enable `GET /api/v1/air-quality/current`)
+
 Worker APNs configuration:
 
 - `APNS_TEAM_ID` (Apple Team ID)

--- a/Sources/App/AirQuality/AirNowClient.swift
+++ b/Sources/App/AirQuality/AirNowClient.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Logging
+
+enum AirNowClientError: Error, Sendable {
+    case invalidURL
+    case missingData
+    case upstreamFailure(status: Int)
+}
+
+protocol AirNowClient: Sendable {
+    func fetchCurrentObservations(latitude: Double, longitude: Double) async throws -> [AirNowObservation]
+}
+
+struct DefaultAirNowClient: AirNowClient {
+    private let http: any HTTPClient
+    private let apiKey: String
+    private let baseURL: URL
+    private let logger: Logger
+
+    init(
+        apiKey: String,
+        http: any HTTPClient,
+        baseURL: URL = URL(string: "https://www.airnowapi.org")!,
+        logger: Logger = .networkDownloader
+    ) {
+        self.apiKey = apiKey
+        self.http = http
+        self.baseURL = baseURL
+        self.logger = logger
+    }
+
+    func fetchCurrentObservations(latitude: Double, longitude: Double) async throws -> [AirNowObservation] {
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            throw AirNowClientError.invalidURL
+        }
+        components.path = "/aq/observation/latLong/current/"
+        components.queryItems = [
+            .init(name: "format", value: "application/json"),
+            .init(name: "latitude", value: String(latitude)),
+            .init(name: "longitude", value: String(longitude)),
+            .init(name: "distance", value: "25"),
+            .init(name: "API_KEY", value: apiKey)
+        ]
+        guard let url = components.url else { throw AirNowClientError.invalidURL }
+
+        let response = try await http.get(url, headers: ["Accept": "application/json"])
+        guard (200...299).contains(response.status) else {
+            logger.warning("AirNow request failed status=\(response.status)")
+            throw AirNowClientError.upstreamFailure(status: response.status)
+        }
+        guard let data = response.data else { throw AirNowClientError.missingData }
+        return try JSONDecoder().decode([AirNowObservation].self, from: data)
+    }
+}

--- a/Sources/App/AirQuality/AirNowObservation.swift
+++ b/Sources/App/AirQuality/AirNowObservation.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct AirNowObservation: Decodable, Sendable, Equatable {
+    struct Category: Decodable, Sendable, Equatable {
+        let number: Int?
+        let name: String?
+
+        enum CodingKeys: String, CodingKey {
+            case number = "Number"
+            case name = "Name"
+        }
+    }
+
+    let dateObserved: String
+    let hourObserved: Int
+    let localTimeZone: String?
+    let parameterName: String?
+    let aqi: Int?
+    let category: Category?
+
+    enum CodingKeys: String, CodingKey {
+        case dateObserved = "DateObserved"
+        case hourObserved = "HourObserved"
+        case localTimeZone = "LocalTimeZone"
+        case parameterName = "ParameterName"
+        case aqi = "AQI"
+        case category = "Category"
+    }
+}

--- a/Sources/App/AirQuality/AirQualityConfiguration.swift
+++ b/Sources/App/AirQuality/AirQualityConfiguration.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct AirQualityConfiguration: Sendable, Equatable {
+    let airNowAPIKey: String?
+    let cacheLifetime: TimeInterval
+
+    static func resolved(from environment: [String: String] = ProcessInfo.processInfo.environment) -> AirQualityConfiguration {
+        AirQualityConfiguration(
+            airNowAPIKey: environment["AIRNOW_API_KEY"]?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+            cacheLifetime: 45 * 60
+        )
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
+}

--- a/Sources/App/AirQuality/AirQualityProvider.swift
+++ b/Sources/App/AirQuality/AirQualityProvider.swift
@@ -1,0 +1,101 @@
+import ArcusCore
+import Foundation
+import Vapor
+
+protocol AirQualityCurrentProviding: Sendable {
+    func currentResponse(for h3Cell: Int64) async throws -> AirQualityCurrentResponse?
+}
+
+struct UnavailableAirQualityProvider: AirQualityCurrentProviding {
+    func currentResponse(for h3Cell: Int64) async throws -> AirQualityCurrentResponse? {
+        nil
+    }
+}
+
+actor AirQualityCurrentCache {
+    private struct Entry: Sendable {
+        let response: AirQualityCurrentResponse?
+        let expiresAt: Date
+    }
+
+    private var entries: [Int64: Entry] = [:]
+
+    func response(for h3Cell: Int64, now: Date) -> AirQualityCurrentResponse?? {
+        guard let entry = entries[h3Cell], entry.expiresAt > now else { return nil }
+        return entry.response
+    }
+
+    func store(_ response: AirQualityCurrentResponse?, for h3Cell: Int64, expiresAt: Date) {
+        entries[h3Cell] = Entry(response: response, expiresAt: expiresAt)
+    }
+}
+
+struct DefaultAirQualityProvider: AirQualityCurrentProviding {
+    private let configuration: AirQualityConfiguration
+    private let client: any AirNowClient
+    private let h3Resolver: any StormSetupH3Resolving
+    private let cache: AirQualityCurrentCache
+    private let now: @Sendable () -> Date
+
+    init(
+        configuration: AirQualityConfiguration,
+        client: any AirNowClient,
+        h3Resolver: any StormSetupH3Resolving = DefaultStormSetupH3Resolver(),
+        cache: AirQualityCurrentCache = AirQualityCurrentCache(),
+        now: @escaping @Sendable () -> Date = { .now }
+    ) {
+        self.configuration = configuration
+        self.client = client
+        self.h3Resolver = h3Resolver
+        self.cache = cache
+        self.now = now
+    }
+
+    func currentResponse(for h3Cell: Int64) async throws -> AirQualityCurrentResponse? {
+        let requestDate = now()
+        if let cached = await cache.response(for: h3Cell, now: requestDate) {
+            return cached
+        }
+
+        let centroid = try h3Resolver.resolve(h3Cell: h3Cell).centroid
+        let observations = try await client.fetchCurrentObservations(
+            latitude: centroid.latitude,
+            longitude: centroid.longitude
+        )
+        let response = AirNowNormalizer.normalize(observations: observations)
+        await cache.store(response, for: h3Cell, expiresAt: requestDate.addingTimeInterval(configuration.cacheLifetime))
+        return response
+    }
+}
+
+enum AirNowNormalizer {
+    static func normalize(observations: [AirNowObservation]) -> AirQualityCurrentResponse? {
+        observations
+            .compactMap { observation -> AirQualityCurrentResponse? in
+                guard let aqi = observation.aqi, aqi >= 0,
+                      let observedAt = observation.observedAt else { return nil }
+                return AirQualityCurrentResponse(
+                    aqi: aqi,
+                    category: observation.category.map {
+                        AirQualityCategory(identifier: $0.number, name: $0.name)
+                    },
+                    primaryPollutant: observation.parameterName?.trimmingCharacters(in: .whitespacesAndNewlines),
+                    observedAt: observedAt,
+                    sourceIdentifier: "airnow"
+                )
+            }
+            .max { lhs, rhs in lhs.aqi < rhs.aqi }
+    }
+}
+
+private extension AirNowObservation {
+    var observedAt: Date? {
+        guard (0...23).contains(hourObserved) else { return nil }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.dateFormat = "yyyy-MM-dd H"
+        formatter.timeZone = localTimeZone.flatMap(TimeZone.init(identifier:)) ?? .gmt
+        return formatter.date(from: "\(dateObserved) \(hourObserved)")
+    }
+}

--- a/Sources/App/AirQuality/AirQualityProvider.swift
+++ b/Sources/App/AirQuality/AirQualityProvider.swift
@@ -58,13 +58,19 @@ struct DefaultAirQualityProvider: AirQualityCurrentProviding {
         }
 
         let centroid = try h3Resolver.resolve(h3Cell: h3Cell).centroid
-        let observations = try await client.fetchCurrentObservations(
-            latitude: centroid.latitude,
-            longitude: centroid.longitude
-        )
-        let response = AirNowNormalizer.normalize(observations: observations)
-        await cache.store(response, for: h3Cell, expiresAt: requestDate.addingTimeInterval(configuration.cacheLifetime))
-        return response
+        do {
+            let observations = try await client.fetchCurrentObservations(
+                latitude: centroid.latitude,
+                longitude: centroid.longitude
+            )
+            let response = AirNowNormalizer.normalize(observations: observations)
+            await cache.store(response, for: h3Cell, expiresAt: requestDate.addingTimeInterval(configuration.cacheLifetime))
+            return response
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            return nil
+        }
     }
 }
 

--- a/Sources/App/Controllers/AirQualityController.swift
+++ b/Sources/App/Controllers/AirQualityController.swift
@@ -1,0 +1,25 @@
+import ArcusCore
+import Foundation
+import Vapor
+
+struct AirQualityController: RouteCollection {
+    func boot(routes: any RoutesBuilder) throws {
+        routes.grouped("api", "v1", "air-quality").get("current", use: current)
+    }
+
+    func current(req: Request) async throws -> AirQualityCurrentResponse {
+        let query = try req.query.decode(CurrentQuery.self)
+        guard let rawH3 = query.h3?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let h3Cell = Int64(rawH3) else {
+            throw Abort(.badRequest, reason: "Missing or invalid required query parameter 'h3'.")
+        }
+        guard let response = try await req.application.airQualityProvider.currentResponse(for: h3Cell) else {
+            throw Abort(.serviceUnavailable, reason: "Current AQI is unavailable.")
+        }
+        return response
+    }
+
+    private struct CurrentQuery: Content {
+        let h3: String?
+    }
+}

--- a/Sources/App/Extensions/VaporContentConformances.swift
+++ b/Sources/App/Extensions/VaporContentConformances.swift
@@ -27,3 +27,5 @@ extension AnvilEffectiveLayerDTO: @retroactive Content {}
 extension AnvilQualityDTO: @retroactive Content {}
 extension AnvilStormMotionDTO: @retroactive Content {}
 extension AnvilBunkersRightStormMotionDTO: @retroactive Content {}
+extension AirQualityCurrentResponse: @retroactive Content {}
+extension AirQualityCategory: @retroactive Content {}

--- a/Sources/App/Extensions/ext+Application.swift
+++ b/Sources/App/Extensions/ext+Application.swift
@@ -29,8 +29,17 @@ extension Application {
     func recordWorkerScheduledJob(_ jobName: String) {
         workerScheduledJobNames.append(jobName)
     }
+
+    var airQualityProvider: any AirQualityCurrentProviding {
+        get { storage[AirQualityProviderKey.self]! }
+        set { storage[AirQualityProviderKey.self] = newValue }
+    }
 }
 
 private struct WorkerScheduledJobNamesKey: StorageKey {
     typealias Value = [String]
+}
+
+private struct AirQualityProviderKey: StorageKey {
+    typealias Value = any AirQualityCurrentProviding
 }

--- a/Sources/App/apiRoutes.swift
+++ b/Sources/App/apiRoutes.swift
@@ -16,6 +16,7 @@ func configureAPIRoutes(_ app: Application) throws {
     try app.register(collection: DeviceController())
     try app.register(collection: OperatorDashboardController())
     try app.register(collection: StormSetupController())
+    try app.register(collection: AirQualityController())
 }
 
 public func normalizedOptional(_ value: String?) -> String? {

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -22,6 +22,17 @@ public func configure(_ app: Application, mode: AppRuntimeMode) async throws {
     configureMigrations(on: app)
     try configureQueues(on: app)
 
+    let airQualityConfiguration = AirQualityConfiguration.resolved()
+    if let airNowAPIKey = airQualityConfiguration.airNowAPIKey {
+        app.airQualityProvider = DefaultAirQualityProvider(
+            configuration: airQualityConfiguration,
+            client: DefaultAirNowClient(apiKey: airNowAPIKey, http: VaporApplicationHTTPClient(application: app))
+        )
+    } else {
+        app.airQualityProvider = UnavailableAirQualityProvider()
+        app.logger.warning("AirNow AQI is disabled because AIRNOW_API_KEY is not configured.")
+    }
+
     if app.environment == .testing {
         app.nwsIngestService = StubNWSIngestService()
     } else {

--- a/Tests/AppTests/AirQualityTests.swift
+++ b/Tests/AppTests/AirQualityTests.swift
@@ -44,7 +44,40 @@ struct AirQualityTests {
         #expect(response == nil)
     }
 
+    @Test("upstream AirNow failures normalize to unavailable")
+    func upstreamAirNowFailuresNormalizeToUnavailable() async throws {
+        let provider = DefaultAirQualityProvider(
+            configuration: AirQualityConfiguration(airNowAPIKey: "test", cacheLifetime: 60),
+            client: ThrowingAirNowClient(),
+            h3Resolver: StubStormSetupH3Resolver(),
+            cache: AirQualityCurrentCache(),
+            now: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+
+        let response = try await provider.currentResponse(for: 617_700_169_958_293_503)
+
+        #expect(response == nil)
+    }
+
     private func observations(from json: String) throws -> [AirNowObservation] {
         try JSONDecoder().decode([AirNowObservation].self, from: Data(json.utf8))
+    }
+}
+
+private struct ThrowingAirNowClient: AirNowClient {
+    func fetchCurrentObservations(latitude: Double, longitude: Double) async throws -> [AirNowObservation] {
+        _ = latitude
+        _ = longitude
+        throw AirNowClientError.upstreamFailure(status: 429)
+    }
+}
+
+private struct StubStormSetupH3Resolver: StormSetupH3Resolving {
+    func resolve(h3Cell: Int64) throws -> StormSetupResolvedH3Cell {
+        _ = h3Cell
+        return StormSetupResolvedH3Cell(
+            h3Cell: 617_700_169_958_293_503,
+            centroid: StormSetupCentroid(latitude: 39.7392, longitude: -104.9903)
+        )
     }
 }

--- a/Tests/AppTests/AirQualityTests.swift
+++ b/Tests/AppTests/AirQualityTests.swift
@@ -1,0 +1,50 @@
+@testable import App
+import ArcusCore
+import Foundation
+import Testing
+
+@Suite("AirNow AQI normalization")
+struct AirQualityTests {
+    @Test("provider observations decode AirNow wire keys")
+    func observationsDecode() throws {
+        let observations = try JSONDecoder().decode([AirNowObservation].self, from: Data("""
+        [{"DateObserved":"2026-07-12","HourObserved":14,"LocalTimeZone":"America/Denver","ParameterName":"PM2.5","AQI":87,"Category":{"Number":2,"Name":"Moderate"}}]
+        """.utf8))
+
+        #expect(observations.count == 1)
+        #expect(observations[0].aqi == 87)
+        #expect(observations[0].category?.name == "Moderate")
+    }
+
+    @Test("highest valid pollutant AQI becomes the normalized current value")
+    func highestAQIWins() throws {
+        let response = AirNowNormalizer.normalize(observations: try observations(from: """
+        [
+          {"DateObserved":"2026-07-12","HourObserved":14,"LocalTimeZone":"America/Denver","ParameterName":"OZONE","AQI":72,"Category":{"Number":2,"Name":"Moderate"}},
+          {"DateObserved":"2026-07-12","HourObserved":15,"LocalTimeZone":"America/Denver","ParameterName":"PM2.5","AQI":121,"Category":{"Number":3,"Name":"Unhealthy for Sensitive Groups"}}
+        ]
+        """))
+
+        #expect(response?.aqi == 121)
+        #expect(response?.primaryPollutant == "PM2.5")
+        #expect(response?.category?.identifier == 3)
+        #expect(response?.sourceIdentifier == "airnow")
+    }
+
+    @Test("missing or invalid observations normalize to unavailable")
+    func invalidObservationsAreDiscarded() throws {
+        let response = AirNowNormalizer.normalize(observations: try observations(from: """
+        [
+          {"DateObserved":"2026-07-12","HourObserved":14,"AQI":-1},
+          {"DateObserved":"2026-07-12","HourObserved":25,"AQI":41},
+          {"DateObserved":"2026-07-12","HourObserved":14,"ParameterName":"OZONE"}
+        ]
+        """))
+
+        #expect(response == nil)
+    }
+
+    private func observations(from json: String) throws -> [AirNowObservation] {
+        try JSONDecoder().decode([AirNowObservation].self, from: Data(json.utf8))
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       ARCUS_DEBUG_ENDPOINTS_ENABLED: "true"
       ANVIL_PROFILE_ANALYSIS_BASE_URL: ${ANVIL_PROFILE_ANALYSIS_BASE_URL:-http://host.docker.internal:8089/api}
       ANVIL_PROFILE_ANALYSIS_TIMEOUT_SECONDS: "10"
+      AIRNOW_API_KEY: ${AIRNOW_API_KEY:-}
     restart: unless-stopped
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
# Summary
Add a new API route that resolves an H3 cell to its centroid, fetches current AirNow observations for that location, normalizes them into the app's current AQI response, and caches the result briefly.

# What Changed
- Added `GET /api/v1/air-quality/current` with `h3` query validation.
- Added an AirNow client/provider layer plus response normalization and short-lived per-H3 caching.
- Wired AirQuality into app configuration, route registration, docs, Docker defaults, and content conformances.
- Added tests for decoding and normalization behavior.

# User Impact
Clients can request current AQI for an H3 cell when `AIRNOW_API_KEY` is configured. Invalid `h3` values now return 400, and unavailable AQI data returns 503.

# Testing
- `swift test`

# Notes
- The endpoint is disabled unless `AIRNOW_API_KEY` is set.