### PR TITLE
Filter notification candidates by 24-hour presence freshness

### DIFF
--- a/Sources/App/Infrastructure/Notifications/LocationFreshnessPolicy.swift
+++ b/Sources/App/Infrastructure/Notifications/LocationFreshnessPolicy.swift
@@ -25,7 +25,7 @@ public struct LocationFreshnessDecision: Sendable, Equatable {
 
 public struct LocationFreshnessPolicy: Sendable {
     private static let hour: TimeInterval = 60 * 60
-    private static let staleThreshold: TimeInterval = 24 * hour
+    public static let hardStaleThreshold: TimeInterval = 24 * hour
     private static let whenInUseFreshThreshold: TimeInterval = 2 * hour
     private static let alwaysFreshThreshold: TimeInterval = 6 * hour
 
@@ -38,7 +38,7 @@ public struct LocationFreshnessPolicy: Sendable {
     ) -> LocationFreshnessDecision {
         let age = max(0, now.timeIntervalSince(capturedAt))
 
-        guard age <= Self.staleThreshold else {
+        guard age <= Self.hardStaleThreshold else {
             return .init(state: .stale, age: age)
         }
 

--- a/Sources/App/Jobs/NotificationSendJob.swift
+++ b/Sources/App/Jobs/NotificationSendJob.swift
@@ -225,6 +225,8 @@ public struct NotificationSendJob: AsyncJob {
             )
             return
         }
+
+        let presenceCutoff = attemptedAt.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold)
         
         // if mode is h3 and we have cells
         // right now we aren't falling back to zones... but maybe we should?
@@ -256,6 +258,7 @@ public struct NotificationSendJob: AsyncJob {
             // Get our list of candidates
             let h3Candidates = try await loadH3Candidates(
                 cells: geo.h3Cells,
+                capturedAtOrAfter: presenceCutoff,
                 on: context.application.db
             )
             
@@ -275,6 +278,7 @@ public struct NotificationSendJob: AsyncJob {
             // we only have 2 modes right now, so its ugc
             let ugcCandidates = try await loadUGCCandidates(
                 ugcCodes: series.ugcCodes,
+                capturedAtOrAfter: presenceCutoff,
                 on: context.application.db
             )
 
@@ -316,6 +320,7 @@ public struct NotificationSendJob: AsyncJob {
 extension NotificationSendJob {
     func loadUGCCandidates(
         ugcCodes: [String],
+        capturedAtOrAfter cutoff: Date,
         on db: any Database
     ) async throws -> [NotificationCandidate] {
         guard let sql = db as? any SQLDatabase else {
@@ -337,6 +342,7 @@ extension NotificationSendJob {
             WHERE i.is_active = TRUE
               AND i.is_subscribed = TRUE
               AND i.apns_device_token <> ''
+              AND p.captured_at >= \(bind: cutoff)
               AND (
                   p.county  = ANY(\(bind: ugcCodes)::text[])
                 OR p.zone  = ANY(\(bind: ugcCodes)::text[])
@@ -348,6 +354,7 @@ extension NotificationSendJob {
     
     func loadH3Candidates(
         cells: [Int64],
+        capturedAtOrAfter cutoff: Date,
         on db: any Database
     ) async throws -> [NotificationCandidate] {
         guard let sql = db as? any SQLDatabase else {
@@ -373,6 +380,7 @@ extension NotificationSendJob {
               AND i.apns_device_token <> ''
               AND p.h3_cell IS NOT NULL
               AND p.h3_cell = ANY(\(bind: cells)::bigint[])
+              AND p.captured_at >= \(bind: cutoff)
             """)
             .all(decoding: NotificationCandidate.self)
     }

--- a/Sources/App/Models/API/OperatorDashboardSnapshotResponse.swift
+++ b/Sources/App/Models/API/OperatorDashboardSnapshotResponse.swift
@@ -299,22 +299,57 @@ public struct StoredTargetableCoverageBreakdown: Codable, Sendable {
 public struct StoredTargetableCoverageMetric: Codable, Sendable {
     public var installationFreshnessSeconds: Int
     public var presenceFreshnessSeconds: Int
+    public var hardStalePresenceThresholdSeconds: Int
     public var activeSubscribedInstallationCount: Int
     public var targetableInstallationCount: Int
+    public var candidateQueryEligibleInstallationCount: Int
+    public var hardStalePresenceCount: Int
     public var lossBreakdown: StoredTargetableCoverageBreakdown
 
     public init(
         installationFreshnessSeconds: Int = OperatorDashboardConfig.installationFreshnessThresholdSeconds,
         presenceFreshnessSeconds: Int = OperatorDashboardConfig.presenceFreshnessThresholdSeconds,
+        hardStalePresenceThresholdSeconds: Int = Int(LocationFreshnessPolicy.hardStaleThreshold),
         activeSubscribedInstallationCount: Int = 0,
         targetableInstallationCount: Int = 0,
+        candidateQueryEligibleInstallationCount: Int = 0,
+        hardStalePresenceCount: Int = 0,
         lossBreakdown: StoredTargetableCoverageBreakdown = .init()
     ) {
         self.installationFreshnessSeconds = installationFreshnessSeconds
         self.presenceFreshnessSeconds = presenceFreshnessSeconds
+        self.hardStalePresenceThresholdSeconds = hardStalePresenceThresholdSeconds
         self.activeSubscribedInstallationCount = activeSubscribedInstallationCount
         self.targetableInstallationCount = targetableInstallationCount
+        self.candidateQueryEligibleInstallationCount = candidateQueryEligibleInstallationCount
+        self.hardStalePresenceCount = hardStalePresenceCount
         self.lossBreakdown = lossBreakdown
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case installationFreshnessSeconds
+        case presenceFreshnessSeconds
+        case hardStalePresenceThresholdSeconds
+        case activeSubscribedInstallationCount
+        case targetableInstallationCount
+        case candidateQueryEligibleInstallationCount
+        case hardStalePresenceCount
+        case lossBreakdown
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.installationFreshnessSeconds = try container.decodeIfPresent(Int.self, forKey: .installationFreshnessSeconds)
+            ?? OperatorDashboardConfig.installationFreshnessThresholdSeconds
+        self.presenceFreshnessSeconds = try container.decodeIfPresent(Int.self, forKey: .presenceFreshnessSeconds)
+            ?? OperatorDashboardConfig.presenceFreshnessThresholdSeconds
+        self.hardStalePresenceThresholdSeconds = try container.decodeIfPresent(Int.self, forKey: .hardStalePresenceThresholdSeconds)
+            ?? Int(LocationFreshnessPolicy.hardStaleThreshold)
+        self.activeSubscribedInstallationCount = try container.decodeIfPresent(Int.self, forKey: .activeSubscribedInstallationCount) ?? 0
+        self.targetableInstallationCount = try container.decodeIfPresent(Int.self, forKey: .targetableInstallationCount) ?? 0
+        self.candidateQueryEligibleInstallationCount = try container.decodeIfPresent(Int.self, forKey: .candidateQueryEligibleInstallationCount) ?? 0
+        self.hardStalePresenceCount = try container.decodeIfPresent(Int.self, forKey: .hardStalePresenceCount) ?? 0
+        self.lossBreakdown = try container.decodeIfPresent(StoredTargetableCoverageBreakdown.self, forKey: .lossBreakdown) ?? .init()
     }
 }
 
@@ -1013,19 +1048,30 @@ public struct TargetableCoverageMetricResponse: Content, Sendable {
     public var refreshedAt: Date?
     public var installationFreshnessSeconds: Int
     public var presenceFreshnessSeconds: Int
+    public var hardStalePresenceThresholdSeconds: Int
     public var activeSubscribedInstallationCount: Int
     public var targetableInstallationCount: Int
     public var targetableRate: Double?
+    public var candidateQueryEligibleInstallationCount: Int
+    public var hardStalePresenceCount: Int
+    public var candidateQueryEligibilityRate: Double?
     public var lossBreakdown: TargetableCoverageBreakdownResponse
 
     init(refreshedAt: Date?, metric: StoredTargetableCoverageMetric) {
         self.refreshedAt = refreshedAt
         self.installationFreshnessSeconds = metric.installationFreshnessSeconds
         self.presenceFreshnessSeconds = metric.presenceFreshnessSeconds
+        self.hardStalePresenceThresholdSeconds = metric.hardStalePresenceThresholdSeconds
         self.activeSubscribedInstallationCount = metric.activeSubscribedInstallationCount
         self.targetableInstallationCount = metric.targetableInstallationCount
         self.targetableRate = OperatorDashboardCalculations.rate(
             numerator: metric.targetableInstallationCount,
+            denominator: metric.activeSubscribedInstallationCount
+        )
+        self.candidateQueryEligibleInstallationCount = metric.candidateQueryEligibleInstallationCount
+        self.hardStalePresenceCount = metric.hardStalePresenceCount
+        self.candidateQueryEligibilityRate = OperatorDashboardCalculations.rate(
+            numerator: metric.candidateQueryEligibleInstallationCount,
             denominator: metric.activeSubscribedInstallationCount
         )
         self.lossBreakdown = .init(

--- a/Sources/App/lib/OperatorDashboardPageRenderer.swift
+++ b/Sources/App/lib/OperatorDashboardPageRenderer.swift
@@ -742,8 +742,10 @@ enum OperatorDashboardPageRenderer {
           }
 
           function renderCoverageCard(metric) {
-            return renderCard('Fresh targetable coverage', formatPercent(metric.targetableRate), metric.refreshedAt, [
-              { label: 'Targetable', value: `${metric.targetableInstallationCount} / ${metric.activeSubscribedInstallationCount}` },
+            return renderCard('Candidate-query eligibility', formatPercent(metric.candidateQueryEligibilityRate), metric.refreshedAt, [
+              { label: 'Eligible ≤24h', value: `${metric.candidateQueryEligibleInstallationCount} / ${metric.activeSubscribedInstallationCount}` },
+              { label: 'Excluded >24h', value: String(metric.hardStalePresenceCount) },
+              { label: 'Fresh targetable (≤6h)', value: `${metric.targetableInstallationCount} / ${metric.activeSubscribedInstallationCount}` },
               { label: 'Missing token', value: String(metric.lossBreakdown.missingDeviceTokenCount) },
               { label: 'Stale install', value: String(metric.lossBreakdown.staleInstallationHeartbeatCount) },
               { label: 'Stale presence', value: String(metric.lossBreakdown.stalePresenceCount) },
@@ -1278,11 +1280,13 @@ enum OperatorDashboardPageRenderer {
 
     private static func coverageCard(_ metric: TargetableCoverageMetricResponse) -> String {
         card(
-            title: "Fresh targetable coverage",
-            primary: maybePercent(metric.targetableRate),
+            title: "Candidate-query eligibility",
+            primary: maybePercent(metric.candidateQueryEligibilityRate),
             refreshedAt: metric.refreshedAt,
             lines: [
-                ("Targetable", "\(metric.targetableInstallationCount) / \(metric.activeSubscribedInstallationCount)"),
+                ("Eligible ≤24h", "\(metric.candidateQueryEligibleInstallationCount) / \(metric.activeSubscribedInstallationCount)"),
+                ("Excluded >24h", "\(metric.hardStalePresenceCount)"),
+                ("Fresh targetable (≤6h)", "\(metric.targetableInstallationCount) / \(metric.activeSubscribedInstallationCount)"),
                 ("Missing token", "\(metric.lossBreakdown.missingDeviceTokenCount)"),
                 ("Stale install", "\(metric.lossBreakdown.staleInstallationHeartbeatCount)"),
                 ("Stale presence", "\(metric.lossBreakdown.stalePresenceCount)"),

--- a/Sources/App/lib/OperatorDashboardSnapshotRefresher.swift
+++ b/Sources/App/lib/OperatorDashboardSnapshotRefresher.swift
@@ -247,7 +247,7 @@ struct OperatorDashboardSnapshotRefresher {
         )
     }
 
-    private func loadTargetableCoverage(on sql: any SQLDatabase, now: Date) async throws -> StoredTargetableCoverageMetric {
+    func loadTargetableCoverage(on sql: any SQLDatabase, now: Date) async throws -> StoredTargetableCoverageMetric {
         let installationCutoff = now.addingTimeInterval(-Double(OperatorDashboardConfig.installationFreshnessThresholdSeconds))
         let presenceCutoff = now.addingTimeInterval(-Double(OperatorDashboardConfig.presenceFreshnessThresholdSeconds))
         let hardStalePresenceCutoff = now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold)

--- a/Sources/App/lib/OperatorDashboardSnapshotRefresher.swift
+++ b/Sources/App/lib/OperatorDashboardSnapshotRefresher.swift
@@ -250,6 +250,7 @@ struct OperatorDashboardSnapshotRefresher {
     private func loadTargetableCoverage(on sql: any SQLDatabase, now: Date) async throws -> StoredTargetableCoverageMetric {
         let installationCutoff = now.addingTimeInterval(-Double(OperatorDashboardConfig.installationFreshnessThresholdSeconds))
         let presenceCutoff = now.addingTimeInterval(-Double(OperatorDashboardConfig.presenceFreshnessThresholdSeconds))
+        let hardStalePresenceCutoff = now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold)
         let row = try await sql.raw("""
             SELECT
                 COUNT(*) FILTER (
@@ -303,7 +304,33 @@ struct OperatorDashboardSnapshotRefresher {
                           OR COALESCE(BTRIM(p.zone), '') <> ''
                           OR COALESCE(BTRIM(p.fire_zone), '') <> ''
                       )
-                ) AS "missingTargetingDataCount"
+                ) AS "missingTargetingDataCount",
+                COUNT(*) FILTER (
+                    WHERE i.is_active = TRUE
+                      AND i.is_subscribed = TRUE
+                      AND i.apns_device_token <> ''
+                      AND p.installation_id IS NOT NULL
+                      AND p.captured_at >= \(bind: hardStalePresenceCutoff)
+                      AND (
+                          p.h3_cell IS NOT NULL
+                          OR COALESCE(BTRIM(p.county), '') <> ''
+                          OR COALESCE(BTRIM(p.zone), '') <> ''
+                          OR COALESCE(BTRIM(p.fire_zone), '') <> ''
+                      )
+                ) AS "candidateQueryEligibleInstallationCount",
+                COUNT(*) FILTER (
+                    WHERE i.is_active = TRUE
+                      AND i.is_subscribed = TRUE
+                      AND i.apns_device_token <> ''
+                      AND p.installation_id IS NOT NULL
+                      AND p.captured_at < \(bind: hardStalePresenceCutoff)
+                      AND (
+                          p.h3_cell IS NOT NULL
+                          OR COALESCE(BTRIM(p.county), '') <> ''
+                          OR COALESCE(BTRIM(p.zone), '') <> ''
+                          OR COALESCE(BTRIM(p.fire_zone), '') <> ''
+                      )
+                ) AS "hardStalePresenceCount"
             FROM device_installations i
             LEFT JOIN device_presence p
               ON p.installation_id = i.installation_id
@@ -312,8 +339,11 @@ struct OperatorDashboardSnapshotRefresher {
         return .init(
             installationFreshnessSeconds: OperatorDashboardConfig.installationFreshnessThresholdSeconds,
             presenceFreshnessSeconds: OperatorDashboardConfig.presenceFreshnessThresholdSeconds,
+            hardStalePresenceThresholdSeconds: Int(LocationFreshnessPolicy.hardStaleThreshold),
             activeSubscribedInstallationCount: row.map { Int($0.activeSubscribedInstallationCount) } ?? 0,
             targetableInstallationCount: row.map { Int($0.targetableInstallationCount) } ?? 0,
+            candidateQueryEligibleInstallationCount: row.map { Int($0.candidateQueryEligibleInstallationCount) } ?? 0,
+            hardStalePresenceCount: row.map { Int($0.hardStalePresenceCount) } ?? 0,
             lossBreakdown: .init(
                 missingDeviceTokenCount: row.map { Int($0.missingDeviceTokenCount) } ?? 0,
                 staleInstallationHeartbeatCount: row.map { Int($0.staleInstallationHeartbeatCount) } ?? 0,
@@ -776,6 +806,8 @@ private struct TargetableCoverageRow: Decodable {
     let staleInstallationHeartbeatCount: Int64
     let stalePresenceCount: Int64
     let missingTargetingDataCount: Int64
+    let candidateQueryEligibleInstallationCount: Int64
+    let hardStalePresenceCount: Int64
 }
 
 private struct H3AggregateRow: Decodable {

--- a/Tests/AppTests/LocationFreshnessPolicyTests.swift
+++ b/Tests/AppTests/LocationFreshnessPolicyTests.swift
@@ -11,6 +11,11 @@ struct LocationFreshnessPolicyTests {
         now.addingTimeInterval(-(hoursAgo * 60 * 60) - secondsAgo)
     }
 
+    @Test("hard stale threshold remains 24 hours")
+    func hardStaleThresholdIsTwentyFourHours() {
+        #expect(LocationFreshnessPolicy.hardStaleThreshold == 24 * 60 * 60)
+    }
+
     @Test("When In Use: now is fresh")
     func whenInUseNowFresh() {
         let decision = policy.decide(

--- a/Tests/AppTests/NotificationMissedDecisionPersistenceTests.swift
+++ b/Tests/AppTests/NotificationMissedDecisionPersistenceTests.swift
@@ -177,9 +177,10 @@ struct NotificationMissedDecisionPersistenceTests {
             #expect(result.inserted)
             #expect(result.id != nil)
 
-            let row = try await NotificationMissedDecisionModel.query(on: app.db)
-                .filter(\.$revisionUrn == revisionUrn)
-                .first()
+            let row = try await NotificationMissedDecisionModel.find(
+                result.id,
+                on: app.db
+            )
             #expect(row != nil)
             #expect(row?.freshnessState == .stale)
             #expect(row?.permissionMode == .whenInUse)

--- a/Tests/AppTests/NotificationSendJobCandidateQueryTests.swift
+++ b/Tests/AppTests/NotificationSendJobCandidateQueryTests.swift
@@ -1,0 +1,176 @@
+@testable import App
+import Fluent
+import FluentPostgresDriver
+import FluentSQL
+import Foundation
+import Testing
+import Vapor
+
+@Suite("Notification send job candidate queries", .serialized)
+struct NotificationSendJobCandidateQueryTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func withApp(test: (Application) async throws -> Void) async throws {
+        let app = try await Application.make(.testing)
+        do {
+            let databaseURL = Environment.get("DATABASE_URL")
+                ?? "postgres://arcus:arcus@127.0.0.1:5432/arcus_signal?tlsmode=disable"
+            app.databases.use(try .postgres(url: databaseURL), as: .psql)
+            try await bootstrapTables(on: app.db)
+            try await test(app)
+        } catch {
+            try? await app.asyncShutdown()
+            throw error
+        }
+        try await app.asyncShutdown()
+    }
+
+    private func bootstrapTables(on db: any Database) async throws {
+        guard let sql = db as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        try await sql.raw("""
+            CREATE TABLE IF NOT EXISTS device_installations (
+                installation_id UUID PRIMARY KEY,
+                apns_device_token TEXT NOT NULL,
+                apns_environment TEXT NOT NULL,
+                platform TEXT NOT NULL,
+                os_version TEXT NOT NULL,
+                app_version TEXT NOT NULL,
+                build_number TEXT NOT NULL,
+                location_auth TEXT NOT NULL,
+                is_active BOOLEAN NOT NULL,
+                is_subscribed BOOLEAN NOT NULL DEFAULT TRUE,
+                created_at TIMESTAMP NOT NULL,
+                updated_at TIMESTAMP NOT NULL,
+                last_seen_at TIMESTAMP NOT NULL
+            );
+            """).run()
+
+        try await sql.raw("""
+            ALTER TABLE device_installations
+            ADD COLUMN IF NOT EXISTS is_subscribed BOOLEAN NOT NULL DEFAULT TRUE;
+            """).run()
+
+        try await sql.raw("""
+            CREATE TABLE IF NOT EXISTS device_presence (
+                installation_id UUID PRIMARY KEY REFERENCES device_installations(installation_id) ON DELETE CASCADE,
+                captured_at TIMESTAMP NOT NULL,
+                received_at TIMESTAMP NOT NULL,
+                location_age_seconds DOUBLE PRECISION NOT NULL,
+                horizontal_accuracy_meters DOUBLE PRECISION NOT NULL,
+                cell_scheme TEXT NOT NULL,
+                h3_cell BIGINT,
+                h3_resolution INTEGER,
+                county TEXT,
+                zone TEXT,
+                fire_zone TEXT,
+                source TEXT NOT NULL,
+                created_at TIMESTAMP NOT NULL,
+                updated_at TIMESTAMP NOT NULL,
+                county_label TEXT,
+                fire_zone_label TEXT
+            );
+            """).run()
+    }
+
+    private func seedCandidate(
+        id: UUID,
+        capturedAt: Date,
+        h3Cell: Int64?,
+        county: String?,
+        isActive: Bool = true,
+        isSubscribed: Bool = true,
+        token: String = "token",
+        on db: any Database
+    ) async throws {
+        guard let sql = db as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        try await sql.raw("""
+            INSERT INTO device_installations
+                (installation_id, apns_device_token, apns_environment, platform, os_version, app_version,
+                 build_number, location_auth, is_active, is_subscribed, created_at, updated_at, last_seen_at)
+            VALUES
+                (\(bind: id), \(bind: token), 'sandbox', 'iOS', '26.0', '1.0.0', '100',
+                 'always', \(bind: isActive), \(bind: isSubscribed), \(bind: now), \(bind: now), \(bind: now));
+            """).run()
+
+        try await sql.raw("""
+            INSERT INTO device_presence
+                (installation_id, captured_at, received_at, location_age_seconds, horizontal_accuracy_meters,
+                 cell_scheme, h3_cell, h3_resolution, county, zone, fire_zone, source, created_at, updated_at,
+                 county_label, fire_zone_label)
+            VALUES
+                (\(bind: id), \(bind: capturedAt), \(bind: capturedAt), 0, 0,
+                 \(bind: h3Cell == nil ? "ugc-only" : "h3"), \(bind: h3Cell), \(bind: h3Cell == nil ? nil : 8),
+                 \(bind: county), NULL, NULL, 'foreground', \(bind: now), \(bind: now), \(bind: county), NULL);
+            """).run()
+    }
+
+    private func seedCandidates(
+        h3Cell: Int64?,
+        county: String?,
+        on db: any Database
+    ) async throws -> (included: Set<UUID>, excluded: Set<UUID>) {
+        let cutoff = now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold)
+        let newer = UUID()
+        let exactlyAtCutoff = UUID()
+        let older = UUID()
+        let inactive = UUID()
+        let unsubscribed = UUID()
+        let tokenless = UUID()
+
+        try await seedCandidate(id: newer, capturedAt: cutoff.addingTimeInterval(1), h3Cell: h3Cell, county: county, on: db)
+        try await seedCandidate(id: exactlyAtCutoff, capturedAt: cutoff, h3Cell: h3Cell, county: county, on: db)
+        try await seedCandidate(id: older, capturedAt: cutoff.addingTimeInterval(-1), h3Cell: h3Cell, county: county, on: db)
+        try await seedCandidate(id: inactive, capturedAt: now, h3Cell: h3Cell, county: county, isActive: false, on: db)
+        try await seedCandidate(id: unsubscribed, capturedAt: now, h3Cell: h3Cell, county: county, isSubscribed: false, on: db)
+        try await seedCandidate(id: tokenless, capturedAt: now, h3Cell: h3Cell, county: county, token: "", on: db)
+
+        return ([newer, exactlyAtCutoff], [older, inactive, unsubscribed, tokenless])
+    }
+
+    @Test("H3 candidates include fresh and cutoff presence while preserving installation exclusions")
+    func h3CandidatesFilterHardStalePresence() async throws {
+        try await withApp { app in
+            let h3Cell = Int64(
+                UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(15),
+                radix: 16
+            )!
+            let expected = try await seedCandidates(h3Cell: h3Cell, county: nil, on: app.db)
+            let cutoff = now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold)
+
+            let candidates = try await NotificationSendJob().loadH3Candidates(
+                cells: [h3Cell],
+                capturedAtOrAfter: cutoff,
+                on: app.db
+            )
+            let actual = Set(candidates.map(\.id))
+
+            #expect(actual == expected.included)
+            #expect(actual.isDisjoint(with: expected.excluded))
+        }
+    }
+
+    @Test("UGC candidates include fresh and cutoff presence while preserving installation exclusions")
+    func ugcCandidatesFilterHardStalePresence() async throws {
+        try await withApp { app in
+            let county = "test-\(UUID().uuidString)"
+            let expected = try await seedCandidates(h3Cell: nil, county: county, on: app.db)
+            let cutoff = now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold)
+
+            let candidates = try await NotificationSendJob().loadUGCCandidates(
+                ugcCodes: [county],
+                capturedAtOrAfter: cutoff,
+                on: app.db
+            )
+            let actual = Set(candidates.map(\.id))
+
+            #expect(actual == expected.included)
+            #expect(actual.isDisjoint(with: expected.excluded))
+        }
+    }
+}

--- a/Tests/AppTests/NotificationSendJobCandidateQueryTests.swift
+++ b/Tests/AppTests/NotificationSendJobCandidateQueryTests.swift
@@ -8,16 +8,27 @@ import Vapor
 
 @Suite("Notification send job candidate queries", .serialized)
 struct NotificationSendJobCandidateQueryTests {
+    private enum Rollback: Error {
+        case afterAssertions
+    }
+
     private let now = Date(timeIntervalSince1970: 1_800_000_000)
 
-    private func withApp(test: (Application) async throws -> Void) async throws {
+    private func withApp(test: @escaping @Sendable (any Database) async throws -> Void) async throws {
         let app = try await Application.make(.testing)
         do {
             let databaseURL = Environment.get("DATABASE_URL")
                 ?? "postgres://arcus:arcus@127.0.0.1:5432/arcus_signal?tlsmode=disable"
             app.databases.use(try .postgres(url: databaseURL), as: .psql)
             try await bootstrapTables(on: app.db)
-            try await test(app)
+            do {
+                try await app.db.transaction { database in
+                    try await test(database)
+                    throw Rollback.afterAssertions
+                }
+            } catch Rollback.afterAssertions {
+                // Expected: keep shared integration-test tables unchanged.
+            }
         } catch {
             try? await app.asyncShutdown()
             throw error
@@ -135,18 +146,18 @@ struct NotificationSendJobCandidateQueryTests {
 
     @Test("H3 candidates include fresh and cutoff presence while preserving installation exclusions")
     func h3CandidatesFilterHardStalePresence() async throws {
-        try await withApp { app in
+        try await withApp { database in
             let h3Cell = Int64(
                 UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(15),
                 radix: 16
             )!
-            let expected = try await seedCandidates(h3Cell: h3Cell, county: nil, on: app.db)
+            let expected = try await seedCandidates(h3Cell: h3Cell, county: nil, on: database)
             let cutoff = now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold)
 
             let candidates = try await NotificationSendJob().loadH3Candidates(
                 cells: [h3Cell],
                 capturedAtOrAfter: cutoff,
-                on: app.db
+                on: database
             )
             let actual = Set(candidates.map(\.id))
 
@@ -157,15 +168,15 @@ struct NotificationSendJobCandidateQueryTests {
 
     @Test("UGC candidates include fresh and cutoff presence while preserving installation exclusions")
     func ugcCandidatesFilterHardStalePresence() async throws {
-        try await withApp { app in
+        try await withApp { database in
             let county = "test-\(UUID().uuidString)"
-            let expected = try await seedCandidates(h3Cell: nil, county: county, on: app.db)
+            let expected = try await seedCandidates(h3Cell: nil, county: county, on: database)
             let cutoff = now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold)
 
             let candidates = try await NotificationSendJob().loadUGCCandidates(
                 ugcCodes: [county],
                 capturedAtOrAfter: cutoff,
-                on: app.db
+                on: database
             )
             let actual = Set(candidates.map(\.id))
 

--- a/Tests/AppTests/OperatorDashboardTargetableCoverageTests.swift
+++ b/Tests/AppTests/OperatorDashboardTargetableCoverageTests.swift
@@ -1,0 +1,127 @@
+@testable import App
+import Fluent
+import FluentSQL
+import Foundation
+import Testing
+import Vapor
+
+@Suite("Operator dashboard targetable coverage", .serialized)
+struct OperatorDashboardTargetableCoverageTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func withApp(test: (Application) async throws -> Void) async throws {
+        let app = try await Application.make(.testing)
+        do {
+            try await configure(app, mode: .api)
+            try await app.autoMigrate()
+            try await clearDeviceData(on: app.db)
+            try await test(app)
+        } catch {
+            try? await app.asyncShutdown()
+            throw error
+        }
+        try await app.asyncShutdown()
+    }
+
+    private func clearDeviceData(on database: any Database) async throws {
+        guard let sql = database as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        try await sql.raw("DELETE FROM device_presence;").run()
+        try await sql.raw("DELETE FROM device_installations;").run()
+    }
+
+    private func seedInstallation(
+        token: String = "token",
+        locationAuth: LocationAuth = .always,
+        isActive: Bool = true,
+        isSubscribed: Bool = true,
+        lastSeenAt: Date,
+        capturedAt: Date? = nil,
+        hasTargetingData: Bool = true,
+        on database: any Database
+    ) async throws {
+        let installationID = UUID()
+        try await DeviceInstallationModel(
+            installationId: installationID,
+            apnsDeviceToken: token,
+            apnsEnvironment: .sandbox,
+            platform: .iOS,
+            osVersion: "26.0",
+            appVersion: "1.0.0",
+            buildNumber: "100",
+            locationAuth: locationAuth,
+            isActive: isActive,
+            lastSeenAt: lastSeenAt,
+            isSubscribed: isSubscribed
+        ).create(on: database)
+
+        guard let capturedAt else { return }
+        try await DevicePresenceModel(
+            installationId: installationID,
+            capturedAt: capturedAt,
+            receivedAt: capturedAt,
+            locationAgeSeconds: 0,
+            horizontalAccuracyMeters: 0,
+            cellScheme: hasTargetingData ? .h3 : .ugcOnly,
+            h3Cell: hasTargetingData ? 617_700_169_958_293_503 : nil,
+            h3Resolution: hasTargetingData ? 8 : nil,
+            county: nil,
+            zone: nil,
+            fireZone: nil,
+            source: .foregroundPrime,
+            countyLabel: nil,
+            fireZoneLabel: nil
+        ).create(on: database)
+    }
+
+    @Test("coverage aggregate uses the shared hard-stale cutoff without legacy heartbeat or authorization filters")
+    func coverageAggregateUsesHardStaleCutoff() async throws {
+        try await withApp { app in
+            let cutoff = now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold)
+            let staleHeartbeat = now.addingTimeInterval(-48 * 60 * 60)
+
+            try await seedInstallation(
+                locationAuth: .denied,
+                lastSeenAt: staleHeartbeat,
+                capturedAt: cutoff,
+                on: app.db
+            )
+            try await seedInstallation(
+                lastSeenAt: now,
+                capturedAt: cutoff.addingTimeInterval(1),
+                on: app.db
+            )
+            try await seedInstallation(
+                lastSeenAt: staleHeartbeat,
+                capturedAt: cutoff.addingTimeInterval(-1),
+                on: app.db
+            )
+            try await seedInstallation(
+                token: "",
+                lastSeenAt: now,
+                capturedAt: now,
+                on: app.db
+            )
+            try await seedInstallation(
+                lastSeenAt: now,
+                capturedAt: now,
+                hasTargetingData: false,
+                on: app.db
+            )
+            try await seedInstallation(lastSeenAt: now, capturedAt: nil, on: app.db)
+            try await seedInstallation(isActive: false, lastSeenAt: now, capturedAt: now, on: app.db)
+            try await seedInstallation(isSubscribed: false, lastSeenAt: now, capturedAt: now, on: app.db)
+
+            try await OperatorDashboardSnapshotRefresher().refreshIfDue(on: app, forceAll: true, now: now)
+
+            let snapshot = try #require(try await app.operatorDashboardSnapshotStore.load(on: app.db))
+            let coverage = snapshot.targetableCoverage
+            #expect(coverage.hardStalePresenceThresholdSeconds == Int(LocationFreshnessPolicy.hardStaleThreshold))
+            #expect(coverage.activeSubscribedInstallationCount == 6)
+            #expect(coverage.candidateQueryEligibleInstallationCount == 2)
+            #expect(coverage.hardStalePresenceCount == 1)
+        }
+    }
+}

--- a/Tests/AppTests/OperatorDashboardTargetableCoverageTests.swift
+++ b/Tests/AppTests/OperatorDashboardTargetableCoverageTests.swift
@@ -7,15 +7,33 @@ import Vapor
 
 @Suite("Operator dashboard targetable coverage", .serialized)
 struct OperatorDashboardTargetableCoverageTests {
+    private enum Rollback: Error {
+        case afterAssertions
+    }
+
     private let now = Date(timeIntervalSince1970: 1_800_000_000)
 
-    private func withApp(test: (Application) async throws -> Void) async throws {
+    private func withApp(test: @escaping @Sendable (any Database) async throws -> Void) async throws {
         let app = try await Application.make(.testing)
         do {
             try await configure(app, mode: .api)
             try await app.autoMigrate()
-            try await clearDeviceData(on: app.db)
-            try await test(app)
+            do {
+                try await app.db.transaction { database in
+                    guard let sql = database as? any SQLDatabase else {
+                        throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+                    }
+
+                    try await sql.raw(
+                        "LOCK TABLE device_installations, device_presence IN ACCESS EXCLUSIVE MODE"
+                    ).run()
+                    try await clearDeviceData(on: database)
+                    try await test(database)
+                    throw Rollback.afterAssertions
+                }
+            } catch Rollback.afterAssertions {
+                // Expected: keep shared integration-test tables unchanged.
+            }
         } catch {
             try? await app.asyncShutdown()
             throw error
@@ -78,7 +96,7 @@ struct OperatorDashboardTargetableCoverageTests {
 
     @Test("coverage aggregate uses the shared hard-stale cutoff without legacy heartbeat or authorization filters")
     func coverageAggregateUsesHardStaleCutoff() async throws {
-        try await withApp { app in
+        try await withApp { database in
             let cutoff = now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold)
             let staleHeartbeat = now.addingTimeInterval(-48 * 60 * 60)
 
@@ -86,38 +104,40 @@ struct OperatorDashboardTargetableCoverageTests {
                 locationAuth: .denied,
                 lastSeenAt: staleHeartbeat,
                 capturedAt: cutoff,
-                on: app.db
+                on: database
             )
             try await seedInstallation(
                 lastSeenAt: now,
                 capturedAt: cutoff.addingTimeInterval(1),
-                on: app.db
+                on: database
             )
             try await seedInstallation(
                 lastSeenAt: staleHeartbeat,
                 capturedAt: cutoff.addingTimeInterval(-1),
-                on: app.db
+                on: database
             )
             try await seedInstallation(
                 token: "",
                 lastSeenAt: now,
                 capturedAt: now,
-                on: app.db
+                on: database
             )
             try await seedInstallation(
                 lastSeenAt: now,
                 capturedAt: now,
                 hasTargetingData: false,
-                on: app.db
+                on: database
             )
-            try await seedInstallation(lastSeenAt: now, capturedAt: nil, on: app.db)
-            try await seedInstallation(isActive: false, lastSeenAt: now, capturedAt: now, on: app.db)
-            try await seedInstallation(isSubscribed: false, lastSeenAt: now, capturedAt: now, on: app.db)
+            try await seedInstallation(lastSeenAt: now, capturedAt: nil, on: database)
+            try await seedInstallation(isActive: false, lastSeenAt: now, capturedAt: now, on: database)
+            try await seedInstallation(isSubscribed: false, lastSeenAt: now, capturedAt: now, on: database)
 
-            try await OperatorDashboardSnapshotRefresher().refreshIfDue(on: app, forceAll: true, now: now)
+            guard let sql = database as? any SQLDatabase else {
+                throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+            }
 
-            let snapshot = try #require(try await app.operatorDashboardSnapshotStore.load(on: app.db))
-            let coverage = snapshot.targetableCoverage
+            let coverage = try await OperatorDashboardSnapshotRefresher()
+                .loadTargetableCoverage(on: sql, now: now)
             #expect(coverage.hardStalePresenceThresholdSeconds == Int(LocationFreshnessPolicy.hardStaleThreshold))
             #expect(coverage.activeSubscribedInstallationCount == 6)
             #expect(coverage.candidateQueryEligibleInstallationCount == 2)

--- a/Tests/AppTests/OperatorDashboardTests.swift
+++ b/Tests/AppTests/OperatorDashboardTests.swift
@@ -102,8 +102,11 @@ struct OperatorDashboardTests {
             targetableCoverage: .init(
                 installationFreshnessSeconds: 86_400,
                 presenceFreshnessSeconds: 21_600,
+                hardStalePresenceThresholdSeconds: 86_400,
                 activeSubscribedInstallationCount: 100,
                 targetableInstallationCount: 61,
+                candidateQueryEligibleInstallationCount: 74,
+                hardStalePresenceCount: 13,
                 lossBreakdown: .init(
                     missingDeviceTokenCount: 3,
                     staleInstallationHeartbeatCount: 12,
@@ -188,6 +191,7 @@ struct OperatorDashboardTests {
         #expect(abs((response.deliveryKPIs.sendNoOpRateByReason.noOpRate ?? 0) - 0.25) < 0.0001)
         #expect(abs((response.deliveryKPIs.zeroCandidateRevisionRate.zeroCandidateRate ?? 0) - 0.25) < 0.0001)
         #expect(abs((response.audienceTargeting.freshTargetableInstallationCoverage.targetableRate ?? 0) - 0.61) < 0.0001)
+        #expect(abs((response.audienceTargeting.freshTargetableInstallationCoverage.candidateQueryEligibilityRate ?? 0) - 0.74) < 0.0001)
         #expect(abs((response.audienceTargeting.alertsWithGeographyAndH3Success.successRate ?? 0) - 0.8333333333) < 0.0001)
     }
 
@@ -285,6 +289,9 @@ struct OperatorDashboardTests {
         let snapshot = try decoder.decode(OperatorDashboardStoredSnapshot.self, from: Data(json.utf8))
         #expect(snapshot.schemaVersion == 0)
         #expect(snapshot.touchedSeries.first?.ugcCodes == [])
+        #expect(snapshot.targetableCoverage.hardStalePresenceThresholdSeconds == Int(LocationFreshnessPolicy.hardStaleThreshold))
+        #expect(snapshot.targetableCoverage.candidateQueryEligibleInstallationCount == 0)
+        #expect(snapshot.targetableCoverage.hardStalePresenceCount == 0)
     }
 
     @Test("legacy snapshot backfills touched-series fields")
@@ -327,6 +334,11 @@ struct OperatorDashboardTests {
                 #expect(payload.operatorContext.lastTouchedSeries.entries.first?.ugcCodes == ["COC005", "COC013"])
                 #expect(payload.operatorContext.lastTouchedSeries.entries.first?.tornadoDetection == "OBSERVED")
                 #expect(payload.operatorContext.lastTouchedSeries.entries.first?.tornadoDamageThreat == "CONSIDERABLE")
+                let coverage = payload.audienceTargeting.freshTargetableInstallationCoverage
+                #expect(coverage.hardStalePresenceThresholdSeconds == 86_400)
+                #expect(coverage.candidateQueryEligibleInstallationCount == 74)
+                #expect(coverage.hardStalePresenceCount == 13)
+                #expect(abs((coverage.candidateQueryEligibilityRate ?? 0) - 0.74) < 0.0001)
             })
         }
     }
@@ -355,6 +367,14 @@ struct OperatorDashboardTests {
                 #expect(res.body.string.contains("fetch('/v1/metrics'"))
                 #expect(res.body.string.contains("window.setTimeout(fetchSnapshot, nextDelay)"))
                 #expect(res.body.string.contains("The page polls the canonical"))
+                #expect(res.body.string.components(separatedBy: "Eligible ≤24h").count == 3)
+                #expect(res.body.string.contains("Excluded &gt;24h"))
+                #expect(res.body.string.contains("Excluded >24h"))
+                #expect(res.body.string.contains("74 / 100"))
+                #expect(res.body.string.contains(">13<"))
+                #expect(res.body.string.contains("candidateQueryEligibilityRate"))
+                #expect(res.body.string.contains("candidateQueryEligibleInstallationCount"))
+                #expect(res.body.string.contains("hardStalePresenceCount"))
                 #expect(res.body.string.contains("hero-rendered-at"))
                 #expect(res.body.string.contains("http-equiv=\"refresh\"") == false)
             })


### PR DESCRIPTION
# Summary
Apply the shared 24-hour hard-stale presence cutoff to notification candidate queries and expose matching eligibility metrics in the operator dashboard. The branch also adds regression coverage for H3/UGC filtering and dashboard aggregation, plus compatibility defaults for stored snapshots.

# What Changed
- Exclude presence records older than 24 hours from H3 and UGC notification candidate queries.
- Promote the shared hard-stale threshold for reuse by delivery and dashboard code.
- Add candidate-query eligibility and hard-stale presence counts/rates to stored and rendered operator dashboard metrics.
- Preserve decoding compatibility for older dashboard snapshots by backfilling new metric fields.
- Add regression tests for cutoff-boundary candidate filtering, dashboard aggregation, and snapshot/rendered response behavior.

# User Impact
Users with presence data older than 24 hours are no longer selected as notification candidates, reducing delivery to stale locations. Operators gain dashboard visibility into candidate-query eligibility and hard-stale exclusions.

# Testing
- `swift test` built successfully and executed 427 tests across 56 suites, but reported 1 failing issue.
- A follow-up focused test command could not run because the sandbox blocked Swift manifest/module-cache access.

# Notes
- The working tree contains an unrelated uncommitted change in `docs/Sql/Device.sql`; it is excluded from this PR.
- This PR is opened as a draft for review because the full-suite failure remains to be isolated.