### PR TITLE
Isolate notification ledger persistence

### DIFF
--- a/Sources/App/Jobs/NotificationSendJob.swift
+++ b/Sources/App/Jobs/NotificationSendJob.swift
@@ -8,15 +8,9 @@
 import ArcusCore
 import APNSCore
 import Fluent
-import FluentSQL
 import Foundation
 import Queues
 import Vapor
-
-struct LedgerClaimResult {
-    let inserted: Bool
-    let id: UUID?
-}
 
 struct DispatchNotificationsResult {
     let candidateResolutionReached: Bool
@@ -71,6 +65,7 @@ public struct NotificationSendJob: AsyncJob {
     private let freshnessPolicy: LocationFreshnessPolicy
     private let missedDecisionStore: NotificationMissedDecisionStore
     private let candidateStore: NotificationCandidateStore
+    private let deliveryStore: NotificationDeliveryStore
 
     public init() {
         self.sender = APNsClient()
@@ -78,6 +73,7 @@ public struct NotificationSendJob: AsyncJob {
         self.freshnessPolicy = LocationFreshnessPolicy()
         self.missedDecisionStore = NotificationMissedDecisionStore()
         self.candidateStore = NotificationCandidateStore()
+        self.deliveryStore = NotificationDeliveryStore()
     }
 
     init(
@@ -85,13 +81,15 @@ public struct NotificationSendJob: AsyncJob {
         engine: NotificationEngine = NotificationEngine(),
         freshnessPolicy: LocationFreshnessPolicy = LocationFreshnessPolicy(),
         missedDecisionStore: NotificationMissedDecisionStore = NotificationMissedDecisionStore(),
-        candidateStore: NotificationCandidateStore = NotificationCandidateStore()
+        candidateStore: NotificationCandidateStore = NotificationCandidateStore(),
+        deliveryStore: NotificationDeliveryStore = NotificationDeliveryStore()
     ) {
         self.sender = sender
         self.engine = engine
         self.freshnessPolicy = freshnessPolicy
         self.missedDecisionStore = missedDecisionStore
         self.candidateStore = candidateStore
+        self.deliveryStore = deliveryStore
     }
 
     func deliveryDisposition(
@@ -307,48 +305,6 @@ public struct NotificationSendJob: AsyncJob {
 
 
 extension NotificationSendJob {
-    func claimNotificationLedger(
-        installationID: UUID,
-        seriesID: UUID,
-        revisionUrn: String,
-        mode: NotificationTargetMode,
-        reason: NotificationReason,
-        freshnessState: LocationFreshnessState,
-        on db: any Database
-    ) async throws -> LedgerClaimResult {
-        guard let sql = db as? any SQLDatabase else {
-            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
-        }
-
-        let newID = UUID()
-
-        let row = try await sql.raw("""
-            INSERT INTO notification_ledger
-                (id, installation_id, series_id, revision_urn, mode, reason, freshness_state, created, status)
-            VALUES
-                (\(bind: newID),
-                 \(bind: installationID),
-                 \(bind: seriesID),
-                 \(bind: revisionUrn),
-                 \(bind: mode),
-                 \(bind: reason),
-                 \(bind: freshnessState),
-                 NOW(),
-                'claimed')
-            ON CONFLICT (installation_id, series_id, revision_urn)
-            DO NOTHING
-            RETURNING id
-            """)
-            .first()
-
-        if let row {
-            let returnedID = try row.decode(column: "id", as: UUID.self)
-            return LedgerClaimResult(inserted: true, id: returnedID)
-        } else {
-            return LedgerClaimResult(inserted: false, id: nil)
-        }
-    }
-    
     func dispatchNotifications(
         to candidates: [NotificationCandidate],
         with payload: NotificationSendJobPayload,
@@ -442,7 +398,7 @@ extension NotificationSendJob {
                 freshnessDecision = deliveryDecision
             }
 
-            let claim = try await claimNotificationLedger(
+            let claim = try await deliveryStore.claim(
                 installationID: candidate.id,
                 seriesID: payload.seriesId,
                 revisionUrn: payload.revisionUrn,
@@ -490,11 +446,10 @@ extension NotificationSendJob {
                     environment: apnsEnvironment
                 )
 
-                if let existingClaim = try await NotificationLedgerModel.find(claim.id, on: context.application.db) {
-                    existingClaim.status = "sent"
-                    existingClaim.completedAt = .now
-                    try await existingClaim.save(on: context.application.db)
-                }
+                try await deliveryStore.completeSent(
+                    claimID: claim.id,
+                    on: context.application.db
+                )
                 sentCount += 1
                 
                 context.logger.info(
@@ -521,21 +476,20 @@ extension NotificationSendJob {
                 context.logger.error("APNS rejected request: \(error.reason.debugDescription)")
 //                }
                 
-                guard let existingClaim = try await NotificationLedgerModel.find(claim.id, on: context.application.db) else {
-                    throw Abort(.notFound)
-                }
-                
                 // TODO: figure out retries
                 // At least we aren't dropping them now
+                let apnsErrorCode: String
                 if let reason = error.reason {
-                    existingClaim.apnsErrorCode = reason.errorDescription
+                    apnsErrorCode = reason.errorDescription
                 } else {
-                    existingClaim.apnsErrorCode = error.reason.debugDescription
+                    apnsErrorCode = error.reason.debugDescription
                 }
 
-                existingClaim.status = "failed"
-                existingClaim.completedAt = .now
-                try await existingClaim.save(on: context.application.db)
+                try await deliveryStore.completeFailed(
+                    claimID: claim.id,
+                    apnsErrorCode: apnsErrorCode,
+                    on: context.application.db
+                )
                 failedCount += 1
                 
 //
@@ -573,14 +527,13 @@ extension NotificationSendJob {
                         "error": .string(String(describing: error))
                     ]
                 )
-                guard let existingClaim = try await NotificationLedgerModel.find(claim.id, on: context.application.db) else {
-                    throw Abort(.notFound)
-                }
                 // TODO: figure out retries
                 // At least we aren't dropping them now
-                existingClaim.status = "failed"
-                existingClaim.completedAt = .now
-                try await existingClaim.save(on: context.application.db)
+                try await deliveryStore.completeFailed(
+                    claimID: claim.id,
+                    apnsErrorCode: nil,
+                    on: context.application.db
+                )
                 failedCount += 1
             }
         }

--- a/Sources/App/Models/Notification/NotificationDeliveryStore.swift
+++ b/Sources/App/Models/Notification/NotificationDeliveryStore.swift
@@ -1,0 +1,83 @@
+import Fluent
+import FluentSQL
+import Foundation
+import Vapor
+
+struct LedgerClaimResult {
+    let inserted: Bool
+    let id: UUID?
+}
+
+struct NotificationDeliveryStore {
+    func claim(
+        installationID: UUID,
+        seriesID: UUID,
+        revisionUrn: String,
+        mode: NotificationTargetMode,
+        reason: NotificationReason,
+        freshnessState: LocationFreshnessState,
+        on db: any Database
+    ) async throws -> LedgerClaimResult {
+        guard let sql = db as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        let newID = UUID()
+
+        let row = try await sql.raw("""
+            INSERT INTO notification_ledger
+                (id, installation_id, series_id, revision_urn, mode, reason, freshness_state, created, status)
+            VALUES
+                (\(bind: newID),
+                 \(bind: installationID),
+                 \(bind: seriesID),
+                 \(bind: revisionUrn),
+                 \(bind: mode),
+                 \(bind: reason),
+                 \(bind: freshnessState),
+                 NOW(),
+                'claimed')
+            ON CONFLICT (installation_id, series_id, revision_urn)
+            DO NOTHING
+            RETURNING id
+            """)
+            .first()
+
+        if let row {
+            let returnedID = try row.decode(column: "id", as: UUID.self)
+            return LedgerClaimResult(inserted: true, id: returnedID)
+        } else {
+            return LedgerClaimResult(inserted: false, id: nil)
+        }
+    }
+
+    func completeSent(
+        claimID: UUID?,
+        on db: any Database
+    ) async throws {
+        guard let claim = try await NotificationLedgerModel.find(claimID, on: db) else {
+            return
+        }
+
+        claim.status = "sent"
+        claim.completedAt = .now
+        try await claim.save(on: db)
+    }
+
+    func completeFailed(
+        claimID: UUID?,
+        apnsErrorCode: String?,
+        on db: any Database
+    ) async throws {
+        guard let claim = try await NotificationLedgerModel.find(claimID, on: db) else {
+            throw Abort(.notFound)
+        }
+
+        if let apnsErrorCode {
+            claim.apnsErrorCode = apnsErrorCode
+        }
+        claim.status = "failed"
+        claim.completedAt = .now
+        try await claim.save(on: db)
+    }
+}

--- a/Tests/AppTests/NotificationLedgerFreshnessPersistenceTests.swift
+++ b/Tests/AppTests/NotificationLedgerFreshnessPersistenceTests.swift
@@ -141,96 +141,173 @@ struct NotificationLedgerFreshnessPersistenceTests {
             """).run()
     }
 
-    @Test("fresh candidate claim persists fresh freshness_state")
-    func freshClaimPersistsFreshness() async throws {
+    private func seedAndClaim(
+        revisionUrn: String,
+        mode: NotificationTargetMode,
+        reason: NotificationReason,
+        freshnessState: LocationFreshnessState,
+        using store: NotificationDeliveryStore,
+        on db: any Database
+    ) async throws -> (result: LedgerClaimResult, installationID: UUID, seriesID: UUID) {
+        let installationID = UUID()
+        let seriesID = UUID()
+        try await seedInstallation(id: installationID, on: db)
+        try await seedSeries(id: seriesID, on: db)
+
+        let result = try await store.claim(
+            installationID: installationID,
+            seriesID: seriesID,
+            revisionUrn: revisionUrn,
+            mode: mode,
+            reason: reason,
+            freshnessState: freshnessState,
+            on: db
+        )
+        return (result, installationID, seriesID)
+    }
+
+    @Test("fresh, degraded, and duplicate claims preserve exact original fields")
+    func claimSemanticsArePreserved() async throws {
         try await withApp { app in
-            let job = NotificationSendJob()
-            let installationID = UUID()
-            let seriesID = UUID()
-            let revisionUrn = "urn:oid:fresh-claim"
-
-            try await seedInstallation(id: installationID, on: app.db)
-            try await seedSeries(id: seriesID, on: app.db)
-
-            let claim = try await job.claimNotificationLedger(
-                installationID: installationID,
-                seriesID: seriesID,
-                revisionUrn: revisionUrn,
+            let store = NotificationDeliveryStore()
+            let fresh = try await seedAndClaim(
+                revisionUrn: "urn:oid:fresh-claim",
                 mode: .h3,
                 reason: .new,
                 freshnessState: .fresh,
+                using: store,
                 on: app.db
             )
-
-            #expect(claim.inserted)
-            let ledger = try await NotificationLedgerModel.find(claim.id, on: app.db)
-            #expect(ledger?.freshnessState == .fresh)
-            #expect(ledger?.status == "claimed")
-        }
-    }
-
-    @Test("degraded candidate claim persists degraded freshness_state")
-    func degradedClaimPersistsFreshness() async throws {
-        try await withApp { app in
-            let job = NotificationSendJob()
-            let installationID = UUID()
-            let seriesID = UUID()
-            let revisionUrn = "urn:oid:degraded-claim"
-
-            try await seedInstallation(id: installationID, on: app.db)
-            try await seedSeries(id: seriesID, on: app.db)
-
-            let claim = try await job.claimNotificationLedger(
-                installationID: installationID,
-                seriesID: seriesID,
-                revisionUrn: revisionUrn,
+            let degraded = try await seedAndClaim(
+                revisionUrn: "urn:oid:degraded-claim",
+                mode: .ugc,
+                reason: .update,
+                freshnessState: .degraded,
+                using: store,
+                on: app.db
+            )
+            let duplicate = try await store.claim(
+                installationID: fresh.installationID,
+                seriesID: fresh.seriesID,
+                revisionUrn: "urn:oid:fresh-claim",
                 mode: .ugc,
                 reason: .update,
                 freshnessState: .degraded,
                 on: app.db
             )
 
-            #expect(claim.inserted)
-            let ledger = try await NotificationLedgerModel.find(claim.id, on: app.db)
-            #expect(ledger?.freshnessState == .degraded)
-            #expect(ledger?.status == "claimed")
+            #expect(fresh.result.inserted)
+            #expect(degraded.result.inserted)
+            #expect(duplicate.inserted == false)
+            #expect(duplicate.id == nil)
+
+            let freshRows = try await NotificationLedgerModel.query(on: app.db)
+                .filter(\.$deviceInstallation.$id == fresh.installationID)
+                .filter(\.$series.$id == fresh.seriesID)
+                .filter(\.$revisionUrn == "urn:oid:fresh-claim")
+                .all()
+            let freshLedger = try #require(freshRows.first)
+            let degradedLedger = try #require(
+                try await NotificationLedgerModel.find(degraded.result.id, on: app.db)
+            )
+
+            #expect(freshRows.count == 1)
+            #expect(freshLedger.mode == NotificationTargetMode.h3.rawValue)
+            #expect(freshLedger.reason == NotificationReason.new.rawValue)
+            #expect(freshLedger.freshnessState == .fresh)
+            #expect(freshLedger.status == "claimed")
+            #expect(degradedLedger.mode == NotificationTargetMode.ugc.rawValue)
+            #expect(degradedLedger.reason == NotificationReason.update.rawValue)
+            #expect(degradedLedger.freshnessState == .degraded)
+            #expect(degradedLedger.status == "claimed")
         }
     }
 
-    @Test("failed claimed send keeps original persisted freshness_state")
-    func failedClaimKeepsOriginalFreshness() async throws {
+    @Test("sent, APNs-failed, and generic-failed completions preserve terminal semantics")
+    func completionSemanticsArePreserved() async throws {
         try await withApp { app in
-            let job = NotificationSendJob()
-            let installationID = UUID()
-            let seriesID = UUID()
-            let revisionUrn = "urn:oid:failed-claim"
-
-            try await seedInstallation(id: installationID, on: app.db)
-            try await seedSeries(id: seriesID, on: app.db)
-
-            let claim = try await job.claimNotificationLedger(
-                installationID: installationID,
-                seriesID: seriesID,
-                revisionUrn: revisionUrn,
+            let store = NotificationDeliveryStore()
+            let sent = try await seedAndClaim(
+                revisionUrn: "urn:oid:sent-completion",
+                mode: .ugc,
+                reason: .update,
+                freshnessState: .degraded,
+                using: store,
+                on: app.db
+            ).result
+            let failed = try await seedAndClaim(
+                revisionUrn: "urn:oid:failed-completion",
                 mode: .h3,
                 reason: .new,
                 freshnessState: .degraded,
+                using: store,
+                on: app.db
+            ).result
+            let genericFailed = try await seedAndClaim(
+                revisionUrn: "urn:oid:generic-failed-completion",
+                mode: .h3,
+                reason: .new,
+                freshnessState: .fresh,
+                using: store,
+                on: app.db
+            ).result
+            let existing = try #require(
+                try await NotificationLedgerModel.find(genericFailed.id, on: app.db)
+            )
+            existing.apnsErrorCode = "existing-code"
+            try await existing.save(on: app.db)
+
+            try await store.completeSent(claimID: sent.id, on: app.db)
+            try await store.completeFailed(
+                claimID: failed.id,
+                apnsErrorCode: "BadDeviceToken",
+                on: app.db
+            )
+            try await store.completeFailed(
+                claimID: genericFailed.id,
+                apnsErrorCode: nil,
                 on: app.db
             )
 
-            #expect(claim.inserted)
+            let sentLedger = try #require(try await NotificationLedgerModel.find(sent.id, on: app.db))
+            let failedLedger = try #require(try await NotificationLedgerModel.find(failed.id, on: app.db))
+            let genericLedger = try #require(
+                try await NotificationLedgerModel.find(genericFailed.id, on: app.db)
+            )
 
-            guard let existing = try await NotificationLedgerModel.find(claim.id, on: app.db) else {
-                Issue.record("Missing claimed ledger row")
-                return
+            #expect(sentLedger.status == "sent")
+            #expect(sentLedger.completedAt != nil)
+            #expect(sentLedger.mode == NotificationTargetMode.ugc.rawValue)
+            #expect(sentLedger.reason == NotificationReason.update.rawValue)
+            #expect(sentLedger.freshnessState == .degraded)
+            #expect(sentLedger.apnsErrorCode == nil)
+            #expect(failedLedger.status == "failed")
+            #expect(failedLedger.completedAt != nil)
+            #expect(failedLedger.apnsErrorCode == "BadDeviceToken")
+            #expect(failedLedger.freshnessState == .degraded)
+            #expect(genericLedger.status == "failed")
+            #expect(genericLedger.completedAt != nil)
+            #expect(genericLedger.apnsErrorCode == "existing-code")
+        }
+    }
+
+    @Test("missing sent completion is a no-op and missing failed completion remains not found")
+    func missingCompletionSemanticsArePreserved() async throws {
+        try await withApp { app in
+            let store = NotificationDeliveryStore()
+
+            try await store.completeSent(claimID: UUID(), on: app.db)
+
+            do {
+                try await store.completeFailed(
+                    claimID: UUID(),
+                    apnsErrorCode: nil,
+                    on: app.db
+                )
+                Issue.record("Expected missing failed completion to throw")
+            } catch let error as Abort {
+                #expect(error.status == .notFound)
             }
-            existing.status = "failed"
-            existing.completedAt = Date()
-            try await existing.save(on: app.db)
-
-            let refreshed = try await NotificationLedgerModel.find(claim.id, on: app.db)
-            #expect(refreshed?.status == "failed")
-            #expect(refreshed?.freshnessState == .degraded)
         }
     }
 }

--- a/Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift
+++ b/Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift
@@ -403,6 +403,8 @@ struct NotificationSendJobDeliveryBoundaryTests {
                 .first()
             #expect(ledger != nil)
             #expect(ledger?.freshnessState == .degraded)
+            #expect(ledger?.status == "sent")
+            #expect(ledger?.completedAt != nil)
         }
     }
 
@@ -445,6 +447,109 @@ struct NotificationSendJobDeliveryBoundaryTests {
                 .first()
             #expect(ledger != nil)
             #expect(ledger?.freshnessState == .fresh)
+            #expect(ledger?.status == "sent")
+            #expect(ledger?.completedAt != nil)
+        }
+    }
+
+    @Test("duplicate claims skip all downstream delivery side effects")
+    func duplicateClaimsSkipDownstreamDeliverySideEffects() async throws {
+        try await withApp { app in
+            let sender = RecordingNotificationSender()
+            let job = NotificationSendJob(sender: sender)
+            let context = makeQueueContext(app: app)
+
+            let installationID = UUID()
+            let seriesID = UUID()
+            let revisionUrn = "urn:oid:duplicate-boundary"
+            let now = Date()
+            let series = makeSeries(id: seriesID, revisionUrn: revisionUrn, now: now)
+            let candidate = makeCandidate(
+                id: installationID,
+                auth: .always,
+                capturedAt: now.addingTimeInterval(-(60 * 60))
+            )
+            let payload = NotificationSendJobPayload(
+                seriesId: seriesID,
+                revisionUrn: revisionUrn,
+                mode: .h3,
+                reason: .new
+            )
+
+            try await seedInstallation(id: installationID, locationAuth: .always, on: app.db)
+            try await seedSeries(id: seriesID, revisionUrn: revisionUrn, on: app.db)
+
+            let first = try await job.dispatchNotifications(
+                to: [candidate],
+                with: payload,
+                and: series,
+                using: context
+            )
+            let duplicate = try await job.dispatchNotifications(
+                to: [candidate],
+                with: payload,
+                and: series,
+                using: context
+            )
+
+            #expect(first.claimedCount == 1)
+            #expect(first.sentCount == 1)
+            #expect(duplicate.claimedCount == 0)
+            #expect(duplicate.sentCount == 0)
+            #expect(duplicate.failedCount == 0)
+            #expect(duplicate.noOpReason == .allCandidatesPreviouslyClaimed)
+            #expect(await sender.sendCount == 1)
+
+            let debugCount = try await NotificationDebugModel.query(on: app.db)
+                .filter(\.$series.$id == seriesID)
+                .filter(\.$installationID == installationID)
+                .filter(\.$revisionUrn == revisionUrn)
+                .filter(\.$recordKind == NotificationDebugRecordKind.candidate.rawValue)
+                .count()
+            #expect(debugCount == 1)
+        }
+    }
+
+    @Test("generic sender failure persists one failed claimed delivery")
+    func genericSenderFailurePersistsFailedClaim() async throws {
+        try await withApp { app in
+            let job = NotificationSendJob(sender: ThrowingNotificationSender())
+            let context = makeQueueContext(app: app)
+
+            let installationID = UUID()
+            let seriesID = UUID()
+            let revisionUrn = "urn:oid:failed-boundary"
+            let now = Date()
+            let series = makeSeries(id: seriesID, revisionUrn: revisionUrn, now: now)
+            let candidate = makeCandidate(
+                id: installationID,
+                auth: .always,
+                capturedAt: now.addingTimeInterval(-(60 * 60))
+            )
+
+            try await seedInstallation(id: installationID, locationAuth: .always, on: app.db)
+            try await seedSeries(id: seriesID, revisionUrn: revisionUrn, on: app.db)
+
+            let summary = try await job.dispatchNotifications(
+                to: [candidate],
+                with: .init(seriesId: seriesID, revisionUrn: revisionUrn, mode: .h3, reason: .new),
+                and: series,
+                using: context
+            )
+
+            #expect(summary.claimedCount == 1)
+            #expect(summary.sentCount == 0)
+            #expect(summary.failedCount == 1)
+            #expect(summary.noOpReason == nil)
+
+            let ledger = try #require(try await NotificationLedgerModel.query(on: app.db)
+                .filter(\.$deviceInstallation.$id == installationID)
+                .filter(\.$series.$id == seriesID)
+                .filter(\.$revisionUrn == revisionUrn)
+                .first())
+            #expect(ledger.status == "failed")
+            #expect(ledger.completedAt != nil)
+            #expect(ledger.apnsErrorCode == nil)
         }
     }
 
@@ -505,5 +610,19 @@ private actor RecordingNotificationSender: NotificationSender {
         environment _: APNsEnvironment
     ) async throws {
         sendCount += 1
+    }
+}
+
+private struct ThrowingNotificationSender: NotificationSender {
+    private struct DeterministicFailure: Error {}
+
+    func sendNotification(
+        app _: Application,
+        with _: AlertDetails,
+        hotAlertPayload _: HotAlertAPNsPayload,
+        to _: String,
+        environment _: APNsEnvironment
+    ) async throws {
+        throw DeterministicFailure()
     }
 }

--- a/docs/plans/architecture-recovery-progress.md
+++ b/docs/plans/architecture-recovery-progress.md
@@ -36,7 +36,7 @@ This ledger tracks the sequential, behavior-preserving architecture recovery cam
 | 03 | [#156](https://github.com/justinrooks/arcus-signal/issues/156) | 3 | Extract pure H3 coverage result | None | `gpt-5.6-terra`, high | Pending |
 | 04 | [#157](https://github.com/justinrooks/arcus-signal/issues/157) | 4 | Move H3 work before transaction | 03 | `gpt-5.6-sol`, high | Complete |
 | 05 | [#158](https://github.com/justinrooks/arcus-signal/issues/158) | 5 | Isolate notification candidate selection | 01 | `gpt-5.6-sol`, high | Complete |
-| 06 | [#159](https://github.com/justinrooks/arcus-signal/issues/159) | 6 | Isolate notification ledger persistence | 01, 05 | `gpt-5.6-sol`, high + senior review | Pending |
+| 06 | [#159](https://github.com/justinrooks/arcus-signal/issues/159) | 6 | Isolate notification ledger persistence | 01, 05 | `gpt-5.6-sol`, high + senior review | Ready for commit |
 | 07 | [#160](https://github.com/justinrooks/arcus-signal/issues/160) | 7 | Characterize NWS persistence flow | None | `gpt-5.6-sol`, high | Pending |
 | 08 | [#161](https://github.com/justinrooks/arcus-signal/issues/161) | 8 | Extract NWS transaction script | 07 | `gpt-5.6-sol`, high + senior review | Pending |
 | 09 | [#162](https://github.com/justinrooks/arcus-signal/issues/162) | 9 | Recover explicit API dependency ownership | 02 | `gpt-5.6-sol`, high | Pending |
@@ -130,11 +130,15 @@ This ledger tracks the sequential, behavior-preserving architecture recovery cam
 
 ### Issue #159 - 06: Isolate notification ledger persistence
 
-- **Status:** Pending
+- **Status:** Ready for commit
 - **Roadmap:** Slice 6
 - **Execution profile:** `gpt-5.6-sol`, high reasoning with senior human review
 - **Dependencies:** 01, 05
 - **Stop condition:** Claim/completion persistence is isolated without retry or delivery changes.
+- **Files changed:** `Sources/App/Models/Notification/NotificationDeliveryStore.swift`, `Sources/App/Jobs/NotificationSendJob.swift`, `Tests/AppTests/NotificationLedgerFreshnessPersistenceTests.swift`, `Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift`, and `docs/plans/architecture-recovery-progress.md`.
+- **Behavior:** `NotificationDeliveryStore` now solely owns the unchanged atomic ledger claim SQL and sent/failed completion mutation. `NotificationSendJob` retains sequential candidate orchestration, copy/debug/APNs work, APNs error interpretation, logging, and metrics through a trailing defaulted store dependency. Duplicate, missing-row, and generic-failure behavior remain unchanged.
+- **Validation:** `swift test --filter NotificationLedgerFreshnessPersistenceTests` passed (3 tests); `swift test --filter NotificationSendJobDeliveryBoundaryTests` passed (6 tests); `swift test --filter NotificationMissedDecisionPersistenceTests` passed (2 tests); `swift test --filter NotificationEngineTests` passed (8 tests). Independent defect review found one low-severity job-boundary duplicate-claim test gap; the test auditor reported no findings. The gap was accepted, fixed, and confirmed resolved by focused re-review with no new defect.
+- **Residual risk / handoff:** Claim-before-APNs remains intentionally at-most-once: abandoned or failed claims are not reclaimed. Independent review confirmed exact claim SQL preservation, sent missing-row no-op behavior, failed missing-row `404`, and generic failure leaving `apns_error_code` unchanged.
 
 ### Issue #160 - 07: Characterize NWS persistence flow
 


### PR DESCRIPTION
# Summary
Moves notification ledger claim and terminal completion persistence into `NotificationDeliveryStore` while preserving the existing sequential delivery state machine and exact database behavior.

# What Changed
- Added a delivery store owning atomic ledger claims and sent/failed completion mutations.
- Injected the store into `NotificationSendJob` with existing default behavior.
- Preserved claim-before-copy/send ordering, duplicate-claim handling, missing-row semantics, APNs error mapping, and delivery metrics.
- Added focused persistence and delivery-boundary coverage for fresh/degraded/duplicate claims, sent/APNs/generic failures, and missing completion rows.
- Updated the architecture progress ledger with the implementation scope, validation, and handoff notes.

# User Impact
No intentional notification, retry, queue, schema, or API behavior changes. The refactor gives exact-once claim and terminal status persistence one owner without changing delivery outcomes.

# Testing
- `swift test --filter NotificationLedgerFreshnessPersistenceTests` passed: 3 tests.
- `swift test --filter NotificationSendJobDeliveryBoundaryTests` passed: 6 tests.
- `swift test --filter NotificationMissedDecisionPersistenceTests` passed: 2 tests.
- `swift test --filter NotificationEngineTests` passed: 8 tests.
- `git diff --check origin/main...HEAD` passed for the committed branch range.

# Notes
- The PR contains the committed five-file change only.
- Uncommitted edits in `docs/Sql/Device.sql`, `docs/audits/weekly-bug-scan.md`, and `docs/audits/weekly-test-gap-audit.md` were intentionally excluded.