### PR TITLE
Centralize HRRR surface-to-pressure identity

### DIFF
--- a/Sources/App/StormSetup/AnvilProfilePreviewProvider.swift
+++ b/Sources/App/StormSetup/AnvilProfilePreviewProvider.swift
@@ -140,12 +140,14 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         if let pressureArtifactCatalogLookupService {
             let pressureResolution = HrrrRunResolution(
                 targetValidTime: runResolution.targetValidTime,
-                candidates: runResolution.candidates.map(makePressureCandidate(from:))
+                candidates: runResolution.candidates.map {
+                    HrrrSurfaceToPressureCandidatePolicy.makePressureCandidate(from: $0)
+                }
             )
 
             for candidate in runResolution.candidates {
                 try Task.checkCancellation()
-                let pressureCandidate = makePressureCandidate(from: candidate)
+                let pressureCandidate = HrrrSurfaceToPressureCandidatePolicy.makePressureCandidate(from: candidate)
                 var readyArtifact: PressureArtifactCatalogReadyArtifact?
                 do {
                     readyArtifact = try await pressureArtifactCatalogLookupService.readyArtifact(
@@ -232,7 +234,7 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
 
         for candidate in runResolution.candidates {
             try Task.checkCancellation()
-            let pressureCandidate = makePressureCandidate(from: candidate)
+            let pressureCandidate = HrrrSurfaceToPressureCandidatePolicy.makePressureCandidate(from: candidate)
             do {
                 let preview = try await previewPressureCandidate(
                     pressureCandidate,
@@ -601,18 +603,6 @@ struct DefaultAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
         return SurfaceLevelLoadResult(
             level: surfaceLevel,
             subsetCacheHit: loadResult.subsetCacheResult.cacheHit
-        )
-    }
-
-    private func makePressureCandidate(from candidate: HrrrRunCandidate) -> HrrrRunCandidate {
-        let runTime = StormSetupUTC.calendar.date(byAdding: .hour, value: -1, to: candidate.runTime) ?? candidate.runTime
-        return HrrrRunCandidate(
-            model: candidate.model,
-            product: .wrfprsf,
-            domain: candidate.domain,
-            runTime: runTime,
-            forecastHour: candidate.forecastHour + 1,
-            fieldSetVersion: HrrrProduct.wrfprsf.defaultFieldSetVersion
         )
     }
 

--- a/Sources/App/StormSetup/HRRRPressureArtifactProbeService.swift
+++ b/Sources/App/StormSetup/HRRRPressureArtifactProbeService.swift
@@ -101,7 +101,7 @@ struct HRRRPressureArtifactProbeService: HRRRPressureArtifactProbing {
 
         for candidate in resolution.candidates {
             try Task.checkCancellation()
-            let pressureCandidate = makePressureCandidate(from: candidate)
+            let pressureCandidate = HrrrSurfaceToPressureCandidatePolicy.makePressureCandidate(from: candidate)
             let source = urlBuilder.makeSourceMetadata(for: pressureCandidate)
             guard let idxURL = source.idxURL else {
                 logger.warning(
@@ -285,18 +285,6 @@ struct HRRRPressureArtifactProbeService: HRRRPressureArtifactProbing {
 }
 
 private extension HRRRPressureArtifactProbeService {
-    func makePressureCandidate(from candidate: HrrrRunCandidate) -> HrrrRunCandidate {
-        let runTime = StormSetupUTC.calendar.date(byAdding: .hour, value: -1, to: candidate.runTime) ?? candidate.runTime
-        return HrrrRunCandidate(
-            model: candidate.model,
-            product: .wrfprsf,
-            domain: candidate.domain,
-            runTime: runTime,
-            forecastHour: candidate.forecastHour + 1,
-            fieldSetVersion: HrrrProduct.wrfprsf.defaultFieldSetVersion
-        )
-    }
-
     func makePayload(from candidate: HrrrRunCandidate) -> PressureArtifactWarmJobPayload {
         PressureArtifactWarmJobPayload(
             runTime: candidate.runTime,

--- a/Sources/App/StormSetup/HrrrPressureDirectObjectResolver.swift
+++ b/Sources/App/StormSetup/HrrrPressureDirectObjectResolver.swift
@@ -144,7 +144,7 @@ struct DefaultHrrrPressureDirectObjectResolver: HrrrPressureDirectObjectResolvin
 
         for candidate in resolution.candidates {
             try Task.checkCancellation()
-            let pressureCandidate = makePressureCandidate(from: candidate)
+            let pressureCandidate = HrrrSurfaceToPressureCandidatePolicy.makePressureCandidate(from: candidate)
             let source = urlBuilder.makeSourceMetadata(for: pressureCandidate)
 
             let idxProbe = try await remoteObjectChecker.probe(url: source.idxURL ?? urlBuilder.makeIdxURL(for: pressureCandidate))
@@ -172,18 +172,6 @@ struct DefaultHrrrPressureDirectObjectResolver: HrrrPressureDirectObjectResolvin
         }
 
         throw HrrrPressureDirectObjectResolverError.noAvailableCandidate(failures)
-    }
-
-    private func makePressureCandidate(from candidate: HrrrRunCandidate) -> HrrrRunCandidate {
-        let runTime = StormSetupUTC.calendar.date(byAdding: .hour, value: -1, to: candidate.runTime) ?? candidate.runTime
-        return HrrrRunCandidate(
-            model: candidate.model,
-            product: .wrfprsf,
-            domain: candidate.domain,
-            runTime: runTime,
-            forecastHour: candidate.forecastHour + 1,
-            fieldSetVersion: HrrrProduct.wrfprsf.defaultFieldSetVersion
-        )
     }
 
     private func probeSummary(for probe: HrrrRemoteObjectProbeResult) -> String {

--- a/Sources/App/StormSetup/HrrrSourceModels.swift
+++ b/Sources/App/StormSetup/HrrrSourceModels.swift
@@ -95,6 +95,20 @@ struct HrrrRunCandidate: Content, Sendable, Equatable {
     }
 }
 
+enum HrrrSurfaceToPressureCandidatePolicy {
+    static func makePressureCandidate(from candidate: HrrrRunCandidate) -> HrrrRunCandidate {
+        let runTime = StormSetupUTC.calendar.date(byAdding: .hour, value: -1, to: candidate.runTime) ?? candidate.runTime
+        return HrrrRunCandidate(
+            model: candidate.model,
+            product: .wrfprsf,
+            domain: candidate.domain,
+            runTime: runTime,
+            forecastHour: candidate.forecastHour + 1,
+            fieldSetVersion: HrrrProduct.wrfprsf.defaultFieldSetVersion
+        )
+    }
+}
+
 struct HrrrRunResolution: Sendable, Equatable {
     let targetValidTime: Date
     let candidates: [HrrrRunCandidate]

--- a/Sources/App/lib/OperatorDashboardSnapshotRefresher.swift
+++ b/Sources/App/lib/OperatorDashboardSnapshotRefresher.swift
@@ -507,7 +507,9 @@ struct OperatorDashboardSnapshotRefresher {
         let runResolution = hrrrRunResolver.resolveRunCandidates()
         let pressureResolution = HrrrRunResolution(
             targetValidTime: runResolution.targetValidTime,
-            candidates: runResolution.candidates.map(makePressureCandidate(from:))
+            candidates: runResolution.candidates.map {
+                HrrrSurfaceToPressureCandidatePolicy.makePressureCandidate(from: $0)
+            }
         )
         let staleCutoff = pressureResolution.targetValidTime.addingTimeInterval(
             -app.stormSetupConfiguration.pressureArtifactMaxStaleAgeSeconds
@@ -649,18 +651,6 @@ struct OperatorDashboardSnapshotRefresher {
         default:
             return "Newest catalog row is \(row.status)."
         }
-    }
-
-    private func makePressureCandidate(from candidate: HrrrRunCandidate) -> HrrrRunCandidate {
-        let runTime = StormSetupUTC.calendar.date(byAdding: .hour, value: -1, to: candidate.runTime) ?? candidate.runTime
-        return HrrrRunCandidate(
-            model: candidate.model,
-            product: .wrfprsf,
-            domain: candidate.domain,
-            runTime: runTime,
-            forecastHour: candidate.forecastHour + 1,
-            fieldSetVersion: HrrrProduct.wrfprsf.defaultFieldSetVersion
-        )
     }
 
     private func loadRecentNotificationDebugEntries(on sql: any SQLDatabase) async throws -> [StoredRecentNotificationDebugEntry] {

--- a/Tests/AppTests/StormSetupHrrrSourceTests.swift
+++ b/Tests/AppTests/StormSetupHrrrSourceTests.swift
@@ -30,6 +30,63 @@ struct StormSetupHrrrSourceTests {
         #expect(HrrrProduct.wrfprsf.defaultFieldSetVersion == .tornadoPressureV2)
     }
 
+    @Test("surface-to-pressure policy preserves pressure artifact identity")
+    func surfaceToPressurePolicyPreservesPressureArtifactIdentity() throws {
+        let cases: [(surface: HrrrRunCandidate, expected: HrrrRunCandidate)] = [
+            (
+                HrrrRunCandidate(
+                    runTime: makeUTCDate(year: 2026, month: 6, day: 19, hour: 21),
+                    forecastHour: 0
+                ),
+                HrrrRunCandidate(
+                    product: .wrfprsf,
+                    runTime: makeUTCDate(year: 2026, month: 6, day: 19, hour: 20),
+                    forecastHour: 1,
+                    fieldSetVersion: .tornadoPressureV2
+                )
+            ),
+            (
+                HrrrRunCandidate(
+                    runTime: makeUTCDate(year: 2026, month: 6, day: 19, hour: 21),
+                    forecastHour: 9
+                ),
+                HrrrRunCandidate(
+                    product: .wrfprsf,
+                    runTime: makeUTCDate(year: 2026, month: 6, day: 19, hour: 20),
+                    forecastHour: 10,
+                    fieldSetVersion: .tornadoPressureV2
+                )
+            ),
+            (
+                HrrrRunCandidate(
+                    product: .wrfprsf,
+                    runTime: makeUTCDate(year: 2026, month: 6, day: 20, hour: 0),
+                    forecastHour: 12,
+                    fieldSetVersion: .tornadoPressureV1
+                ),
+                HrrrRunCandidate(
+                    product: .wrfprsf,
+                    runTime: makeUTCDate(year: 2026, month: 6, day: 19, hour: 23),
+                    forecastHour: 13,
+                    fieldSetVersion: .tornadoPressureV2
+                )
+            )
+        ]
+
+        for testCase in cases {
+            let pressure = HrrrSurfaceToPressureCandidatePolicy.makePressureCandidate(from: testCase.surface)
+
+            #expect(pressure.model == testCase.expected.model)
+            #expect(pressure.domain == testCase.expected.domain)
+            #expect(pressure.runTime == testCase.expected.runTime)
+            #expect(pressure.forecastHour == testCase.expected.forecastHour)
+            #expect(pressure.validTime == testCase.expected.validTime)
+            #expect(pressure.validTime == testCase.surface.validTime)
+            #expect(pressure.product == testCase.expected.product)
+            #expect(pressure.fieldSetVersion == testCase.expected.fieldSetVersion)
+        }
+    }
+
     @Test("fixed clock produces ordered HRRR candidates and valid times")
     func resolverProducesOrderedCandidates() throws {
         let fixedNow = makeUTCDate(year: 2026, month: 6, day: 3, hour: 22, minute: 45)

--- a/docs/plans/architecture-recovery-progress.md
+++ b/docs/plans/architecture-recovery-progress.md
@@ -32,7 +32,7 @@ This ledger tracks the sequential, behavior-preserving architecture recovery cam
 | Seq. | GitHub issue | Roadmap | Title | Dependencies | Execution profile | Status |
 |---:|---|---|---|---|---|---|
 | 01 | [#154](https://github.com/justinrooks/arcus-signal/issues/154) | 1 | Characterize notification dequeue lifecycle | None | `gpt-5.6-terra`, medium | Pending |
-| 02 | [#155](https://github.com/justinrooks/arcus-signal/issues/155) | 2 | Centralize HRRR surface-to-pressure identity | None | `gpt-5.6-terra`, high | Pending |
+| 02 | [#155](https://github.com/justinrooks/arcus-signal/issues/155) | 2 | Centralize HRRR surface-to-pressure identity | None | `gpt-5.6-terra`, high | Complete |
 | 03 | [#156](https://github.com/justinrooks/arcus-signal/issues/156) | 3 | Extract pure H3 coverage result | None | `gpt-5.6-terra`, high | Pending |
 | 04 | [#157](https://github.com/justinrooks/arcus-signal/issues/157) | 4 | Move H3 work before transaction | 03 | `gpt-5.6-sol`, high | Pending |
 | 05 | [#158](https://github.com/justinrooks/arcus-signal/issues/158) | 5 | Isolate notification candidate selection | 01 | `gpt-5.6-sol`, high | Pending |
@@ -82,11 +82,15 @@ This ledger tracks the sequential, behavior-preserving architecture recovery cam
 
 ### Issue #155 - 02: Centralize HRRR surface-to-pressure identity
 
-- **Status:** Pending
+- **Status:** Complete
 - **Roadmap:** Slice 2
 - **Execution profile:** `gpt-5.6-terra`, high reasoning
 - **Dependencies:** None
 - **Stop condition:** One production mapping owner; ordering and identities unchanged.
+- **Files changed:** `Sources/App/StormSetup/HrrrSourceModels.swift`, `Sources/App/StormSetup/HRRRPressureArtifactProbeService.swift`, `Sources/App/StormSetup/HrrrPressureDirectObjectResolver.swift`, `Sources/App/StormSetup/AnvilProfilePreviewProvider.swift`, `Sources/App/lib/OperatorDashboardSnapshotRefresher.swift`, and `Tests/AppTests/StormSetupHrrrSourceTests.swift`.
+- **Behavior:** `HrrrSurfaceToPressureCandidatePolicy` is the sole owner of the existing prior-hour run, next forecast-hour, `wrfprsf`, default pressure field-set conversion. Probe, direct-object resolution, preview, and dashboard readiness use it without changing iteration, lookup, cancellation, or fallback flow.
+- **Validation:** `swift test --filter StormSetupHrrrSourceTests` passed (16 tests); `swift test --filter AnvilProfilePreviewProviderTests` passed (17 tests); `swift test --filter HRRRPressureArtifactProbeServiceTests` passed (10 tests); `swift test --filter OperatorDashboardPressureArtifactTests` passed (9 tests). `git diff --check` is blocked by pre-existing trailing whitespace in `docs/Sql/Device.sql`.
+- **Residual risk / handoff:** No slice-owned residual risk. Re-run `git diff --check` after the unrelated `docs/Sql/Device.sql` whitespace is resolved.
 
 ### Issue #156 - 03: Extract pure H3 coverage result
 


### PR DESCRIPTION
# Summary
Centralizes the existing HRRR surface-to-pressure candidate conversion in one policy and updates all current consumers to use it. The change preserves the prior-hour run, next forecast-hour, product, field-set, ordering, cancellation, lookup, and fallback behavior while removing duplicated mapping logic.

# What Changed
- Added `HrrrSurfaceToPressureCandidatePolicy` as the single owner of surface-to-pressure identity conversion.
- Updated pressure probing, direct-object resolution, Anvil preview, and operator-dashboard readiness to use the shared policy.
- Added boundary tests covering valid-time preservation, prior-hour rollover, forecast-hour conversion, product, and field-set identity.
- Marked recovery issue #155 complete in the architecture progress ledger.

# User Impact
No intentional API or schema changes. Users and operators receive the same HRRR results and fallback behavior, with reduced risk of inconsistent pressure artifact selection across workflows.

# Testing
- `swift test --filter StormSetupHrrrSourceTests` passed: 16 tests.
- `swift test --filter AnvilProfilePreviewProviderTests` passed: 17 tests.
- `swift test --filter HRRRPressureArtifactProbeServiceTests` passed: 10 tests.
- `swift test --filter OperatorDashboardPressureArtifactTests` passed: 9 tests.
- `git diff --check origin/main...HEAD` passed for the committed PR range.

# Notes
- The PR contains the committed seven-file change only.
- Uncommitted edits in `docs/Sql/Device.sql` and `docs/audits/weekly-test-gap-audit.md` were intentionally excluded.