### PR TITLE
Move H3 computation before the transaction

### DIFF
--- a/Sources/App/Jobs/TargetEventRevisionJob.swift
+++ b/Sources/App/Jobs/TargetEventRevisionJob.swift
@@ -40,7 +40,15 @@ public struct TargetEventRevisionPayload: Codable, Sendable {
 public struct TargetEventRevisionJob: AsyncJob {
     public typealias Payload = TargetEventRevisionPayload
 
-    public init() {}
+    private let buildCoverage: @Sendable (GeoShape) throws -> H3CoverageResult
+
+    public init() {
+        self.buildCoverage = { try H3CoverageBuilder.build(for: $0) }
+    }
+
+    init(buildCoverage: @escaping @Sendable (GeoShape) throws -> H3CoverageResult) {
+        self.buildCoverage = buildCoverage
+    }
 
     public func dequeue(_ context: QueueContext, _ payload: Payload) async throws {
         context.logger.info(
@@ -53,8 +61,43 @@ public struct TargetEventRevisionJob: AsyncJob {
         )
 
         do {
-            let result = try await context.application.db.transaction { database in
-                try await persistGeolocation(payload, on: database, logger: context.logger)
+            let coverage = try buildCoverage(payload.geometry)
+            let result: TargetDispatchCompletionResult
+            switch coverage {
+            case .supported(let supportedCoverage):
+                context.logger.info(
+                    "Computed H3 cover",
+                    metadata: [
+                        "seriesId": .string(payload.seriesId.uuidString),
+                        "h3Count": .stringConvertible(supportedCoverage.cells.count),
+                        "h3Hash": .string(supportedCoverage.h3Hash),
+                        "geometryHash": .string(supportedCoverage.geometryHash)
+                    ]
+                )
+                result = try await context.application.db.transaction { database in
+                    try await persistGeolocation(
+                        payload,
+                        coverage: supportedCoverage,
+                        on: database,
+                        logger: context.logger
+                    )
+                }
+            case .unsupportedPoint:
+                context.logger.debug(
+                    "No polygon geometry available; skipping H3 persistence",
+                    metadata: ["seriesId": .string(payload.seriesId.uuidString)]
+                )
+                result = .unsupportedGeometry
+            case .coverFailure(let errorDescription):
+                context.logger.warning(
+                    "H3 cover computation failed; falling back to UGC notification dispatch.",
+                    metadata: [
+                        "seriesId": .string(payload.seriesId.uuidString),
+                        "revisionUrn": .string(payload.revisionUrn),
+                        "error": .string(errorDescription)
+                    ]
+                )
+                result = .unsupportedGeometry
             }
 
             try await markDispatchResult(
@@ -134,59 +177,27 @@ private extension TargetEventRevisionJob {
 
     func persistGeolocation(
         _ payload: TargetEventRevisionPayload,
+        coverage: H3Coverage,
         on database: any Database,
         logger: Logger
     ) async throws -> TargetDispatchCompletionResult {
-        let coverage = try H3CoverageBuilder.build(for: payload.geometry)
-        let cover: H3Coverage
-        switch coverage {
-        case .supported(let supportedCoverage):
-            cover = supportedCoverage
-        case .unsupportedPoint:
-            logger.debug(
-                "No polygon geometry available; skipping H3 persistence",
-                metadata: ["seriesId": .string(payload.seriesId.uuidString)]
-            )
-            return .unsupportedGeometry
-        case .coverFailure(let errorDescription):
-            logger.warning(
-                "H3 cover computation failed; falling back to UGC notification dispatch.",
-                metadata: [
-                    "seriesId": .string(payload.seriesId.uuidString),
-                    "revisionUrn": .string(payload.revisionUrn),
-                    "error": .string(errorDescription)
-                ]
-            )
-            return .unsupportedGeometry
-        }
-
-        logger.info(
-            "Computed H3 cover",
-            metadata: [
-                "seriesId": .string(payload.seriesId.uuidString),
-                "h3Count": .stringConvertible(cover.cells.count),
-                "h3Hash": .string(cover.h3Hash),
-                "geometryHash": .string(cover.geometryHash)
-            ]
-        )
-
         if let existing = try await ArcusGeolocationModel.query(on: database)
             .filter(\.$series.$id == payload.seriesId)
             .first() {
-            if existing.geometryHash == cover.geometryHash
-                && existing.h3Hash == cover.h3Hash
-                && existing.h3Resolution == cover.resolution
-                && existing.h3Cells == cover.cells {
+            if existing.geometryHash == coverage.geometryHash
+                && existing.h3Hash == coverage.h3Hash
+                && existing.h3Resolution == coverage.resolution
+                && existing.h3Cells == coverage.cells {
                 logger.debug(
                     "Geolocation unchanged; skipping update.",
                     metadata: ["seriesId": .string(payload.seriesId.uuidString)]
                 )
             } else {
                 existing.geometry = payload.geometry
-                existing.geometryHash = cover.geometryHash
-                existing.h3Cells = cover.cells
-                existing.h3Resolution = cover.resolution
-                existing.h3Hash = cover.h3Hash
+                existing.geometryHash = coverage.geometryHash
+                existing.h3Cells = coverage.cells
+                existing.h3Resolution = coverage.resolution
+                existing.h3Hash = coverage.h3Hash
                 try await existing.update(on: database)
                 logger.info("Updated geolocation cover", metadata: ["seriesId": .string(payload.seriesId.uuidString)])
             }
@@ -194,10 +205,10 @@ private extension TargetEventRevisionJob {
             let geoRecord = ArcusGeolocationModel(
                 series: payload.seriesId,
                 geometry: payload.geometry,
-                geometryHash: cover.geometryHash,
-                h3Cells: cover.cells,
-                h3Resolution: cover.resolution,
-                h3Hash: cover.h3Hash
+                geometryHash: coverage.geometryHash,
+                h3Cells: coverage.cells,
+                h3Resolution: coverage.resolution,
+                h3Hash: coverage.h3Hash
             )
             try await geoRecord.create(on: database)
             logger.info("Created geolocation cover", metadata: ["seriesId": .string(payload.seriesId.uuidString)])

--- a/Tests/AppTests/TargetEventRevisionJobFallbackTests.swift
+++ b/Tests/AppTests/TargetEventRevisionJobFallbackTests.swift
@@ -133,6 +133,98 @@ struct TargetEventRevisionJobFallbackTests {
         }
     }
 
+    @Test("precomputed supported coverage is persisted unchanged")
+    func precomputedSupportedCoverageIsPersistedUnchanged() async throws {
+        try await withWorkerApp { app in
+            let now = Date()
+            let seriesID = UUID()
+            let revisionUrn = "urn:oid:test-precomputed-coverage-\(UUID().uuidString.lowercased())"
+            let geometry = makePolygonGeometry()
+            let coverage = H3Coverage(
+                cells: [617_700_169_958_293_503, -617_700_170_495_164_415],
+                h3Hash: "injected-h3-hash",
+                geometryHash: "injected-geometry-hash",
+                resolution: 7
+            )
+            let payload = TargetEventRevisionPayload(
+                seriesId: seriesID,
+                revisionUrn: revisionUrn,
+                geometry: geometry,
+                reason: .new
+            )
+
+            try await makeSeries(id: seriesID, revisionUrn: revisionUrn, now: now).create(on: app.db)
+            try await ArcusTargetDispatchOutboxModel(
+                revisionUrn: revisionUrn,
+                seriesId: seriesID,
+                payload: payload
+            ).create(on: app.db)
+
+            let job = TargetEventRevisionJob(buildCoverage: { _ in .supported(coverage) })
+            try await job.dequeue(makeQueueContext(app: app), payload)
+
+            let geolocation = try await ArcusGeolocationModel.query(on: app.db)
+                .filter(\.$series.$id == seriesID)
+                .first()
+            #expect(geolocation?.h3Cells == coverage.cells)
+            #expect(geolocation?.h3Resolution == coverage.resolution)
+            #expect(geolocation?.geometryHash == coverage.geometryHash)
+            #expect(geolocation?.h3Hash == coverage.h3Hash)
+        }
+    }
+
+    @Test("precomputed cover failure uses ugc without h3 persistence")
+    func precomputedCoverFailureUsesUGCWithoutH3Persistence() async throws {
+        try await withWorkerApp { app in
+            let now = Date()
+            let seriesID = UUID()
+            let revisionUrn = "urn:oid:test-cover-failure-\(UUID().uuidString.lowercased())"
+            let payload = TargetEventRevisionPayload(
+                seriesId: seriesID,
+                revisionUrn: revisionUrn,
+                geometry: makePolygonGeometry(),
+                reason: .new
+            )
+
+            try await makeSeries(id: seriesID, revisionUrn: revisionUrn, now: now).create(on: app.db)
+            try await ArcusTargetDispatchOutboxModel(
+                revisionUrn: revisionUrn,
+                seriesId: seriesID,
+                payload: payload
+            ).create(on: app.db)
+
+            let job = TargetEventRevisionJob(
+                buildCoverage: { _ in .coverFailure(errorDescription: "injected cover failure") }
+            )
+            try await job.dequeue(makeQueueContext(app: app), payload)
+
+            let targetDispatchRow = try await ArcusTargetDispatchOutboxModel.query(on: app.db)
+                .filter(\.$revisionUrn, .equal, revisionUrn)
+                .first()
+            #expect(targetDispatchRow?.result == "unsupported_geometry")
+            #expect(targetDispatchRow?.completed != nil)
+
+            let geolocation = try await ArcusGeolocationModel.query(on: app.db)
+                .filter(\.$series.$id == seriesID)
+                .first()
+            #expect(geolocation == nil)
+
+            let ugcRows = try await ArcusNotificationOutboxModel.query(on: app.db)
+                .filter(\.$revisionUrn, .equal, revisionUrn)
+                .filter(\.$mode, .equal, NotificationTargetMode.ugc.rawValue)
+                .all()
+            #expect(ugcRows.count == 1)
+            #expect(ugcRows.first?.state == "done")
+            #expect(ugcRows.first?.attempts == 1)
+
+            let h3Rows = try await ArcusNotificationOutboxModel.query(on: app.db)
+                .filter(\.$revisionUrn, .equal, revisionUrn)
+                .filter(\.$mode, .equal, NotificationTargetMode.h3.rawValue)
+                .all()
+            #expect(h3Rows.isEmpty)
+        }
+    }
+
     @Test("unchanged polygon geometry still enqueues h3 notification dispatch")
     func unchangedPolygonGeometryStillQueuesH3Notification() async throws {
         try await withWorkerApp { app in

--- a/docs/plans/architecture-recovery-progress.md
+++ b/docs/plans/architecture-recovery-progress.md
@@ -34,7 +34,7 @@ This ledger tracks the sequential, behavior-preserving architecture recovery cam
 | 01 | [#154](https://github.com/justinrooks/arcus-signal/issues/154) | 1 | Characterize notification dequeue lifecycle | None | `gpt-5.6-terra`, medium | Pending |
 | 02 | [#155](https://github.com/justinrooks/arcus-signal/issues/155) | 2 | Centralize HRRR surface-to-pressure identity | None | `gpt-5.6-terra`, high | Complete |
 | 03 | [#156](https://github.com/justinrooks/arcus-signal/issues/156) | 3 | Extract pure H3 coverage result | None | `gpt-5.6-terra`, high | Pending |
-| 04 | [#157](https://github.com/justinrooks/arcus-signal/issues/157) | 4 | Move H3 work before transaction | 03 | `gpt-5.6-sol`, high | Pending |
+| 04 | [#157](https://github.com/justinrooks/arcus-signal/issues/157) | 4 | Move H3 work before transaction | 03 | `gpt-5.6-sol`, high | Complete |
 | 05 | [#158](https://github.com/justinrooks/arcus-signal/issues/158) | 5 | Isolate notification candidate selection | 01 | `gpt-5.6-sol`, high | Pending |
 | 06 | [#159](https://github.com/justinrooks/arcus-signal/issues/159) | 6 | Isolate notification ledger persistence | 01, 05 | `gpt-5.6-sol`, high + senior review | Pending |
 | 07 | [#160](https://github.com/justinrooks/arcus-signal/issues/160) | 7 | Characterize NWS persistence flow | None | `gpt-5.6-sol`, high | Pending |
@@ -106,11 +106,15 @@ This ledger tracks the sequential, behavior-preserving architecture recovery cam
 
 ### Issue #157 - 04: Move H3 work before transaction
 
-- **Status:** Pending
+- **Status:** Complete
 - **Roadmap:** Slice 4
 - **Execution profile:** `gpt-5.6-sol`, high reasoning
 - **Dependencies:** 03
 - **Stop condition:** Transaction contains persistence only; output unchanged.
+- **Files changed:** `Sources/App/Jobs/TargetEventRevisionJob.swift`, `Tests/AppTests/TargetEventRevisionJobFallbackTests.swift`, and `docs/plans/architecture-recovery-progress.md`.
+- **Behavior:** H3 coverage and hashing now execute once before transaction creation. Supported coverage enters the unchanged geolocation/outbox transaction; unsupported-point and cover-failure results bypass it and retain the existing completion and UGC drain flow.
+- **Validation:** `swift test --filter TargetEventRevisionJobFallbackTests` passed (5 tests); `swift test --filter H3` passed (19 tests); `swift test --no-parallel` passed (437 tests). The scoped whitespace check passed; unscoped `git diff --check` remains blocked only by pre-existing trailing whitespace in `docs/Sql/Device.sql:48`.
+- **Residual risk / handoff:** No known behavior change beyond transaction placement. The internal `@Sendable` builder seam proves supported coverage reaches persistence without recomputation or normalization and cover failure creates no H3 persistence effects.
 
 ### Issue #158 - 05: Isolate notification candidate selection
 


### PR DESCRIPTION
# Summary
Moves H3 coverage construction and hashing out of the database transaction while preserving geolocation persistence, notification outbox insertion, completion tracking, and UGC fallback behavior.

# What Changed
- Computes H3 coverage once before opening the transaction.
- Passes supported precomputed coverage into the persistence transaction without recomputation or normalization.
- Bypasses the transaction for unsupported points and cover failures while retaining existing UGC fallback and dispatch completion flow.
- Adds injection-based tests for precomputed coverage persistence and cover-failure behavior.
- Marks recovery issue #157 complete in the architecture progress ledger.

# User Impact
No intentional API, schema, or notification behavior changes. The change reduces transaction-held computation time while preserving existing targeting and fallback outcomes.

# Testing
- `swift test --no-parallel` passed: 437 tests in 57 suites.
- `git diff --check origin/main...HEAD` passed for the committed PR range.

# Notes
- The PR contains the committed three-file change only.
- Uncommitted edits in `docs/Sql/Device.sql` and `docs/audits/weekly-test-gap-audit.md` were intentionally excluded.