### PR TITLE
Isolate notification candidate selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+# codex
+.codex/*

--- a/Sources/App/Jobs/NotificationSendJob.swift
+++ b/Sources/App/Jobs/NotificationSendJob.swift
@@ -5,28 +5,13 @@
 //  Created by Justin Rooks on 3/3/26.
 //
 
+import ArcusCore
 import APNSCore
 import Fluent
 import FluentSQL
 import Foundation
 import Queues
 import Vapor
-import ArcusCore
-
-struct NotificationCandidate: Decodable {
-    let id: UUID
-    let apnsToken: String
-    let apnsEnvironment: String
-    let locationAuthRaw: String
-    let capturedAt: Date
-    let receivedAt: Date
-    let countyLabel: String?
-    let fireZoneLabel: String?
-
-    var locationAuth: LocationAuth {
-        LocationAuth(rawValue: locationAuthRaw) ?? .unknown
-    }
-}
 
 struct LedgerClaimResult {
     let inserted: Bool
@@ -85,24 +70,28 @@ public struct NotificationSendJob: AsyncJob {
     private let engine: NotificationEngine
     private let freshnessPolicy: LocationFreshnessPolicy
     private let missedDecisionStore: NotificationMissedDecisionStore
+    private let candidateStore: NotificationCandidateStore
 
     public init() {
         self.sender = APNsClient()
         self.engine = NotificationEngine()
         self.freshnessPolicy = LocationFreshnessPolicy()
         self.missedDecisionStore = NotificationMissedDecisionStore()
+        self.candidateStore = NotificationCandidateStore()
     }
 
     init(
         sender: any NotificationSender,
         engine: NotificationEngine = NotificationEngine(),
         freshnessPolicy: LocationFreshnessPolicy = LocationFreshnessPolicy(),
-        missedDecisionStore: NotificationMissedDecisionStore = NotificationMissedDecisionStore()
+        missedDecisionStore: NotificationMissedDecisionStore = NotificationMissedDecisionStore(),
+        candidateStore: NotificationCandidateStore = NotificationCandidateStore()
     ) {
         self.sender = sender
         self.engine = engine
         self.freshnessPolicy = freshnessPolicy
         self.missedDecisionStore = missedDecisionStore
+        self.candidateStore = candidateStore
     }
 
     func deliveryDisposition(
@@ -256,7 +245,7 @@ public struct NotificationSendJob: AsyncJob {
             }
             
             // Get our list of candidates
-            let h3Candidates = try await loadH3Candidates(
+            let h3Candidates = try await candidateStore.loadH3Candidates(
                 cells: geo.h3Cells,
                 capturedAtOrAfter: presenceCutoff,
                 on: context.application.db
@@ -276,7 +265,7 @@ public struct NotificationSendJob: AsyncJob {
             )
         } else {
             // we only have 2 modes right now, so its ugc
-            let ugcCandidates = try await loadUGCCandidates(
+            let ugcCandidates = try await candidateStore.loadUGCCandidates(
                 ugcCodes: series.ugcCodes,
                 capturedAtOrAfter: presenceCutoff,
                 on: context.application.db
@@ -318,73 +307,6 @@ public struct NotificationSendJob: AsyncJob {
 
 
 extension NotificationSendJob {
-    func loadUGCCandidates(
-        ugcCodes: [String],
-        capturedAtOrAfter cutoff: Date,
-        on db: any Database
-    ) async throws -> [NotificationCandidate] {
-        guard let sql = db as? any SQLDatabase else {
-            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
-        }
-
-        return try await sql.raw("""
-            SELECT
-                i.installation_id AS "id",
-                i.apns_device_token AS "apnsToken",
-                i.apns_environment AS "apnsEnvironment",
-                i.location_auth AS "locationAuthRaw",
-                p.captured_at AS "capturedAt",
-                p.received_at AS "receivedAt",
-                p.county_label as countyLabel,
-                p.fire_zone_label as fireZoneLabel
-            FROM device_installations i
-            JOIN device_presence p on i.installation_id = p.installation_id
-            WHERE i.is_active = TRUE
-              AND i.is_subscribed = TRUE
-              AND i.apns_device_token <> ''
-              AND p.captured_at >= \(bind: cutoff)
-              AND (
-                  p.county  = ANY(\(bind: ugcCodes)::text[])
-                OR p.zone  = ANY(\(bind: ugcCodes)::text[])
-                OR p.fire_zone = ANY(\(bind: ugcCodes)::text[])
-              )
-            """)
-            .all(decoding: NotificationCandidate.self)
-    }
-    
-    func loadH3Candidates(
-        cells: [Int64],
-        capturedAtOrAfter cutoff: Date,
-        on db: any Database
-    ) async throws -> [NotificationCandidate] {
-        guard let sql = db as? any SQLDatabase else {
-            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
-        }
-        guard cells.count > 0 else { return [] }
-
-        return try await sql.raw("""
-            SELECT
-                i.installation_id AS "id",
-                i.apns_device_token AS "apnsToken",
-                i.apns_environment AS "apnsEnvironment",
-                i.location_auth AS "locationAuthRaw",
-                p.captured_at AS "capturedAt",
-                p.received_at AS "receivedAt",
-                p.county_label as countyLabel,
-                p.fire_zone_label as fireZoneLabel
-            FROM device_installations i
-            JOIN device_presence p
-              ON i.installation_id = p.installation_id
-            WHERE i.is_active = TRUE
-              AND i.is_subscribed = TRUE
-              AND i.apns_device_token <> ''
-              AND p.h3_cell IS NOT NULL
-              AND p.h3_cell = ANY(\(bind: cells)::bigint[])
-              AND p.captured_at >= \(bind: cutoff)
-            """)
-            .all(decoding: NotificationCandidate.self)
-    }
-    
     func claimNotificationLedger(
         installationID: UUID,
         seriesID: UUID,

--- a/Sources/App/Models/Notification/NotificationCandidateStore.swift
+++ b/Sources/App/Models/Notification/NotificationCandidateStore.swift
@@ -1,0 +1,89 @@
+import ArcusCore
+import Fluent
+import FluentSQL
+import Foundation
+import Vapor
+
+struct NotificationCandidate: Decodable {
+    let id: UUID
+    let apnsToken: String
+    let apnsEnvironment: String
+    let locationAuthRaw: String
+    let capturedAt: Date
+    let receivedAt: Date
+    let countyLabel: String?
+    let fireZoneLabel: String?
+
+    var locationAuth: LocationAuth {
+        LocationAuth(rawValue: locationAuthRaw) ?? .unknown
+    }
+}
+
+struct NotificationCandidateStore {
+    func loadUGCCandidates(
+        ugcCodes: [String],
+        capturedAtOrAfter cutoff: Date,
+        on db: any Database
+    ) async throws -> [NotificationCandidate] {
+        guard let sql = db as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        return try await sql.raw("""
+            SELECT
+                i.installation_id AS "id",
+                i.apns_device_token AS "apnsToken",
+                i.apns_environment AS "apnsEnvironment",
+                i.location_auth AS "locationAuthRaw",
+                p.captured_at AS "capturedAt",
+                p.received_at AS "receivedAt",
+                p.county_label AS "countyLabel",
+                p.fire_zone_label AS "fireZoneLabel"
+            FROM device_installations i
+            JOIN device_presence p on i.installation_id = p.installation_id
+            WHERE i.is_active = TRUE
+              AND i.is_subscribed = TRUE
+              AND i.apns_device_token <> ''
+              AND p.captured_at >= \(bind: cutoff)
+              AND (
+                  p.county  = ANY(\(bind: ugcCodes)::text[])
+                OR p.zone  = ANY(\(bind: ugcCodes)::text[])
+                OR p.fire_zone = ANY(\(bind: ugcCodes)::text[])
+              )
+            """)
+            .all(decoding: NotificationCandidate.self)
+    }
+
+    func loadH3Candidates(
+        cells: [Int64],
+        capturedAtOrAfter cutoff: Date,
+        on db: any Database
+    ) async throws -> [NotificationCandidate] {
+        guard let sql = db as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+        guard cells.count > 0 else { return [] }
+
+        return try await sql.raw("""
+            SELECT
+                i.installation_id AS "id",
+                i.apns_device_token AS "apnsToken",
+                i.apns_environment AS "apnsEnvironment",
+                i.location_auth AS "locationAuthRaw",
+                p.captured_at AS "capturedAt",
+                p.received_at AS "receivedAt",
+                p.county_label AS "countyLabel",
+                p.fire_zone_label AS "fireZoneLabel"
+            FROM device_installations i
+            JOIN device_presence p
+              ON i.installation_id = p.installation_id
+            WHERE i.is_active = TRUE
+              AND i.is_subscribed = TRUE
+              AND i.apns_device_token <> ''
+              AND p.h3_cell IS NOT NULL
+              AND p.h3_cell = ANY(\(bind: cells)::bigint[])
+              AND p.captured_at >= \(bind: cutoff)
+            """)
+            .all(decoding: NotificationCandidate.self)
+    }
+}

--- a/Tests/AppTests/NotificationSendJobCandidateQueryTests.swift
+++ b/Tests/AppTests/NotificationSendJobCandidateQueryTests.swift
@@ -6,7 +6,7 @@ import Foundation
 import Testing
 import Vapor
 
-@Suite("Notification send job candidate queries", .serialized)
+@Suite("Notification candidate store queries", .serialized)
 struct NotificationSendJobCandidateQueryTests {
     private enum Rollback: Error {
         case afterAssertions
@@ -91,6 +91,8 @@ struct NotificationSendJobCandidateQueryTests {
         capturedAt: Date,
         h3Cell: Int64?,
         county: String?,
+        zone: String? = nil,
+        fireZone: String? = nil,
         isActive: Bool = true,
         isSubscribed: Bool = true,
         token: String = "token",
@@ -115,9 +117,10 @@ struct NotificationSendJobCandidateQueryTests {
                  cell_scheme, h3_cell, h3_resolution, county, zone, fire_zone, source, created_at, updated_at,
                  county_label, fire_zone_label)
             VALUES
-                (\(bind: id), \(bind: capturedAt), \(bind: capturedAt), 0, 0,
+                (\(bind: id), \(bind: capturedAt), \(bind: capturedAt.addingTimeInterval(30)), 0, 0,
                  \(bind: h3Cell == nil ? "ugc-only" : "h3"), \(bind: h3Cell), \(bind: h3Cell == nil ? nil : 8),
-                 \(bind: county), NULL, NULL, 'foreground', \(bind: now), \(bind: now), \(bind: county), NULL);
+                 \(bind: county), \(bind: zone), \(bind: fireZone), 'foreground', \(bind: now), \(bind: now),
+                 \(bind: county), 'Test Fire Zone');
             """).run()
     }
 
@@ -125,7 +128,7 @@ struct NotificationSendJobCandidateQueryTests {
         h3Cell: Int64?,
         county: String?,
         on db: any Database
-    ) async throws -> (included: Set<UUID>, excluded: Set<UUID>) {
+    ) async throws -> (atCutoff: UUID, included: Set<UUID>, excluded: Set<UUID>) {
         let cutoff = now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold)
         let newer = UUID()
         let exactlyAtCutoff = UUID()
@@ -141,7 +144,24 @@ struct NotificationSendJobCandidateQueryTests {
         try await seedCandidate(id: unsubscribed, capturedAt: now, h3Cell: h3Cell, county: county, isSubscribed: false, on: db)
         try await seedCandidate(id: tokenless, capturedAt: now, h3Cell: h3Cell, county: county, token: "", on: db)
 
-        return ([newer, exactlyAtCutoff], [older, inactive, unsubscribed, tokenless])
+        return (exactlyAtCutoff, [newer, exactlyAtCutoff], [older, inactive, unsubscribed, tokenless])
+    }
+
+    private func assertDecodedFields(
+        for candidate: NotificationCandidate,
+        id: UUID,
+        capturedAt: Date,
+        countyLabel: String?
+    ) {
+        #expect(candidate.id == id)
+        #expect(candidate.apnsToken == "token")
+        #expect(candidate.apnsEnvironment == "sandbox")
+        #expect(candidate.locationAuthRaw == "always")
+        #expect(candidate.locationAuth == .always)
+        #expect(candidate.capturedAt == capturedAt)
+        #expect(candidate.receivedAt == capturedAt.addingTimeInterval(30))
+        #expect(candidate.countyLabel == countyLabel)
+        #expect(candidate.fireZoneLabel == "Test Fire Zone")
     }
 
     @Test("H3 candidates include fresh and cutoff presence while preserving installation exclusions")
@@ -154,7 +174,7 @@ struct NotificationSendJobCandidateQueryTests {
             let expected = try await seedCandidates(h3Cell: h3Cell, county: nil, on: database)
             let cutoff = now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold)
 
-            let candidates = try await NotificationSendJob().loadH3Candidates(
+            let candidates = try await NotificationCandidateStore().loadH3Candidates(
                 cells: [h3Cell],
                 capturedAtOrAfter: cutoff,
                 on: database
@@ -163,6 +183,21 @@ struct NotificationSendJobCandidateQueryTests {
 
             #expect(actual == expected.included)
             #expect(actual.isDisjoint(with: expected.excluded))
+            let cutoffCandidate = try #require(candidates.first { $0.id == expected.atCutoff })
+            assertDecodedFields(for: cutoffCandidate, id: expected.atCutoff, capturedAt: cutoff, countyLabel: nil)
+        }
+    }
+
+    @Test("H3 candidates return empty for empty cells")
+    func h3CandidatesReturnEmptyForEmptyCells() async throws {
+        try await withApp { database in
+            let candidates = try await NotificationCandidateStore().loadH3Candidates(
+                cells: [],
+                capturedAtOrAfter: now,
+                on: database
+            )
+
+            #expect(candidates.isEmpty)
         }
     }
 
@@ -172,16 +207,36 @@ struct NotificationSendJobCandidateQueryTests {
             let county = "test-\(UUID().uuidString)"
             let expected = try await seedCandidates(h3Cell: nil, county: county, on: database)
             let cutoff = now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold)
+            let zoneOnly = UUID()
+            let fireZoneOnly = UUID()
+            try await seedCandidate(
+                id: zoneOnly,
+                capturedAt: cutoff,
+                h3Cell: nil,
+                county: nil,
+                zone: county,
+                on: database
+            )
+            try await seedCandidate(
+                id: fireZoneOnly,
+                capturedAt: cutoff,
+                h3Cell: nil,
+                county: nil,
+                fireZone: county,
+                on: database
+            )
 
-            let candidates = try await NotificationSendJob().loadUGCCandidates(
+            let candidates = try await NotificationCandidateStore().loadUGCCandidates(
                 ugcCodes: [county],
                 capturedAtOrAfter: cutoff,
                 on: database
             )
             let actual = Set(candidates.map(\.id))
 
-            #expect(actual == expected.included)
+            #expect(actual == expected.included.union([zoneOnly, fireZoneOnly]))
             #expect(actual.isDisjoint(with: expected.excluded))
+            let cutoffCandidate = try #require(candidates.first { $0.id == expected.atCutoff })
+            assertDecodedFields(for: cutoffCandidate, id: expected.atCutoff, capturedAt: cutoff, countyLabel: county)
         }
     }
 }

--- a/docs/plans/architecture-recovery-progress.md
+++ b/docs/plans/architecture-recovery-progress.md
@@ -35,7 +35,7 @@ This ledger tracks the sequential, behavior-preserving architecture recovery cam
 | 02 | [#155](https://github.com/justinrooks/arcus-signal/issues/155) | 2 | Centralize HRRR surface-to-pressure identity | None | `gpt-5.6-terra`, high | Complete |
 | 03 | [#156](https://github.com/justinrooks/arcus-signal/issues/156) | 3 | Extract pure H3 coverage result | None | `gpt-5.6-terra`, high | Pending |
 | 04 | [#157](https://github.com/justinrooks/arcus-signal/issues/157) | 4 | Move H3 work before transaction | 03 | `gpt-5.6-sol`, high | Complete |
-| 05 | [#158](https://github.com/justinrooks/arcus-signal/issues/158) | 5 | Isolate notification candidate selection | 01 | `gpt-5.6-sol`, high | Pending |
+| 05 | [#158](https://github.com/justinrooks/arcus-signal/issues/158) | 5 | Isolate notification candidate selection | 01 | `gpt-5.6-sol`, high | Complete |
 | 06 | [#159](https://github.com/justinrooks/arcus-signal/issues/159) | 6 | Isolate notification ledger persistence | 01, 05 | `gpt-5.6-sol`, high + senior review | Pending |
 | 07 | [#160](https://github.com/justinrooks/arcus-signal/issues/160) | 7 | Characterize NWS persistence flow | None | `gpt-5.6-sol`, high | Pending |
 | 08 | [#161](https://github.com/justinrooks/arcus-signal/issues/161) | 8 | Extract NWS transaction script | 07 | `gpt-5.6-sol`, high + senior review | Pending |
@@ -118,11 +118,15 @@ This ledger tracks the sequential, behavior-preserving architecture recovery cam
 
 ### Issue #158 - 05: Isolate notification candidate selection
 
-- **Status:** Pending
+- **Status:** Complete
 - **Roadmap:** Slice 5
 - **Execution profile:** `gpt-5.6-sol`, high reasoning
 - **Dependencies:** 01
 - **Stop condition:** Candidate SQL has one owner; send orchestration unchanged.
+- **Files changed:** `Sources/App/Models/Notification/NotificationCandidateStore.swift`, `Sources/App/Jobs/NotificationSendJob.swift`, `Tests/AppTests/NotificationSendJobCandidateQueryTests.swift`, and `docs/plans/architecture-recovery-progress.md`.
+- **Behavior:** `NotificationCandidateStore` now solely owns the H3/UGC candidate row and queries. `NotificationSendJob` retains lifecycle and target-mode orchestration through a trailing defaulted store dependency. Candidate selection, cutoff, exclusions, matching, and sequential delivery are unchanged; quoted label aliases repair previously silent `nil` decoding without changing current notification copy.
+- **Validation:** `swift test --filter NotificationSendJobCandidateQueryTests` passed (3 tests); `swift test --filter NotificationSendJobDeliveryBoundaryTests` passed (4 tests); `swift test --filter LocationFreshnessPolicyTests` passed (13 tests). The scoped whitespace check passed; unscoped `git diff --check` remains blocked only by pre-existing trailing whitespace in `docs/Sql/Device.sql:48`.
+- **Residual risk / handoff:** County and fire-zone labels now decode from populated presence rows, but `NotificationEngine` currently uses generic area wording and ignores them. Issue #159 retains ownership of all ledger claim/completion extraction; no ledger, delivery, retry, queue, schema, or contract behavior moved here.
 
 ### Issue #159 - 06: Isolate notification ledger persistence
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -10,3 +10,4 @@
 - For Docker cache storage, keep the host bind-source path separate from the container runtime path. Verify the resolved environment and mount first; prefer matching ownership and `0770` over using `0777` to mask a path that was never mounted.
 - For the production Storm Setup contract, preserve `AnvilAnalyzeProfileResponse` only; keep Anvil request/profile-preview debug envelopes on the dev diagnostics endpoint unless a story explicitly promotes them.
 - When reading an audit, treat its implementation-status annotations as historical evidence, not proof that adjacent current-state defects are resolved; re-check every claimed open or closed mechanism directly in current code.
+- When a discovered defect is a tiny, understood correction inside the active review unit, present the scope exception clearly but do not force a separate issue/session workflow unless the behavioral risk actually warrants that overhead.


### PR DESCRIPTION
# Summary
Moves H3 and UGC notification candidate queries and their decoded row type into `NotificationCandidateStore`, preserving candidate filtering and delivery orchestration.

# What Changed
- Added a named store for H3/UGC candidate persistence queries.
- Injected the store into `NotificationSendJob` with existing default behavior.
- Preserved freshness cutoffs, installation exclusions, matching, and result fields.
- Expanded query tests for cutoff inclusion, empty H3 cells, UGC zone/fire-zone matching, and decoded fields.
- Updated the architecture progress ledger for issue #158.
- Added the local `.codex` path to `.gitignore` and recorded a workflow lesson.

# User Impact
No intentional notification delivery, queue, retry, schema, or API behavior changes. Candidate labels now decode from populated rows, although current notification copy remains unchanged.

# Testing
- `swift test --filter NotificationSendJobCandidateQueryTests` passed: 3 tests.
- `swift test --filter NotificationSendJobDeliveryBoundaryTests` passed: 4 tests.
- `swift test --filter LocationFreshnessPolicyTests` passed: 13 tests.
- `git diff --check origin/main...HEAD` passed for the committed branch range.

# Notes
- Two unrelated working-tree edits remain uncommitted and are excluded from this PR.