### PR TITLE
Give warm claim and completion SQL one owner

### DIFF
--- a/Sources/App/Models/Data/PressureArtifactCatalogStore.swift
+++ b/Sources/App/Models/Data/PressureArtifactCatalogStore.swift
@@ -1,0 +1,160 @@
+import Fluent
+import FluentSQL
+import Foundation
+import Vapor
+
+struct PressureArtifactCatalogStore: Sendable {
+    func ensureCatalogRowExists(
+        for payload: PressureArtifactWarmJobPayload,
+        on database: any Database
+    ) async throws {
+        if try await PressureArtifactCatalogModel.find(
+            runTime: payload.runTime,
+            forecastHour: payload.forecastHour,
+            product: payload.product,
+            fieldSetVersion: payload.fieldSetVersion,
+            on: database
+        ) != nil {
+            return
+        }
+
+        let row = PressureArtifactCatalogModel(
+            runTime: payload.runTime,
+            forecastHour: payload.forecastHour,
+            validTime: payload.validTime,
+            product: payload.product,
+            fieldSetVersion: payload.fieldSetVersion,
+            status: .pending
+        )
+
+        do {
+            try await row.create(on: database)
+        } catch {
+            if DbUtils.isUniqueConstraintViolation(error) {
+                return
+            }
+
+            throw error
+        }
+    }
+
+    func claimCatalogRow(
+        for payload: PressureArtifactWarmJobPayload,
+        claimToken: UUID,
+        leaseExpiresAt: Date,
+        on database: any Database
+    ) async throws -> PressureArtifactCatalogModel? {
+        guard let sql = database as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        let row = try await sql.raw("""
+            UPDATE pressure_artifact_catalog
+            SET status = \(bind: PressureArtifactCatalogStatus.warming.rawValue),
+                source = \(bind: PressureArtifactCatalogSource.aws.rawValue),
+                last_checked_at = NOW(),
+                error_summary = NULL,
+                local_path = NULL,
+                byte_size = NULL,
+                claim_token = \(bind: claimToken),
+                lease_expires_at = \(bind: leaseExpiresAt)
+            WHERE run_time = \(bind: payload.runTime)
+              AND forecast_hour = \(bind: payload.forecastHour)
+              AND product = \(bind: payload.product.rawValue)
+              AND field_set_version = \(bind: payload.fieldSetVersion.rawValue)
+              AND (
+                status IN (\(bind: PressureArtifactCatalogStatus.pending.rawValue),
+                           \(bind: PressureArtifactCatalogStatus.failed.rawValue))
+                OR (
+                    status = \(bind: PressureArtifactCatalogStatus.expired.rawValue)
+                    AND claim_token IS NULL
+                    AND (
+                        lease_expires_at IS NULL
+                        OR lease_expires_at <= NOW()
+                    )
+                )
+              )
+            RETURNING id
+            """)
+            .first()
+
+        guard row != nil else {
+            return nil
+        }
+
+        return try await PressureArtifactCatalogModel.find(
+            runTime: payload.runTime,
+            forecastHour: payload.forecastHour,
+            product: payload.product,
+            fieldSetVersion: payload.fieldSetVersion,
+            on: database
+        )
+    }
+
+    func markReady(
+        payload: PressureArtifactWarmJobPayload,
+        claimToken: UUID,
+        localPath: String,
+        byteSize: Int64,
+        on database: any Database
+    ) async throws -> Bool {
+        guard let sql = database as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        let updatedRow = try await sql.raw("""
+            UPDATE pressure_artifact_catalog
+            SET status = \(bind: PressureArtifactCatalogStatus.ready.rawValue),
+                source = \(bind: PressureArtifactCatalogSource.aws.rawValue),
+                last_checked_at = NOW(),
+                error_summary = NULL,
+                local_path = \(bind: localPath),
+                byte_size = \(bind: byteSize),
+                claim_token = NULL,
+                lease_expires_at = NULL
+            WHERE run_time = \(bind: payload.runTime)
+              AND forecast_hour = \(bind: payload.forecastHour)
+              AND product = \(bind: payload.product.rawValue)
+              AND field_set_version = \(bind: payload.fieldSetVersion.rawValue)
+              AND status = \(bind: PressureArtifactCatalogStatus.warming.rawValue)
+              AND claim_token = \(bind: claimToken)
+            RETURNING id
+            """)
+            .first()
+
+        return updatedRow != nil
+    }
+
+    func markFailed(
+        payload: PressureArtifactWarmJobPayload,
+        claimToken: UUID,
+        errorSummary: String,
+        on database: any Database
+    ) async throws -> Bool {
+        guard let sql = database as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        let updatedRow = try await sql.raw("""
+            UPDATE pressure_artifact_catalog
+            SET status = \(bind: PressureArtifactCatalogStatus.failed.rawValue),
+                source = \(bind: PressureArtifactCatalogSource.aws.rawValue),
+                last_checked_at = NOW(),
+                error_summary = \(bind: errorSummary),
+                local_path = NULL,
+                byte_size = NULL,
+                claim_token = NULL,
+                lease_expires_at = NULL
+            WHERE run_time = \(bind: payload.runTime)
+              AND forecast_hour = \(bind: payload.forecastHour)
+              AND product = \(bind: payload.product.rawValue)
+              AND field_set_version = \(bind: payload.fieldSetVersion.rawValue)
+              AND status = \(bind: PressureArtifactCatalogStatus.warming.rawValue)
+              AND claim_token = \(bind: claimToken)
+            RETURNING id
+            """)
+            .first()
+
+        return updatedRow != nil
+    }
+}

