### PR TITLE
Extract pure H3 coverage result

### DIFF
--- a/Sources/App/Jobs/H3CoverageBuilder.swift
+++ b/Sources/App/Jobs/H3CoverageBuilder.swift
@@ -1,0 +1,80 @@
+import Foundation
+import SwiftyH3
+
+enum H3CoverageResult: Sendable, Equatable {
+    case supported(H3Coverage)
+    case unsupportedPoint
+    case coverFailure(errorDescription: String)
+}
+
+struct H3Coverage: Sendable, Equatable {
+    let cells: [Int64]
+    let h3Hash: String
+    let geometryHash: String
+    let resolution: Int16
+}
+
+enum H3CoverageBuilder {
+    private static let resolution: Int16 = 8
+
+    static func build(for geometry: GeoShape) throws -> H3CoverageResult {
+        let coveredCells: [Int64]
+        switch geometry {
+        case .point:
+            return .unsupportedPoint
+        case .polygon(let rings):
+            do {
+                coveredCells = try cells(for: rings)
+            } catch {
+                return .coverFailure(errorDescription: String(reflecting: error))
+            }
+        case .multiPolygon(let polygons):
+            do {
+                var mergedCells: Set<Int64> = []
+                for polygon in polygons {
+                    mergedCells.formUnion(try cells(for: polygon))
+                }
+                coveredCells = Array(mergedCells)
+            } catch {
+                return .coverFailure(errorDescription: String(reflecting: error))
+            }
+        }
+
+        let sortedCells = Array(Set(coveredCells)).sorted()
+        return .supported(
+            H3Coverage(
+                cells: sortedCells,
+                h3Hash: hash(cells: sortedCells),
+                geometryHash: try StableContentHasher.sha256Hex(of: geometry, dateEncodingStrategy: .deferredToDate),
+                resolution: resolution
+            )
+        )
+    }
+
+    private static func cells(for rings: [[GeoShape.GeoCoordinate]]) throws -> [Int64] {
+        guard let boundaryRing = rings.first, !boundaryRing.isEmpty else {
+            throw SwiftyH3Error.invalidInput
+        }
+
+        let boundary: H3Loop = boundaryRing.map { coordinate in
+            H3LatLng(latitudeDegs: coordinate.lat, longitudeDegs: coordinate.lon)
+        }
+        let holes: [H3Loop] = rings.dropFirst().map { holeRing in
+            holeRing.map { coordinate in
+                H3LatLng(latitudeDegs: coordinate.lat, longitudeDegs: coordinate.lon)
+            }
+        }
+        let polygon = H3Polygon(boundary, holes: holes)
+        let h3Resolution = H3Cell.Resolution(rawValue: Int32(resolution)) ?? .res8
+        return try polygon.cells(at: h3Resolution).map { Int64(bitPattern: $0.id) }
+    }
+
+    private static func hash(cells: [Int64]) -> String {
+        var data = Data(capacity: cells.count * MemoryLayout<UInt64>.size)
+        for cell in cells {
+            var bigEndian = UInt64(bitPattern: cell).bigEndian
+            withUnsafeBytes(of: &bigEndian) { data.append(contentsOf: $0) }
+        }
+        return StableContentHasher.sha256Hex(of: data)
+    }
+}

--- a/Sources/App/Jobs/TargetEventRevisionJob.swift
+++ b/Sources/App/Jobs/TargetEventRevisionJob.swift
@@ -1,7 +1,6 @@
 import Fluent
 import Foundation
 import Queues
