### PR TITLE
Recover explicit API dependency ownership

### DIFF
--- a/Sources/App/StormSetup/APIDependencyComposition.swift
+++ b/Sources/App/StormSetup/APIDependencyComposition.swift
@@ -1,0 +1,31 @@
+import Vapor
+
+func installAPIRequestDependencies(on application: Application) {
+    let previewProvider: any AnvilProfilePreviewProviding
+    if let configuredProvider = application.configuredAnvilProfilePreviewProvider {
+        previewProvider = configuredProvider
+    } else {
+        let defaultProvider = DefaultAnvilProfilePreviewProvider(application: application)
+        application.anvilProfilePreviewProvider = defaultProvider
+        previewProvider = defaultProvider
+    }
+
+    let analysisProvider: any AnvilProfileAnalysisProviding
+    if let configuredProvider = application.configuredAnvilProfileAnalysisProvider {
+        analysisProvider = configuredProvider
+    } else {
+        let defaultProvider = DefaultAnvilProfileAnalysisProvider(
+            application: application,
+            previewProvider: previewProvider
+        )
+        application.anvilProfileAnalysisProvider = defaultProvider
+        analysisProvider = defaultProvider
+    }
+
+    if application.configuredStormSetupProvider == nil {
+        application.stormSetupProvider = DefaultStormSetupProvider(
+            application: application,
+            anvilProfileAnalysisProvider: analysisProvider
+        )
+    }
+}

--- a/Sources/App/StormSetup/AnvilProfileAnalysisProvider.swift
+++ b/Sources/App/StormSetup/AnvilProfileAnalysisProvider.swift
@@ -76,9 +76,12 @@ struct DefaultAnvilProfileAnalysisProvider: AnvilProfileAnalysisProviding {
         self.directClient = anvilClient
     }
 