--- a/Sources/App/StormSetup/PressureArtifactWarmingService.swift
+++ b/Sources/App/StormSetup/PressureArtifactWarmingService.swift
@@ -1,5 +1,4 @@
 import Fluent
-import FluentSQL
 import Foundation
 import Vapor
 import ArcusCore
@@ -49,6 +48,7 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
     private let dateProvider: any StormSetupDateProviding
     private let maximumByteCount: Int
     private let recoveryTimeoutSeconds: TimeInterval
+    private let catalogStore: PressureArtifactCatalogStore
 
     init(
         httpClient: any HTTPClient,
@@ -58,7 +58,8 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
         dateProvider: any StormSetupDateProviding,
         retentionDuration: TimeInterval,
         maximumByteCount: Int,
-        recoveryTimeoutSeconds: TimeInterval = 30 * 60
+        recoveryTimeoutSeconds: TimeInterval = 30 * 60,
+        catalogStore: PressureArtifactCatalogStore = PressureArtifactCatalogStore()
     ) {
         self.httpClient = httpClient
         self.validator = validator
@@ -73,6 +74,7 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
         self.dateProvider = dateProvider
         self.maximumByteCount = maximumByteCount
         self.recoveryTimeoutSeconds = max(1, recoveryTimeoutSeconds)
+        self.catalogStore = catalogStore
     }
 
     static func makeDefault(application: Application) -> PressureArtifactWarmingService {
@@ -103,12 +105,14 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
             throw PressureArtifactWarmingError.unsupportedProduct(payload.product)
         }
 
-        try await ensureCatalogRowExists(for: payload, on: application.db)
+        try await catalogStore.ensureCatalogRowExists(for: payload, on: application.db)
         let claimToken = UUID()
+        let leaseExpiresAt = dateProvider.now().addingTimeInterval(recoveryTimeoutSeconds)
 