-import SwiftyH3
 import Vapor
 
 public struct TargetEventRevisionPayload: Codable, Sendable {
@@ -39,7 +38,6 @@ public struct TargetEventRevisionPayload: Codable, Sendable {
 }
 
 public struct TargetEventRevisionJob: AsyncJob {
-    private let h3Resolution: Int16 = 8
     public typealias Payload = TargetEventRevisionPayload
 
     public init() {}
@@ -139,47 +137,45 @@ private extension TargetEventRevisionJob {
         on database: any Database,
         logger: Logger
     ) async throws -> TargetDispatchCompletionResult {
-        let cover: (cells: [Int64], hash: String)?
-        do {
-            cover = try buildH3Cover(for: payload.geometry)
-        } catch {
-            logger.warning(
-                "H3 cover computation failed; falling back to UGC notification dispatch.",
-                metadata: [
-                    "seriesId": .string(payload.seriesId.uuidString),
-                    "revisionUrn": .string(payload.revisionUrn),
-                    "error": .string(String(reflecting: error))
-                ]
-            )
-            return .unsupportedGeometry
-        }
-
-        guard let cover else {
+        let coverage = try H3CoverageBuilder.build(for: payload.geometry)
+        let cover: H3Coverage
+        switch coverage {
+        case .supported(let supportedCoverage):
+            cover = supportedCoverage
+        case .unsupportedPoint:
             logger.debug(
                 "No polygon geometry available; skipping H3 persistence",
                 metadata: ["seriesId": .string(payload.seriesId.uuidString)]
             )
             return .unsupportedGeometry
+        case .coverFailure(let errorDescription):
+            logger.warning(
+                "H3 cover computation failed; falling back to UGC notification dispatch.",
+                metadata: [
+                    "seriesId": .string(payload.seriesId.uuidString),
+                    "revisionUrn": .string(payload.revisionUrn),
+                    "error": .string(errorDescription)
+                ]
+            )
+            return .unsupportedGeometry
         }
-
-        let geometryHash = try hashGeometry(payload.geometry)
 
         logger.info(
             "Computed H3 cover",
             metadata: [
                 "seriesId": .string(payload.seriesId.uuidString),
                 "h3Count": .stringConvertible(cover.cells.count),
-                "h3Hash": .string(cover.hash),
-                "geometryHash": .string(geometryHash)
+                "h3Hash": .string(cover.h3Hash),
+                "geometryHash": .string(cover.geometryHash)
             ]
         )
 
         if let existing = try await ArcusGeolocationModel.query(on: database)
             .filter(\.$series.$id == payload.seriesId)
             .first() {
-            if existing.geometryHash == geometryHash
-                && existing.h3Hash == cover.hash
-                && existing.h3Resolution == h3Resolution
+            if existing.geometryHash == cover.geometryHash
+                && existing.h3Hash == cover.h3Hash
+                && existing.h3Resolution == cover.resolution
                 && existing.h3Cells == cover.cells {
                 logger.debug(
                     "Geolocation unchanged; skipping update.",
@@ -187,10 +183,10 @@ private extension TargetEventRevisionJob {
                 )
             } else {
                 existing.geometry = payload.geometry
-                existing.geometryHash = geometryHash
+                existing.geometryHash = cover.geometryHash
                 existing.h3Cells = cover.cells
-                existing.h3Resolution = h3Resolution
-                existing.h3Hash = cover.hash
+                existing.h3Resolution = cover.resolution
+                existing.h3Hash = cover.h3Hash
                 try await existing.update(on: database)
                 logger.info("Updated geolocation cover", metadata: ["seriesId": .string(payload.seriesId.uuidString)])
             }
@@ -198,10 +194,10 @@ private extension TargetEventRevisionJob {
             let geoRecord = ArcusGeolocationModel(
                 series: payload.seriesId,
                 geometry: payload.geometry,
-                geometryHash: geometryHash,
+                geometryHash: cover.geometryHash,
                 h3Cells: cover.cells,
-                h3Resolution: h3Resolution,
-                h3Hash: cover.hash
+                h3Resolution: cover.resolution,
+                h3Hash: cover.h3Hash
             )
             try await geoRecord.create(on: database)
             logger.info("Created geolocation cover", metadata: ["seriesId": .string(payload.seriesId.uuidString)])
@@ -238,64 +234,6 @@ private extension TargetEventRevisionJob {
         row.lastError = errorMessage
         try await row.update(on: database)
     }
-    
-    // MARK: H3 HASHING
-    private func buildH3Cover(
-        for geometry: GeoShape
-    ) throws -> (cells: [Int64], hash: String)? {
-        switch geometry {
-        case .point:
-            return nil
-        case .polygon(let rings):
-            let cells = try h3Cells(for: rings)
-            let sorted = Array(Set(cells)).sorted()
-            return (sorted, hashCells(sorted))
-        case .multiPolygon(let polygons):
-            var mergedCells: Set<Int64> = []
-            for polygon in polygons {
-                let polygonCells = try h3Cells(for: polygon)
-                mergedCells.formUnion(polygonCells)
-            }
-            let sorted = Array(mergedCells).sorted()
-            return (sorted, hashCells(sorted))
-        }
-    }
-
-    private func h3Cells(
-        for rings: [[GeoShape.GeoCoordinate]]
-    ) throws -> [Int64] {
-        guard let boundaryRing = rings.first, !boundaryRing.isEmpty else {
-            throw SwiftyH3Error.invalidInput
-        }
-        let boundary: H3Loop = boundaryRing.map { coordinate in
-            H3LatLng(latitudeDegs: coordinate.lat, longitudeDegs: coordinate.lon)
-        }
-        
-        let holes: [H3Loop] = rings.dropFirst().map { holeRing in
-            holeRing.map { coordinate in
-                H3LatLng(latitudeDegs: coordinate.lat, longitudeDegs: coordinate.lon)
-            }
-        }
-        
-        let polygon = H3Polygon(boundary, holes: holes)
-        let resolution = H3Cell.Resolution(rawValue: Int32(h3Resolution)) ?? .res8
-        let cells = try polygon.cells(at: resolution)
-        return cells.map { Int64(bitPattern: $0.id) }
-    }
-
-    private func hashCells(_ sortedCells: [Int64]) -> String {
-        var data = Data(capacity: sortedCells.count * MemoryLayout<UInt64>.size)
-        for v in sortedCells {
-            var u = UInt64(bitPattern: v).bigEndian
-            withUnsafeBytes(of: &u) { data.append(contentsOf: $0) }
-        }
-        return StableContentHasher.sha256Hex(of: data)
-    }
-
-    private func hashGeometry(_ geometry: GeoShape) throws -> String {
-        try StableContentHasher.sha256Hex(of: geometry, dateEncodingStrategy: .deferredToDate)
-    }
-
     private func geometryType(_ geometry: GeoShape) -> String {
         switch geometry {
         case .point:

--- a/Tests/AppTests/H3CoverageBuilderTests.swift
+++ b/Tests/AppTests/H3CoverageBuilderTests.swift
@@ -1,0 +1,166 @@
+@testable import App
+import Testing
+
+@Suite("H3 coverage builder")
+struct H3CoverageBuilderTests {
+    @Test("polygon produces the characterized signed cells and hashes")
+    func polygonProducesGoldenCoverage() throws {
+        let coverage = try supportedCoverage(for: representativePolygon())
+
+        #expect(coverage.cells == [
+            613167731774062591,
+            613167731782451199,
+            613167731784548351,
+            613167731843268607
+        ])
+        #expect(coverage.h3Hash == "1c740cb5788cb125cc0053984512bc777f494bf5a04f9385fd26bc2a578e7ba3")
+        #expect(coverage.geometryHash == "fc2b6a9f7674598e3314e36295b9274074bba8a899d10edf22a1452f2ea9bd5f")
+        #expect(coverage.resolution == 8)
+    }
+
+    @Test("multipolygon coverage unions duplicate cells and sorts the result")
+    func multipolygonUnionsDeduplicatesAndSorts() throws {
+        let geometry = GeoShape.multiPolygon(polygons: [
+            representativePolygonRings(),
+            representativePolygonRings(),
+            adjacentPolygonRings()
+        ])
+        let reversedGeometry = GeoShape.multiPolygon(polygons: [
+            adjacentPolygonRings(),
+            representativePolygonRings(),
+            representativePolygonRings()
+        ])
+        let coverage = try supportedCoverage(for: geometry)
+        let reversedCoverage = try supportedCoverage(for: reversedGeometry)
+
+        #expect(coverage.cells == [
+            613167731774062591,
+            613167731782451199,
+            613167731784548351,
+            613167731843268607,
+            613167731857948671,
+            613167731860045823,
+            613167731864240127
+        ])
+        #expect(coverage.h3Hash == "3e28637d48fa3fe021bb17a3acd1f0fbecd7bc7a997832d114ac4bee20154d44")
+        #expect(coverage.cells == coverage.cells.sorted())
+        #expect(Set(coverage.cells).count == coverage.cells.count)
+        #expect(reversedCoverage.cells == coverage.cells)
+        #expect(reversedCoverage.h3Hash == coverage.h3Hash)
+    }
+
+    @Test("polygon holes remove cells from the outer coverage")
+    func polygonHoleChangesCoverage() throws {
+        let outerCoverage = try supportedCoverage(for: .polygon(rings: outerPolygonRings()))
+        let holeCoverage = try supportedCoverage(for: .polygon(rings: holePolygonRings()))
+
+        #expect(holeCoverage.cells == [
+            613167729259577343,
+            613167729263771647,
+            613167729274257407,
+            613167729276354559,
+            613167729278451711,
+            613167729280548863,
+            613167729286840319,
+            613167731667107839,
+            613167731774062591,
+            613167731776159743,
+            613167731778256895,
+            613167731780354047,
+            613167731784548351,
+            613167731786645503,
+            613167731799228415,
+            613167731803422719,
+            613167731841171455,
+            613167731845365759,
+            613167731847462911,
+            613167731849560063,
+            613167731853754367,
+            613167731857948671,
+            613167731860045823,
+            613167731864240127,
+            613167731866337279
+        ])
+        #expect(holeCoverage.h3Hash == "5bad2af57d981c162bf4110ceffea3b471fba0dc901f9ff48e08139159c9f6d9")
+        #expect(holeCoverage.geometryHash == "97125ca8538fcaffd69bffbc3ee8bfe64eb8c30c10c240910c5245c1827960ad")
+        #expect(holeCoverage.cells != outerCoverage.cells)
+    }
+
+    @Test("point geometry is unsupported without attempting coverage")
+    func pointIsUnsupported() throws {
+        let result = try H3CoverageBuilder.build(for: .point(lon: -104.9903, lat: 39.7392))
+
+        #expect(result == .unsupportedPoint)
+    }
+
+    @Test("invalid polygon input preserves cover failure diagnostics")
+    func invalidPolygonIsCoverFailure() throws {
+        let result = try H3CoverageBuilder.build(for: .polygon(rings: []))
+
+        guard case .coverFailure(let errorDescription) = result else {
+            throw H3CoverageBuilderTestError.expectedCoverFailure
+        }
+        #expect(errorDescription == "SwiftyH3.SwiftyH3Error.invalidInput")
+    }
+
+    @Test("repeated builds are identical")
+    func repeatedBuildsAreIdentical() throws {
+        let geometry = representativePolygon()
+
+        #expect(try H3CoverageBuilder.build(for: geometry) == H3CoverageBuilder.build(for: geometry))
+    }
+
+    private func supportedCoverage(for geometry: GeoShape) throws -> H3Coverage {
+        guard case .supported(let coverage) = try H3CoverageBuilder.build(for: geometry) else {
+            throw H3CoverageBuilderTestError.expectedSupportedCoverage
+        }
+        return coverage
+    }
+
+    private func representativePolygon() -> GeoShape {
+        .polygon(rings: representativePolygonRings())
+    }
+
+    private func representativePolygonRings() -> [[GeoShape.GeoCoordinate]] {
+        [[
+            .init(lon: -104.9903, lat: 39.7392),
+            .init(lon: -104.9703, lat: 39.7392),
+            .init(lon: -104.9803, lat: 39.7592),
+            .init(lon: -104.9903, lat: 39.7392)
+        ]]
+    }
+
+    private func adjacentPolygonRings() -> [[GeoShape.GeoCoordinate]] {
+        [[
+            .init(lon: -104.9703, lat: 39.7392),
+            .init(lon: -104.9503, lat: 39.7392),
+            .init(lon: -104.9603, lat: 39.7592),
+            .init(lon: -104.9703, lat: 39.7392)
+        ]]
+    }
+
+    private func outerPolygonRings() -> [[GeoShape.GeoCoordinate]] {
+        [[
+            .init(lon: -105.0003, lat: 39.7292),
+            .init(lon: -104.9503, lat: 39.7292),
+            .init(lon: -104.9503, lat: 39.7792),
+            .init(lon: -105.0003, lat: 39.7792),
+            .init(lon: -105.0003, lat: 39.7292)
+        ]]
+    }
+
+    private func holePolygonRings() -> [[GeoShape.GeoCoordinate]] {
+        outerPolygonRings() + [[
+            .init(lon: -104.9853, lat: 39.7442),
+            .init(lon: -104.9653, lat: 39.7442),
+            .init(lon: -104.9653, lat: 39.7642),
+            .init(lon: -104.9853, lat: 39.7642),
+            .init(lon: -104.9853, lat: 39.7442)
+        ]]
+    }
+}
+
+private enum H3CoverageBuilderTestError: Error {
+    case expectedCoverFailure
+    case expectedSupportedCoverage
+}

--- a/Tests/AppTests/TargetEventRevisionJobFallbackTests.swift
+++ b/Tests/AppTests/TargetEventRevisionJobFallbackTests.swift
@@ -2,7 +2,6 @@
 import Fluent
 import Foundation
 import Queues
-import SwiftyH3
 import Testing
 import Vapor
 
@@ -72,42 +71,10 @@ struct TargetEventRevisionJobFallbackTests {
     }
 
     private func h3Cover(for geometry: GeoShape) throws -> (geometryHash: String, h3Cells: [Int64], h3Hash: String) {
-        let geometryHash = try StableContentHasher.sha256Hex(of: geometry, dateEncodingStrategy: .deferredToDate)
-
-        switch geometry {
-        case .point:
-            throw Abort(.badRequest, reason: "Test fixture requires polygon geometry.")
-        case .polygon(let rings):
-            let cells = try h3Cells(for: rings)
-            let sorted = Array(Set(cells)).sorted()
-            return (geometryHash, sorted, h3Hash(for: sorted))
-        case .multiPolygon:
+        guard case .supported(let coverage) = try H3CoverageBuilder.build(for: geometry) else {
             throw Abort(.badRequest, reason: "Test fixture requires polygon geometry.")
         }
-    }
-
-    private func h3Cells(for rings: [[GeoShape.GeoCoordinate]]) throws -> [Int64] {
-        guard let boundaryRing = rings.first, !boundaryRing.isEmpty else {
-            throw SwiftyH3Error.invalidInput
-        }
-
-        let boundary: H3Loop = boundaryRing.map { coordinate in
-            H3LatLng(latitudeDegs: coordinate.lat, longitudeDegs: coordinate.lon)
-        }
-
-        let polygon = H3Polygon(boundary, holes: [])
-        let resolution = H3Cell.Resolution(rawValue: Int32(8)) ?? .res8
-        let cells = try polygon.cells(at: resolution)
-        return cells.map { Int64(bitPattern: $0.id) }
-    }
-
-    private func h3Hash(for sortedCells: [Int64]) -> String {
-        var data = Data(capacity: sortedCells.count * MemoryLayout<UInt64>.size)
-        for value in sortedCells {
-            var bigEndian = UInt64(bitPattern: value).bigEndian
-            withUnsafeBytes(of: &bigEndian) { data.append(contentsOf: $0) }
-        }
-        return StableContentHasher.sha256Hex(of: data)
+        return (coverage.geometryHash, coverage.cells, coverage.h3Hash)
     }
 
     @Test("unsupported geometry enqueues and drains ugc fallback without draining h3")

--- a/docs/plans/architecture-recovery-progress.md
+++ b/docs/plans/architecture-recovery-progress.md
@@ -94,11 +94,15 @@ This ledger tracks the sequential, behavior-preserving architecture recovery cam
 
 ### Issue #156 - 03: Extract pure H3 coverage result
 
-- **Status:** Pending
+- **Status:** Complete
 - **Roadmap:** Slice 3
 - **Execution profile:** `gpt-5.6-terra`, high reasoning
 - **Dependencies:** None
 - **Stop condition:** Pure result extracted at the same transaction point.
+- **Files changed:** `Sources/App/Jobs/H3CoverageBuilder.swift`, `Sources/App/Jobs/TargetEventRevisionJob.swift`, `Tests/AppTests/H3CoverageBuilderTests.swift`, and `Tests/AppTests/TargetEventRevisionJobFallbackTests.swift`.
+- **Behavior:** `H3CoverageBuilder` now owns deterministic polygon/multipolygon cover construction, signed-cell ordering, H3 hashing, and geometry hashing. `TargetEventRevisionJob` retains the same in-transaction invocation, point and cover-failure fallback logs, persistence, outbox insertion, completion, and drain ordering.
+- **Validation:** `swift test --filter TargetEventRevisionJobFallbackTests` passed (3 tests); `swift test --filter H3` passed (18 tests); `swift build` passed. Scoped whitespace checks passed; unscoped `git diff --check` remains blocked only by pre-existing trailing whitespace in `docs/Sql/Device.sql:48`.
+- **Residual risk / handoff:** Geometry-hash errors still propagate as failed jobs, while H3 cover errors retain UGC fallback. Slice #157 may move this now-characterized builder invocation before the transaction; do not alter persistence or fallback behavior.
 
 ### Issue #157 - 04: Move H3 work before transaction
 


### PR DESCRIPTION
# Summary
Extracts deterministic H3 coverage construction from `TargetEventRevisionJob` into a pure, independently testable builder while preserving the existing transaction boundary, persistence behavior, notification outbox flow, and UGC fallback semantics.

# What Changed
- Added `H3CoverageBuilder` and `H3CoverageResult` to own polygon and multipolygon coverage, deduplication, sorting, H3 hashing, and geometry hashing.
- Simplified `TargetEventRevisionJob` to consume the shared coverage result without changing dispatch ordering or fallback handling.
- Added focused H3 coverage tests for golden coverage, multipolygon union, holes, unsupported points, invalid input, and repeatability.
- Updated fallback tests to use the extracted builder and marked recovery issue #156 complete.

# User Impact
No intentional API, schema, or user-facing behavior changes. Existing H3 targeting and UGC fallback behavior are preserved with a smaller, more testable coverage boundary.

# Testing
- `swift test --filter TargetEventRevisionJobFallbackTests` passed: 3 tests.
- `swift test --filter H3` passed: 18 tests across 9 suites.
- `swift build` passed.
- `git diff --check origin/main...HEAD` passed for the committed PR range.

# Notes
- The PR contains the committed five-file change only.
- Uncommitted edits in `docs/Sql/Device.sql` and `docs/audits/weekly-test-gap-audit.md` were intentionally excluded.