-    init(application: Application) {
+    init(
+        application: Application,
+        previewProvider: any AnvilProfilePreviewProviding
+    ) {
         self.init(
-            previewProvider: application.anvilProfilePreviewProvider,
+            previewProvider: previewProvider,
             configuration: application.stormSetupConfiguration,
             httpClient: VaporApplicationHTTPClient(application: application)
         )
@@ -162,9 +165,13 @@ struct DefaultAnvilProfileAnalysisProvider: AnvilProfileAnalysisProviding {
 }
 
 extension Application {
+    var configuredAnvilProfileAnalysisProvider: (any AnvilProfileAnalysisProviding)? {
+        storage[AnvilProfileAnalysisProviderKey.self]
+    }
+
     var anvilProfileAnalysisProvider: any AnvilProfileAnalysisProviding {
         get {
-            storage[AnvilProfileAnalysisProviderKey.self] ?? DefaultAnvilProfileAnalysisProvider(application: self)
+            configuredAnvilProfileAnalysisProvider ?? UnavailableAnvilProfileAnalysisProvider()
         }
         set {
             storage[AnvilProfileAnalysisProviderKey.self] = newValue
@@ -174,4 +181,13 @@ extension Application {
 
 private struct AnvilProfileAnalysisProviderKey: StorageKey {
     typealias Value = any AnvilProfileAnalysisProviding
+}
+
+private struct UnavailableAnvilProfileAnalysisProvider: AnvilProfileAnalysisProviding {
+    func analyzeProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfileAnalysisResponse {
+        _ = h3Cell
+        throw AnvilProfileAnalysisError.internalExecutionFailure(
+            reason: "Anvil analysis provider is not configured. Install API request dependencies during API bootstrap."
+        )
+    }
 }

--- a/Sources/App/StormSetup/AnvilProfilePreviewProvider.swift
+++ b/Sources/App/StormSetup/AnvilProfilePreviewProvider.swift
@@ -815,9 +815,13 @@ private enum SurfaceDiagnosticsStage: String, Sendable {
 }
 
 extension Application {
+    var configuredAnvilProfilePreviewProvider: (any AnvilProfilePreviewProviding)? {
+        storage[AnvilProfilePreviewProviderKey.self]
+    }
+
     var anvilProfilePreviewProvider: any AnvilProfilePreviewProviding {
         get {
-            storage[AnvilProfilePreviewProviderKey.self] ?? DefaultAnvilProfilePreviewProvider(application: self)
+            configuredAnvilProfilePreviewProvider ?? UnavailableAnvilProfilePreviewProvider()
         }
         set {
             storage[AnvilProfilePreviewProviderKey.self] = newValue
@@ -827,6 +831,15 @@ extension Application {
 
 private struct AnvilProfilePreviewProviderKey: StorageKey {
     typealias Value = any AnvilProfilePreviewProviding
+}
+
+private struct UnavailableAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
+    func previewProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfilePreviewResponse {
+        _ = h3Cell
+        throw AnvilProfilePreviewError.internalExecutionFailure(
+            reason: "Anvil preview provider is not configured. Install API request dependencies during API bootstrap."
+        )
+    }
 }
 
 private struct DefaultUnavailableAnvilSurfaceProfileLoader: HrrrAnvilSurfaceProfileLoading {

--- a/Sources/App/StormSetup/StormSetupProvider.swift
+++ b/Sources/App/StormSetup/StormSetupProvider.swift
@@ -125,7 +125,7 @@ struct DefaultStormSetupProvider: StormSetupProviding {
     private let fieldSampler: any StormSetupFieldSampling
     private let normalizer: any StormSetupIngredientNormalizing
     private let interpreter: any StormSetupIngredientAssessing
-    private let anvilProfileAnalysisProvider: (any AnvilProfileAnalysisProviding)?
+    let anvilProfileAnalysisProvider: (any AnvilProfileAnalysisProviding)?
     private let logger: Logger
 
     init(
@@ -855,6 +855,7 @@ private struct StormSetupCurrentComposition: Sendable {
 extension DefaultStormSetupProvider {
     init(
         application: Application,
+        anvilProfileAnalysisProvider: any AnvilProfileAnalysisProviding,
         h3Resolver: any StormSetupH3Resolving = DefaultStormSetupH3Resolver(),
         dateProvider: any StormSetupDateProviding = SystemStormSetupDateProvider(),
         hrrrRunResolver: (any HrrrRunResolving)? = nil,
@@ -887,16 +888,20 @@ extension DefaultStormSetupProvider {
             fieldSampler: sampler,
             normalizer: TornadoIngredientNormalizer(),
             interpreter: TornadoIngredientInterpreter(),
-            anvilProfileAnalysisProvider: application.anvilProfileAnalysisProvider,
+            anvilProfileAnalysisProvider: anvilProfileAnalysisProvider,
             logger: logger ?? application.logger
         )
     }
 }
 
 extension Application {
+    var configuredStormSetupProvider: (any StormSetupProviding)? {
+        storage[StormSetupProviderKey.self]
+    }
+
     var stormSetupProvider: any StormSetupProviding {
         get {
-            storage[StormSetupProviderKey.self] ?? DefaultStormSetupProvider(application: self)
+            configuredStormSetupProvider ?? UnavailableStormSetupProvider()
         }
         set {
             storage[StormSetupProviderKey.self] = newValue
@@ -906,6 +911,16 @@ extension Application {
 
 private struct StormSetupProviderKey: StorageKey {
     typealias Value = any StormSetupProviding
+}
+
+private struct UnavailableStormSetupProvider: StormSetupProviding {
+    func currentSnapshot(for h3Cell: Int64) async throws -> TornadoIngredientSnapshot {
+        _ = h3Cell
+        throw Abort(
+            .internalServerError,
+            reason: "Storm Setup provider is not configured. Install API request dependencies during API bootstrap."
+        )
+    }
 }
 
 extension StormSetupSnapshotCache: StormSetupSnapshotCaching {}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -55,6 +55,7 @@ public func configure(_ app: Application, mode: AppRuntimeMode) async throws {
 
     switch mode {
     case .api:
+        installAPIRequestDependencies(on: app)
         try configureAPIRoutes(app)
     case .worker:
         configureWorkerQueueSettings(on: app)

--- a/Tests/AppTests/APIDependencyCompositionTests.swift
+++ b/Tests/AppTests/APIDependencyCompositionTests.swift
@@ -1,0 +1,205 @@
+@testable import App
+import Foundation
+import Testing
+import Vapor
+import ArcusCore
+
+@Suite("API dependency composition", .serialized)
+struct APIDependencyCompositionTests {
+    @Test("API bootstrap installs and stores the default request providers")
+    func apiBootstrapInstallsDefaultRequestProviders() async throws {
+        try await withApplication { app in
+            #expect(app.configuredAnvilProfilePreviewProvider == nil)
+            #expect(app.configuredAnvilProfileAnalysisProvider == nil)
+            #expect(app.configuredStormSetupProvider == nil)
+
+            try await configure(app, mode: .api)
+
+            #expect(app.configuredAnvilProfilePreviewProvider is DefaultAnvilProfilePreviewProvider)
+            #expect(app.configuredAnvilProfileAnalysisProvider is DefaultAnvilProfileAnalysisProvider)
+            #expect(app.configuredStormSetupProvider is DefaultStormSetupProvider)
+
+            _ = app.anvilProfilePreviewProvider
+            _ = app.anvilProfileAnalysisProvider
+            _ = app.stormSetupProvider
+
+            #expect(app.configuredAnvilProfilePreviewProvider is DefaultAnvilProfilePreviewProvider)
+            #expect(app.configuredAnvilProfileAnalysisProvider is DefaultAnvilProfileAnalysisProvider)
+            #expect(app.configuredStormSetupProvider is DefaultStormSetupProvider)
+        }
+    }
+
+    @Test("API bootstrap preserves all preconfigured request providers")
+    func apiBootstrapPreservesPreconfiguredRequestProviders() async throws {
+        try await withApplication { app in
+            let previewProvider = SentinelAnvilProfilePreviewProvider()
+            let analysisProvider = SentinelAnvilProfileAnalysisProvider()
+            let stormSetupProvider = SentinelAPIStormSetupProvider()
+
+            app.anvilProfilePreviewProvider = previewProvider
+            app.anvilProfileAnalysisProvider = analysisProvider
+            app.stormSetupProvider = stormSetupProvider
+
+            try await configure(app, mode: .api)
+
+            #expect(app.configuredAnvilProfilePreviewProvider as AnyObject === previewProvider)
+            #expect(app.configuredAnvilProfileAnalysisProvider as AnyObject === analysisProvider)
+            #expect(app.configuredStormSetupProvider as AnyObject === stormSetupProvider)
+            #expect(app.anvilProfilePreviewProvider as AnyObject === previewProvider)
+            #expect(app.anvilProfileAnalysisProvider as AnyObject === analysisProvider)
+            #expect(app.stormSetupProvider as AnyObject === stormSetupProvider)
+            #expect(app.anvilProfilePreviewProvider as AnyObject === previewProvider)
+            #expect(app.anvilProfileAnalysisProvider as AnyObject === analysisProvider)
+            #expect(app.stormSetupProvider as AnyObject === stormSetupProvider)
+        }
+    }
+
+    @Test("A preview override participates in downstream default composition")
+    func previewOverrideParticipatesInDownstreamDefaultComposition() async throws {
+        try await withApplication { app in
+            let previewProvider = SentinelAnvilProfilePreviewProvider()
+            app.stormSetupConfiguration = makeAnvilEnabledConfiguration()
+            app.anvilProfilePreviewProvider = previewProvider
+
+            try await configure(app, mode: .api)
+
+            #expect(app.configuredAnvilProfilePreviewProvider as AnyObject === previewProvider)
+            #expect(app.configuredAnvilProfileAnalysisProvider is DefaultAnvilProfileAnalysisProvider)
+            #expect(app.configuredStormSetupProvider is DefaultStormSetupProvider)
+
+            do {
+                _ = try await app.anvilProfileAnalysisProvider.analyzeProfile(for: 0)
+                Issue.record("Expected the injected preview provider to stop downstream analysis.")
+            } catch let error as AnvilProfileAnalysisError {
+                guard case .unusableProfile(let reason) = error else {
+                    Issue.record("Expected unusableProfile, got \(error).")
+                    return
+                }
+                #expect(reason == SentinelAnvilProfilePreviewProvider.reason)
+            }
+        }
+    }
+
+    @Test("An analysis override participates in downstream default composition")
+    func analysisOverrideParticipatesInDownstreamDefaultComposition() async throws {
+        try await withApplication { app in
+            let analysisProvider = SentinelAnvilProfileAnalysisProvider()
+            app.anvilProfileAnalysisProvider = analysisProvider
+
+            try await configure(app, mode: .api)
+
+            #expect(app.configuredAnvilProfilePreviewProvider is DefaultAnvilProfilePreviewProvider)
+            #expect(app.configuredAnvilProfileAnalysisProvider as AnyObject === analysisProvider)
+
+            let stormSetupProvider = try #require(
+                app.configuredStormSetupProvider as? DefaultStormSetupProvider
+            )
+            #expect(stormSetupProvider.anvilProfileAnalysisProvider as AnyObject === analysisProvider)
+        }
+    }
+
+    @Test("Worker bootstrap leaves API request providers unconfigured")
+    func workerBootstrapLeavesRequestProvidersUnconfigured() async throws {
+        try await withApplication { app in
+            try await configure(app, mode: .worker)
+
+            #expect(app.configuredAnvilProfilePreviewProvider == nil)
+            #expect(app.configuredAnvilProfileAnalysisProvider == nil)
+            #expect(app.configuredStormSetupProvider == nil)
+        }
+    }
+
+    @Test("Missing request providers fail explicitly without installing defaults")
+    func missingRequestProvidersFailExplicitly() async throws {
+        try await withApplication { app in
+            do {
+                _ = try await app.anvilProfilePreviewProvider.previewProfile(for: 0)
+                Issue.record("Expected missing preview provider access to fail.")
+            } catch let error as AnvilProfilePreviewError {
+                guard case .internalExecutionFailure(let reason) = error else {
+                    Issue.record("Expected internalExecutionFailure, got \(error).")
+                    return
+                }
+                #expect(reason.contains("Anvil preview provider is not configured."))
+            }
+
+            do {
+                _ = try await app.anvilProfileAnalysisProvider.analyzeProfile(for: 0)
+                Issue.record("Expected missing analysis provider access to fail.")
+            } catch let error as AnvilProfileAnalysisError {
+                guard case .internalExecutionFailure(let reason) = error else {
+                    Issue.record("Expected internalExecutionFailure, got \(error).")
+                    return
+                }
+                #expect(reason.contains("Anvil analysis provider is not configured."))
+            }
+
+            do {
+                _ = try await app.stormSetupProvider.currentSnapshot(for: 0)
+                Issue.record("Expected missing Storm Setup provider access to fail.")
+            } catch let error as Abort {
+                #expect(error.status == .internalServerError)
+                #expect(error.reason.contains("Storm Setup provider is not configured."))
+            }
+
+            #expect(app.configuredAnvilProfilePreviewProvider == nil)
+            #expect(app.configuredAnvilProfileAnalysisProvider == nil)
+            #expect(app.configuredStormSetupProvider == nil)
+        }
+    }
+
+    private func withApplication(
+        test: (Application) async throws -> Void
+    ) async throws {
+        let app = try await Application.make(.testing)
+        do {
+            try await test(app)
+        } catch {
+            try? await app.asyncShutdown()
+            throw error
+        }
+        try await app.asyncShutdown()
+    }
+
+    private func makeAnvilEnabledConfiguration() -> StormSetupConfiguration {
+        StormSetupConfiguration(
+            gribSubsetCacheRootURL: URL(fileURLWithPath: "/tmp/grib-subsets"),
+            pressureGribSubsetCacheRootURL: URL(fileURLWithPath: "/tmp/pressure-grib-subsets"),
+            sampledSnapshotCacheRootURL: URL(fileURLWithPath: "/tmp/sampled-snapshots"),
+            gribSubsetCacheRetentionSeconds: 12 * 60 * 60,
+            gribSubsetMaximumByteCount: 200 * 1024 * 1024,
+            pressureArtifactProbeIntervalSeconds: 5 * 60,
+            pressureArtifactMaxStaleAgeSeconds: 2 * 60 * 60,
+            pressureArtifactDeleteGraceSeconds: 60 * 60,
+            pressureArtifactCleanupIntervalSeconds: 15 * 60,
+            pressureArtifactRecoveryTimeoutSeconds: 30 * 60,
+            wgrib2ExecutableURL: URL(fileURLWithPath: "/usr/local/bin/wgrib2"),
+            wgrib2TimeoutSeconds: 15,
+            anvilProfileAnalysisBaseURL: URL(string: "https://anvil.example.test"),
+            anvilProfileAnalysisTimeoutSeconds: 5
+        )
+    }
+}
+
+private actor SentinelAnvilProfilePreviewProvider: AnvilProfilePreviewProviding {
+    static let reason = "Injected preview provider reached."
+
+    func previewProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfilePreviewResponse {
+        _ = h3Cell
+        throw AnvilProfilePreviewError.unusableProfile(reason: Self.reason)
+    }
+}
+
+private actor SentinelAnvilProfileAnalysisProvider: AnvilProfileAnalysisProviding {
+    func analyzeProfile(for h3Cell: Int64) async throws -> AnvilAnalyzeProfileAnalysisResponse {
+        _ = h3Cell
+        throw AnvilProfileAnalysisError.internalExecutionFailure(reason: "Sentinel provider should never be called.")
+    }
+}
+
+private actor SentinelAPIStormSetupProvider: StormSetupProviding {
+    func currentSnapshot(for h3Cell: Int64) async throws -> TornadoIngredientSnapshot {
+        _ = h3Cell
+        throw Abort(.internalServerError, reason: "Sentinel provider should never be called.")
+    }
+}

--- a/docs/plans/architecture-recovery-progress.md
+++ b/docs/plans/architecture-recovery-progress.md
@@ -39,7 +39,7 @@ This ledger tracks the sequential, behavior-preserving architecture recovery cam
 | 06 | [#159](https://github.com/justinrooks/arcus-signal/issues/159) | 6 | Isolate notification ledger persistence | 01, 05 | `gpt-5.6-sol`, high + senior review | Ready for commit |
 | 07 | [#160](https://github.com/justinrooks/arcus-signal/issues/160) | 7 | Characterize NWS persistence flow | None | `gpt-5.6-sol`, high | Ready for commit |
 | 08 | [#161](https://github.com/justinrooks/arcus-signal/issues/161) | 8 | Extract NWS transaction script | 07 | `gpt-5.6-sol`, high + senior review | Pending |
-| 09 | [#162](https://github.com/justinrooks/arcus-signal/issues/162) | 9 | Recover explicit API dependency ownership | 02 | `gpt-5.6-sol`, high | Pending |
+| 09 | [#162](https://github.com/justinrooks/arcus-signal/issues/162) | 9 | Recover explicit API dependency ownership | 02 | `gpt-5.6-sol`, high | READY FOR COMMIT |
 | 10 | [#163](https://github.com/justinrooks/arcus-signal/issues/163) | 10 | Own warm claim/completion SQL | 02 | `gpt-5.6-sol`, high | Pending |
 | 11 | [#164](https://github.com/justinrooks/arcus-signal/issues/164) | 11A | Own probe catalog transitions | 10 | `gpt-5.6-sol`, high | Pending |
 | 12 | [#165](https://github.com/justinrooks/arcus-signal/issues/165) | 11B | Own cleanup catalog transitions | 10, 11 | `gpt-5.6-sol`, high + persistence/filesystem review | Pending |
@@ -168,11 +168,16 @@ This ledger tracks the sequential, behavior-preserving architecture recovery cam
 
 ### Issue #162 - 09: Recover explicit API dependency ownership
 
-- **Status:** Pending
+- **Status:** READY FOR COMMIT
 - **Roadmap:** Slice 9
 - **Execution profile:** `gpt-5.6-sol`, high reasoning
 - **Dependencies:** 02
 - **Stop condition:** API graph is installed once with stable lifetime; worker ownership unchanged.
+- **Files changed:** `Sources/App/configure.swift`, `Sources/App/StormSetup/APIDependencyComposition.swift`, the three Storm Setup/Anvil provider files, `Tests/AppTests/APIDependencyCompositionTests.swift`, and this progress entry.
+- **Behavior:** `installAPIRequestDependencies(on:)` now installs the API request-provider graph once in preview → analysis → Storm Setup order before route registration. Existing providers survive configuration and feed downstream defaults. Worker bootstrap leaves all three providers unconfigured. Provider getters no longer construct defaults; unconfigured access returns provider-specific configuration failures without mutating storage.
+- **Coverage:** Added six deterministic composition tests covering default API installation and retained storage, all three preconfigure overrides, preview-only and analysis-only overrides participating in downstream default construction, worker non-installation, and explicit missing-provider failures.
+- **Validation:** `swift test --filter AppTests.AppTests` passed (29 tests); `swift test --filter AppTests.APIDependencyCompositionTests` passed (6 tests); the requested Storm Setup controller, Anvil preview controller, Anvil analysis controller, and Storm Setup provider filters passed (6, 9, 5, and 18 tests). The exact broad `swift test --filter AppTests` command selected the full package and failed one unrelated parallel PostgreSQL migration test; the same command already failed once before this slice, and `swift test --filter DevicePresenceMigrationTests` passed alone (1 test). The strict-concurrency build passed with one pre-existing deprecation warning. The issue-scoped tracked diff check and new-file whitespace scan passed; unscoped `git diff --check` remains blocked only by the pre-existing `docs/Sql/Device.sql:48` trailing whitespace. Human review completed with no suggested changes. The independent defect reviewer reported no actionable defects; the test auditor identified the missing analysis-only override coverage and stale summary status, both were accepted and resolved, and both focused re-reviews reported no actionable findings.
+- **Residual risk / handoff:** Default providers remain value-type wrappers around their existing actor/service dependencies, so stable lifetime is established through `Application.storage`, not reference identity of the wrapper itself. The default Storm Setup provider exposes its immutable analysis dependency only at module-internal visibility for deterministic composition testing. No provider contract, route, cache, environment, worker schedule, or external response behavior changed. Ready for commit.
 
 ### Issue #163 - 10: Own warm claim/completion SQL
 


### PR DESCRIPTION
# Summary
Establishes one explicit API bootstrap path for the Storm Setup and Anvil request-provider graph, preserving configured overrides while removing recursive per-access default construction and leaving worker bootstrap independent of API request dependencies.

# What Changed
- Added `installAPIRequestDependencies(on:)` and invoked it during API configuration before route registration.
- Installs preview, analysis, and Storm Setup defaults once in dependency order, while preserving preconfigured providers and downstream composition.
- Replaced provider getter fallbacks with explicit configuration failures when request providers are accessed before API composition.
- Added deterministic composition tests covering API defaults, overrides, downstream dependency wiring, worker non-installation, and missing-provider failures.
- Updated the architecture recovery progress ledger for issue #162.

# User Impact
API request behavior is unchanged when the API is configured normally. Worker bootstrap no longer constructs API request providers; accidental unconfigured access now fails explicitly instead of creating recursive defaults.

# Testing
- `swift test --filter APIDependencyCompositionTests` passed: 6 tests.
- `swift test --filter StormSetupControllerTests` passed: 6 tests.
- `swift test --filter AnvilProfilePreviewControllerTests` passed: 9 tests.
- `swift test --filter AnvilProfileAnalysisControllerTests` passed: 5 tests.
- `swift test --filter StormSetupProviderTests` passed: 18 tests.
- `swift build -Xswiftc -strict-concurrency=complete` passed.
- `git diff --check` passed for the committed branch range.

# Notes
- No target split, generic DI container, protocol rewrite, cache behavior, or worker ownership change is included.
- Uncommitted edits in `docs/Sql/Device.sql`, `docs/audits/weekly-bug-scan.md`, and `docs/audits/weekly-test-gap-audit.md` were intentionally excluded.

Closes #162