-        guard let claimedRow = try await claimCatalogRow(
+        guard let claimedRow = try await catalogStore.claimCatalogRow(
             for: payload,
             claimToken: claimToken,
+            leaseExpiresAt: leaseExpiresAt,
             on: application.db
         ) else {
             try Task.checkCancellation()
@@ -281,7 +285,7 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
             )
 
             try Task.checkCancellation()
-            guard try await markReady(
+            guard try await catalogStore.markReady(
                 payload: payload,
                 claimToken: claimToken,
                 localPath: subset.localFilePath,
@@ -312,10 +316,10 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
             )
         } catch {
             try rethrowCancellationIfNeeded(error)
-            guard try await markFailed(
+            guard try await catalogStore.markFailed(
                 payload: payload,
                 claimToken: claimToken,
-                error: error,
+                errorSummary: String(reflecting: error),
                 on: application.db
             ) else {
                 logger.info(
@@ -414,160 +418,6 @@ extension PressureArtifactWarmingService {
         )
 
         return text
-    }
-
-    func ensureCatalogRowExists(
-        for payload: PressureArtifactWarmJobPayload,
-        on database: any Database
-    ) async throws {
-        if try await PressureArtifactCatalogModel.find(
-            runTime: payload.runTime,
-            forecastHour: payload.forecastHour,
-            product: payload.product,
-            fieldSetVersion: payload.fieldSetVersion,
-            on: database
-        ) != nil {
-            return
-        }
-
-        let row = PressureArtifactCatalogModel(
-            runTime: payload.runTime,
-            forecastHour: payload.forecastHour,
-            validTime: payload.validTime,
-            product: payload.product,
-            fieldSetVersion: payload.fieldSetVersion,
-            status: .pending
-        )
-
-        do {
-            try await row.create(on: database)
-        } catch {
-            if DbUtils.isUniqueConstraintViolation(error) {
-                return
-            }
-
-            throw error
-        }
-    }
-
-    func claimCatalogRow(
-        for payload: PressureArtifactWarmJobPayload,
-        claimToken: UUID,
-        on database: any Database
-    ) async throws -> PressureArtifactCatalogModel? {
-        guard let sql = database as? any SQLDatabase else {
-            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
-        }
-
-        let leaseExpiresAt = dateProvider.now().addingTimeInterval(recoveryTimeoutSeconds)
-        let row = try await sql.raw("""
-            UPDATE pressure_artifact_catalog
-            SET status = \(bind: PressureArtifactCatalogStatus.warming.rawValue),
-                source = \(bind: PressureArtifactCatalogSource.aws.rawValue),
-                last_checked_at = NOW(),
-                error_summary = NULL,
-                local_path = NULL,
-                byte_size = NULL,
-                claim_token = \(bind: claimToken),
-                lease_expires_at = \(bind: leaseExpiresAt)
-            WHERE run_time = \(bind: payload.runTime)
-              AND forecast_hour = \(bind: payload.forecastHour)
-              AND product = \(bind: payload.product.rawValue)
-              AND field_set_version = \(bind: payload.fieldSetVersion.rawValue)
-              AND (
-                status IN (\(bind: PressureArtifactCatalogStatus.pending.rawValue),
-                           \(bind: PressureArtifactCatalogStatus.failed.rawValue))
-                OR (
-                    status = \(bind: PressureArtifactCatalogStatus.expired.rawValue)
-                    AND claim_token IS NULL
-                    AND (
-                        lease_expires_at IS NULL
-                        OR lease_expires_at <= NOW()
-                    )
-                )
-              )
-            RETURNING id
-            """)
-            .first()
-
-        guard row != nil else {
-            return nil
-        }
-
-        return try await PressureArtifactCatalogModel.find(
-            runTime: payload.runTime,
-            forecastHour: payload.forecastHour,
-            product: payload.product,
-            fieldSetVersion: payload.fieldSetVersion,
-            on: database
-        )
-    }
-
-    func markReady(
-        payload: PressureArtifactWarmJobPayload,
-        claimToken: UUID,
-        localPath: String,
-        byteSize: Int64,
-        on database: any Database
-    ) async throws -> Bool {
-        guard let sql = database as? any SQLDatabase else {
-            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
-        }
-
-        let updatedRow = try await sql.raw("""
-            UPDATE pressure_artifact_catalog
-            SET status = \(bind: PressureArtifactCatalogStatus.ready.rawValue),
-                source = \(bind: PressureArtifactCatalogSource.aws.rawValue),
-                last_checked_at = NOW(),
-                error_summary = NULL,
-                local_path = \(bind: localPath),
-                byte_size = \(bind: byteSize),
-                claim_token = NULL,
-                lease_expires_at = NULL
-            WHERE run_time = \(bind: payload.runTime)
-              AND forecast_hour = \(bind: payload.forecastHour)
-              AND product = \(bind: payload.product.rawValue)
-              AND field_set_version = \(bind: payload.fieldSetVersion.rawValue)
-              AND status = \(bind: PressureArtifactCatalogStatus.warming.rawValue)
-              AND claim_token = \(bind: claimToken)
-            RETURNING id
-            """)
-            .first()
-
-        return updatedRow != nil
-    }
-
-    func markFailed(
-        payload: PressureArtifactWarmJobPayload,
-        claimToken: UUID,
-        error: any Error,
-        on database: any Database
-    ) async throws -> Bool {
-        guard let sql = database as? any SQLDatabase else {
-            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
-        }
-
-        let updatedRow = try await sql.raw("""
-            UPDATE pressure_artifact_catalog
-            SET status = \(bind: PressureArtifactCatalogStatus.failed.rawValue),
-                source = \(bind: PressureArtifactCatalogSource.aws.rawValue),
-                last_checked_at = NOW(),
-                error_summary = \(bind: String(reflecting: error)),
-                local_path = NULL,
-                byte_size = NULL,
-                claim_token = NULL,
-                lease_expires_at = NULL
-            WHERE run_time = \(bind: payload.runTime)
-              AND forecast_hour = \(bind: payload.forecastHour)
-              AND product = \(bind: payload.product.rawValue)
-              AND field_set_version = \(bind: payload.fieldSetVersion.rawValue)
-              AND status = \(bind: PressureArtifactCatalogStatus.warming.rawValue)
-              AND claim_token = \(bind: claimToken)
-            RETURNING id
-            """)
-            .first()
-
-        return updatedRow != nil
     }
 
     func claimLostMetadata(

--- a/Tests/AppTests/PressureArtifactWarmJobTests.swift
+++ b/Tests/AppTests/PressureArtifactWarmJobTests.swift
@@ -343,42 +343,29 @@ struct PressureArtifactWarmJobTests {
 
     @Test("warm claim stores a token and lease")
     func warmClaimStoresATokenAndLease() async throws {
-        try await withApp { app, blockingWorkExecutor in
+        try await withApp { app, _ in
             let payload = makePayload()
-            let sourceURLs = makeSourceURLs(for: payload)
             try await seedCatalogRow(status: .pending, payload: payload, on: app.db)
 
-            let client = PressureArtifactWarmStubHTTPClient(
-                idxResponses: [sourceURLs.idx.absoluteString: Data(makeCompleteInventoryText().utf8)],
-                rangeResponses: makeRangeResponses(for: payload)
-            )
-            let validator = PressureArtifactWarmValidatorStub(lineCount: makeExpectedValidationLineCount())
-            let service = PressureArtifactWarmingService(
-                httpClient: client,
-                blockingWorkExecutor: blockingWorkExecutor,
-                validator: validator,
-                cacheRootURL: testRootURL(),
-                dateProvider: FixedStormSetupDateProvider(nowDate: makeDate()),
-                retentionDuration: serviceRetentionSeconds,
-                maximumByteCount: serviceMaximumByteCount,
-                recoveryTimeoutSeconds: 1_800
-            )
+            let store = PressureArtifactCatalogStore()
             let claimToken = UUID()
-            let row = try #require(try await service.claimCatalogRow(
+            let leaseExpiresAt = makeDate().addingTimeInterval(1_800)
+            let row = try #require(try await store.claimCatalogRow(
                 for: payload,
                 claimToken: claimToken,
+                leaseExpiresAt: leaseExpiresAt,
                 on: app.db
             ))
 
             #expect(row.status == .warming)
-            #expect(row.claimToken != nil)
-            #expect(row.leaseExpiresAt != nil)
+            #expect(row.claimToken == claimToken)
+            #expect(row.leaseExpiresAt == leaseExpiresAt)
         }
     }
 
     @Test("expired claims only match the payload artifact key")
     func expiredClaimsOnlyMatchThePayloadArtifactKey() async throws {
-        try await withApp { app, blockingWorkExecutor in
+        try await withApp { app, _ in
             let payload = makePayload()
             let unrelatedPayload = makeUnrelatedPayload()
             try await seedCatalogRow(status: .expired, payload: payload, on: app.db)
@@ -395,20 +382,14 @@ struct PressureArtifactWarmJobTests {
             unrelatedRow.byteSize = 42
             try await unrelatedRow.update(on: app.db)
 
-            let service = PressureArtifactWarmingService(
-                httpClient: PressureArtifactWarmStubHTTPClient(),
-                blockingWorkExecutor: blockingWorkExecutor,
-                validator: PressureArtifactWarmValidatorStub(lineCount: 0),
-                cacheRootURL: testRootURL(),
-                dateProvider: FixedStormSetupDateProvider(nowDate: makeDate()),
-                retentionDuration: serviceRetentionSeconds,
-                maximumByteCount: serviceMaximumByteCount
-            )
+            let store = PressureArtifactCatalogStore()
             let claimToken = UUID()
+            let leaseExpiresAt = makeDate().addingTimeInterval(1_800)
 
-            let claimedRow = try #require(try await service.claimCatalogRow(
+            let claimedRow = try #require(try await store.claimCatalogRow(
                 for: payload,
                 claimToken: claimToken,
+                leaseExpiresAt: leaseExpiresAt,
                 on: app.db
             ))
 
@@ -530,27 +511,11 @@ struct PressureArtifactWarmJobTests {
 
     @Test("an old token cannot mark ready after a newer claim exists")
     func oldTokenCannotMarkReadyAfterANewerClaimExists() async throws {
-        try await withApp { app, blockingWorkExecutor in
+        try await withApp { app, _ in
             let payload = makePayload()
-            let sourceURLs = makeSourceURLs(for: payload)
             try await seedCatalogRow(status: .pending, payload: payload, on: app.db)
 
-            let client = PressureArtifactWarmStubHTTPClient(
-                idxResponses: [sourceURLs.idx.absoluteString: Data(makeCompleteInventoryText().utf8)],
-                rangeResponses: makeRangeResponses(for: payload)
-            )
-            let validator = PressureArtifactWarmValidatorStub(lineCount: makeExpectedValidationLineCount())
-            let service = PressureArtifactWarmingService(
-                httpClient: client,
-                blockingWorkExecutor: blockingWorkExecutor,
-                validator: validator,
-                cacheRootURL: testRootURL(),
-                dateProvider: FixedStormSetupDateProvider(nowDate: makeDate()),
-                retentionDuration: serviceRetentionSeconds,
-                maximumByteCount: serviceMaximumByteCount,
-                recoveryTimeoutSeconds: 1_800
-            )
-
+            let store = PressureArtifactCatalogStore()
             let claimToken = UUID()
             let row = try #require(try await PressureArtifactCatalogModel.find(
                 runTime: payload.runTime,
@@ -564,7 +529,7 @@ struct PressureArtifactWarmJobTests {
             row.leaseExpiresAt = makeDate().addingTimeInterval(1_800)
             try await row.update(on: app.db)
 
-            let result = try await service.markReady(
+            let result = try await store.markReady(
                 payload: payload,
                 claimToken: claimToken,
                 localPath: "/tmp/pressure-artifact.grib2",
@@ -584,6 +549,51 @@ struct PressureArtifactWarmJobTests {
             #expect(refetched.status == .warming)
             #expect(refetched.claimToken != nil)
             #expect(refetched.leaseExpiresAt != nil)
+        }
+    }
+
+    @Test("an old token cannot mark failed after a newer claim exists")
+    func oldTokenCannotMarkFailedAfterANewerClaimExists() async throws {
+        try await withApp { app, _ in
+            let payload = makePayload()
+            try await seedCatalogRow(status: .pending, payload: payload, on: app.db)
+
+            let store = PressureArtifactCatalogStore()
+            let claimToken = UUID()
+            let newerClaimToken = UUID()
+            let leaseExpiresAt = makeDate().addingTimeInterval(1_800)
+            let row = try #require(try await PressureArtifactCatalogModel.find(
+                runTime: payload.runTime,
+                forecastHour: payload.forecastHour,
+                product: payload.product,
+                fieldSetVersion: payload.fieldSetVersion,
+                on: app.db
+            ))
+            row.status = .warming
+            row.claimToken = newerClaimToken
+            row.leaseExpiresAt = leaseExpiresAt
+            try await row.update(on: app.db)
+
+            let result = try await store.markFailed(
+                payload: payload,
+                claimToken: claimToken,
+                errorSummary: "stale owner failure",
+                on: app.db
+            )
+
+            #expect(result == false)
+            let refetched = try #require(try await PressureArtifactCatalogModel.find(
+                runTime: payload.runTime,
+                forecastHour: payload.forecastHour,
+                product: payload.product,
+                fieldSetVersion: payload.fieldSetVersion,
+                on: app.db
+            ))
+
+            #expect(refetched.status == .warming)
+            #expect(refetched.claimToken == newerClaimToken)
+            #expect(refetched.leaseExpiresAt == leaseExpiresAt)
+            #expect(refetched.errorSummary == nil)
         }
     }
 

--- a/docs/plans/architecture-recovery-progress.md
+++ b/docs/plans/architecture-recovery-progress.md
@@ -181,11 +181,17 @@ This ledger tracks the sequential, behavior-preserving architecture recovery cam
 
 ### Issue #163 - 10: Own warm claim/completion SQL
 
-- **Status:** Pending
+- **Status:** READY FOR COMMIT
 - **Roadmap:** Slice 10
 - **Execution profile:** `gpt-5.6-sol`, high reasoning
 - **Dependencies:** 02
 - **Stop condition:** Warm transition SQL has one owner with identical predicates.
+- **Files changed:** `Sources/App/Models/Data/PressureArtifactCatalogStore.swift`, `Sources/App/StormSetup/PressureArtifactWarmingService.swift`, `Tests/AppTests/PressureArtifactWarmJobTests.swift`, and this progress entry.
+- **Behavior:** A concrete, stateless `PressureArtifactCatalogStore` now owns ensure-row, conditional warm claim, claim-fenced ready completion, and claim-fenced failed completion. `PressureArtifactWarmingService` computes the same clamped lease expiration, delegates those four transitions at the same orchestration points, and retains current-row skip lookup, acquisition, validation, cancellation, claim-loss logging, and error propagation behavior. The moved SQL preserves its artifact-key predicates, claim eligibility, mutations, fencing, `RETURNING` behavior, and follow-up model lookup.
+- **Coverage:** Retargeted direct warm-claim, exact-key, and stale-token ready-completion tests to the store. Added deterministic coverage proving an old token cannot mark failed or alter the newer owner’s token, lease, status, or error state.
+- **Validation:** Pre-change `swift test --filter PressureArtifactWarmJobTests` passed (17 tests) and `swift test --filter PressureArtifactCatalogTests` passed (9 tests). Post-change `swift test --filter PressureArtifactWarmJobTests` passed (18 tests); `swift test --filter PressureArtifactCatalogTests` passed (9 tests); `swift test --parallel --num-workers 8 --filter PressureArtifactWarmJobTests` passed (18 tests); and `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` passed with only the pre-existing `ArcusEvent.title` deprecation warning. The issue-scoped tracked diff check and four-file trailing-whitespace scan passed; unscoped `git diff --check` remains blocked only by the pre-existing `docs/Sql/Device.sql:48` trailing whitespace.
+- **Review:** Human review completed with no suggested changes. The independent defect reviewer reported no actionable findings and independently reran the warm suite (18 tests passed). The independent test auditor reported no actionable findings, mapped every acceptance criterion to coverage, and found the evidence sufficient for commit. There were no disagreements, accepted findings, fixes, or affected-area re-review requirements. Final full-diff review found no SQL, concurrency, cancellation, persistence, or scope drift.
+- **Residual risk / handoff:** The pre-existing claim-update/follow-up-lookup race window is intentionally preserved rather than redesigned. Probe, cleanup, lookup, dashboard, model, schema, migration, warm-job composition, cache, HTTP, validation, scheduler, and queue behavior are unchanged. Ready for commit.
 
 ### Issue #164 - 11: Own probe catalog transitions
 


### PR DESCRIPTION
# Summary
Moves the pressure-artifact warm transition SQL into a dedicated catalog store while preserving the existing claim eligibility, claim fencing, mutations, and warming-service orchestration.

# What Changed
- Added `PressureArtifactCatalogStore` for catalog-row creation, warm claims, ready completion, and failed completion.
- Updated `PressureArtifactWarmingService` to delegate those transitions while retaining acquisition, validation, cancellation, and claim-loss handling.
- Retargeted warm-job transition tests to the store and added coverage for stale-token failed completion.
- Updated the architecture recovery progress ledger for issue #163.

# User Impact
No intentional user-facing behavior change. Pressure-artifact warming retains its existing persistence transitions and concurrent claim semantics while the SQL ownership becomes explicit.

# Testing
- `swift test --filter PressureArtifactWarmJobTests` passed: 18 tests.
- `swift test --filter PressureArtifactCatalogTests` passed: 9 tests.
- `swift test --parallel --num-workers 8 --filter PressureArtifactWarmJobTests` passed: 18 tests.
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` passed.
- `git diff --check` passed for the committed branch range.

# Notes
- Probe, cleanup, lookup, dashboard, schema, migration, cache, HTTP, validation, scheduler, and queue behavior are outside this change.
- Uncommitted edits in `docs/Sql/Device.sql`, `docs/audits/weekly-bug-scan.md`, and `docs/audits/weekly-test-gap-audit.md` were intentionally excluded.

Closes #163