### PR TITLE
Give probe catalog transitions one owner

### DIFF
--- a/Sources/App/Models/Data/PressureArtifactCatalogStore.swift
+++ b/Sources/App/Models/Data/PressureArtifactCatalogStore.swift
@@ -157,4 +157,183 @@ struct PressureArtifactCatalogStore: Sendable {
 
         return updatedRow != nil
     }
+
+    func claimWarmableCatalogRow(
+        for payload: PressureArtifactWarmJobPayload,
+        recoveryCutoff: Date,
+        on database: any Database
+    ) async throws -> Bool {
+        guard let sql = database as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        let row = try await sql.raw("""
+            INSERT INTO pressure_artifact_catalog (
+                id,
+                run_time,
+                forecast_hour,
+                valid_time,
+                product,
+                field_set_version,
+                status,
+                source,
+                last_checked_at,
+                error_summary,
+                local_path,
+                byte_size,
+                claim_token,
+                lease_expires_at
+            ) VALUES (
+                gen_random_uuid(),
+                \(bind: payload.runTime),
+                \(bind: payload.forecastHour),
+                \(bind: payload.validTime),
+                \(bind: payload.product.rawValue),
+                \(bind: payload.fieldSetVersion.rawValue),
+                \(bind: PressureArtifactCatalogStatus.pending.rawValue),
+                \(bind: PressureArtifactCatalogSource.aws.rawValue),
+                NOW(),
+                NULL,
+                NULL,
+                NULL,
+                NULL,
+                NULL
+            )
+            ON CONFLICT (run_time, forecast_hour, product, field_set_version)
+            DO UPDATE SET
+                status = \(bind: PressureArtifactCatalogStatus.pending.rawValue),
+                source = \(bind: PressureArtifactCatalogSource.aws.rawValue),
+                last_checked_at = NOW(),
+                error_summary = NULL,
+                local_path = NULL,
+                byte_size = NULL,
+                claim_token = NULL,
+                lease_expires_at = NULL
+            WHERE pressure_artifact_catalog.status IN (
+                \(bind: PressureArtifactCatalogStatus.failed.rawValue)
+            )
+            OR (
+                pressure_artifact_catalog.status = \(bind: PressureArtifactCatalogStatus.pending.rawValue)
+                AND pressure_artifact_catalog.last_checked_at < \(bind: recoveryCutoff)
+            )
+            OR (
+                pressure_artifact_catalog.status = \(bind: PressureArtifactCatalogStatus.warming.rawValue)
+                AND (
+                    pressure_artifact_catalog.lease_expires_at IS NULL
+                    OR pressure_artifact_catalog.lease_expires_at <= NOW()
+                )
+            )
+            OR (
+                pressure_artifact_catalog.status = \(bind: PressureArtifactCatalogStatus.expired.rawValue)
+                AND pressure_artifact_catalog.claim_token IS NULL
+                AND (
+                    pressure_artifact_catalog.lease_expires_at IS NULL
+                    OR pressure_artifact_catalog.lease_expires_at <= NOW()
+                )
+            )
+            RETURNING id
+            """)
+            .first()
+
+        return row != nil
+    }
+
+    func recoverUnusableReadyCatalogRow(
+        for payload: PressureArtifactWarmJobPayload,
+        on database: any Database
+    ) async throws -> Bool {
+        guard let sql = database as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        let updatedRow = try await sql.raw("""
+            UPDATE pressure_artifact_catalog
+            SET status = \(bind: PressureArtifactCatalogStatus.pending.rawValue),
+                source = \(bind: PressureArtifactCatalogSource.aws.rawValue),
+                last_checked_at = NOW(),
+                error_summary = NULL,
+                local_path = NULL,
+                byte_size = NULL,
+                claim_token = NULL,
+                lease_expires_at = NULL
+            WHERE run_time = \(bind: payload.runTime)
+              AND forecast_hour = \(bind: payload.forecastHour)
+              AND product = \(bind: payload.product.rawValue)
+              AND field_set_version = \(bind: payload.fieldSetVersion.rawValue)
+              AND status = \(bind: PressureArtifactCatalogStatus.ready.rawValue)
+            RETURNING id
+            """)
+            .first()
+
+        return updatedRow != nil
+    }
+
+    func markUnavailability(
+        payload: PressureArtifactWarmJobPayload,
+        errorSummary: String,
+        on database: any Database
+    ) async throws {
+        guard let sql = database as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        _ = try await sql.raw("""
+            INSERT INTO pressure_artifact_catalog (
+                id,
+                run_time,
+                forecast_hour,
+                valid_time,
+                product,
+                field_set_version,
+                status,
+                source,
+                last_checked_at,
+                error_summary
+            ) VALUES (
+                gen_random_uuid(),
+                \(bind: payload.runTime),
+                \(bind: payload.forecastHour),
+                \(bind: payload.validTime),
+                \(bind: payload.product.rawValue),
+                \(bind: payload.fieldSetVersion.rawValue),
+                \(bind: PressureArtifactCatalogStatus.failed.rawValue),
+                \(bind: PressureArtifactCatalogSource.aws.rawValue),
+                NOW(),
+                \(bind: errorSummary)
+            )
+            ON CONFLICT (run_time, forecast_hour, product, field_set_version)
+            DO UPDATE SET
+                last_checked_at = NOW()
+            RETURNING id
+            """)
+            .first()
+    }
+
+    func markProbeFailure(
+        payload: PressureArtifactWarmJobPayload,
+        errorSummary: String,
+        on database: any Database
+    ) async throws {
+        guard let sql = database as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        _ = try await sql.raw("""
+            UPDATE pressure_artifact_catalog
+            SET status = \(bind: PressureArtifactCatalogStatus.failed.rawValue),
+                source = \(bind: PressureArtifactCatalogSource.aws.rawValue),
+                last_checked_at = NOW(),
+                error_summary = \(bind: errorSummary),
+                local_path = NULL,
+                byte_size = NULL,
+                claim_token = NULL,
+                lease_expires_at = NULL
+            WHERE run_time = \(bind: payload.runTime)
+              AND forecast_hour = \(bind: payload.forecastHour)
+              AND product = \(bind: payload.product.rawValue)
+              AND field_set_version = \(bind: payload.fieldSetVersion.rawValue)
+            RETURNING id
+            """)
+            .first()
+    }
 }

--- a/Sources/App/StormSetup/HRRRPressureArtifactProbeService.swift
+++ b/Sources/App/StormSetup/HRRRPressureArtifactProbeService.swift
@@ -54,6 +54,7 @@ struct HRRRPressureArtifactProbeService: HRRRPressureArtifactProbing {
     private let dateProvider: any StormSetupDateProviding
     private let recoveryTimeoutSeconds: TimeInterval
     private let urlBuilder: HrrrPressureDirectObjectURLBuilder
+    private let catalogStore: PressureArtifactCatalogStore
 
     init(
         runResolver: any HrrrRunResolving = DefaultHrrrRunResolver(),
@@ -62,7 +63,8 @@ struct HRRRPressureArtifactProbeService: HRRRPressureArtifactProbing {
         blockingWorkExecutor: any PressureArtifactBlockingWorkExecuting,
         dateProvider: any StormSetupDateProviding = SystemStormSetupDateProvider(),
         recoveryTimeoutSeconds: TimeInterval = 30 * 60,
-        urlBuilder: HrrrPressureDirectObjectURLBuilder = HrrrPressureDirectObjectURLBuilder()
+        urlBuilder: HrrrPressureDirectObjectURLBuilder = HrrrPressureDirectObjectURLBuilder(),
+        catalogStore: PressureArtifactCatalogStore = PressureArtifactCatalogStore()
     ) {
         self.runResolver = runResolver
         self.remoteObjectChecker = remoteObjectChecker
@@ -71,6 +73,7 @@ struct HRRRPressureArtifactProbeService: HRRRPressureArtifactProbing {
         self.dateProvider = dateProvider
         self.recoveryTimeoutSeconds = max(1, recoveryTimeoutSeconds)
         self.urlBuilder = urlBuilder
+        self.catalogStore = catalogStore
     }
 
     static func makeDefault(application: Application) -> HRRRPressureArtifactProbeService {
@@ -158,9 +161,9 @@ struct HRRRPressureArtifactProbeService: HRRRPressureArtifactProbing {
                             return
                         }
 
-                        guard try await recoverUnusableReadyCatalogRow(
-                            currentRow,
-                            payload: payload,
+                        try requireSQLDatabase(application.db)
+                        guard try await catalogStore.recoverUnusableReadyCatalogRow(
+                            for: payload,
                             on: application.db
                         ) else {
                             logger.info(
@@ -199,7 +202,8 @@ struct HRRRPressureArtifactProbeService: HRRRPressureArtifactProbing {
                     }
 
                     try Task.checkCancellation()
-                    guard try await claimWarmableCatalogRow(
+                    try requireSQLDatabase(application.db)
+                    guard try await catalogStore.claimWarmableCatalogRow(
                         for: payload,
                         recoveryCutoff: recoveryCutoff,
                         on: application.db
@@ -239,9 +243,10 @@ struct HRRRPressureArtifactProbeService: HRRRPressureArtifactProbing {
                     return
                 } catch {
                     try rethrowCancellationIfNeeded(error)
-                    try await markProbeFailure(
+                    try requireSQLDatabase(application.db)
+                    try await catalogStore.markProbeFailure(
                         payload: payload,
-                        error: error,
+                        errorSummary: String(reflecting: error),
                         on: application.db
                     )
                     logger.error(
@@ -260,10 +265,10 @@ struct HRRRPressureArtifactProbeService: HRRRPressureArtifactProbing {
             }
 
             try Task.checkCancellation()
-            try await markUnavailability(
+            try requireSQLDatabase(application.db)
+            try await catalogStore.markUnavailability(
                 payload: payload,
-                idxURL: idxURL,
-                idxProbe: idxProbe,
+                errorSummary: makeUnavailableSummary(idxURL: idxURL, idxProbe: idxProbe),
                 on: application.db
             )
             logger.info(
@@ -295,185 +300,10 @@ private extension HRRRPressureArtifactProbeService {
         )
     }
 
-    func claimWarmableCatalogRow(
-        for payload: PressureArtifactWarmJobPayload,
-        recoveryCutoff: Date,
-        on database: any Database
-    ) async throws -> Bool {
-        guard let sql = database as? any SQLDatabase else {
+    func requireSQLDatabase(_ database: any Database) throws {
+        guard database is any SQLDatabase else {
             throw HRRRPressureArtifactProbeError.databaseNotSQL
         }
-
-        let row = try await sql.raw("""
-            INSERT INTO pressure_artifact_catalog (
-                id,
-                run_time,
-                forecast_hour,
-                valid_time,
-                product,
-                field_set_version,
-                status,
-                source,
-                last_checked_at,
-                error_summary,
-                local_path,
-                byte_size,
-                claim_token,
-                lease_expires_at
-            ) VALUES (
-                gen_random_uuid(),
-                \(bind: payload.runTime),
-                \(bind: payload.forecastHour),
-                \(bind: payload.validTime),
-                \(bind: payload.product.rawValue),
-                \(bind: payload.fieldSetVersion.rawValue),
-                \(bind: PressureArtifactCatalogStatus.pending.rawValue),
-                \(bind: PressureArtifactCatalogSource.aws.rawValue),
-                NOW(),
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL
-            )
-            ON CONFLICT (run_time, forecast_hour, product, field_set_version)
-            DO UPDATE SET
-                status = \(bind: PressureArtifactCatalogStatus.pending.rawValue),
-                source = \(bind: PressureArtifactCatalogSource.aws.rawValue),
-                last_checked_at = NOW(),
-                error_summary = NULL,
-                local_path = NULL,
-                byte_size = NULL,
-                claim_token = NULL,
-                lease_expires_at = NULL
-            WHERE pressure_artifact_catalog.status IN (
-                \(bind: PressureArtifactCatalogStatus.failed.rawValue)
-            )
-            OR (
-                pressure_artifact_catalog.status = \(bind: PressureArtifactCatalogStatus.pending.rawValue)
-                AND pressure_artifact_catalog.last_checked_at < \(bind: recoveryCutoff)
-            )
-            OR (
-                pressure_artifact_catalog.status = \(bind: PressureArtifactCatalogStatus.warming.rawValue)
-                AND (
-                    pressure_artifact_catalog.lease_expires_at IS NULL
-                    OR pressure_artifact_catalog.lease_expires_at <= NOW()
-                )
-            )
-            OR (
-                pressure_artifact_catalog.status = \(bind: PressureArtifactCatalogStatus.expired.rawValue)
-                AND pressure_artifact_catalog.claim_token IS NULL
-                AND (
-                    pressure_artifact_catalog.lease_expires_at IS NULL
-                    OR pressure_artifact_catalog.lease_expires_at <= NOW()
-                )
-            )
-            RETURNING id
-            """)
-            .first()
-
-        return row != nil
-    }
-
-    func recoverUnusableReadyCatalogRow(
-        _ row: PressureArtifactCatalogModel,
-        payload: PressureArtifactWarmJobPayload,
-        on database: any Database
-    ) async throws -> Bool {
-        guard let sql = database as? any SQLDatabase else {
-            throw HRRRPressureArtifactProbeError.databaseNotSQL
-        }
-
-        let updatedRow = try await sql.raw("""
-            UPDATE pressure_artifact_catalog
-            SET status = \(bind: PressureArtifactCatalogStatus.pending.rawValue),
-                source = \(bind: PressureArtifactCatalogSource.aws.rawValue),
-                last_checked_at = NOW(),
-                error_summary = NULL,
-                local_path = NULL,
-                byte_size = NULL,
-                claim_token = NULL,
-                lease_expires_at = NULL
-            WHERE run_time = \(bind: payload.runTime)
-              AND forecast_hour = \(bind: payload.forecastHour)
-              AND product = \(bind: payload.product.rawValue)
-              AND field_set_version = \(bind: payload.fieldSetVersion.rawValue)
-              AND status = \(bind: PressureArtifactCatalogStatus.ready.rawValue)
-            RETURNING id
-            """)
-            .first()
-
-        return updatedRow != nil
-    }
-
-    func markUnavailability(
-        payload: PressureArtifactWarmJobPayload,
-        idxURL: URL,
-        idxProbe: HrrrRemoteObjectProbeResult,
-        on database: any Database
-    ) async throws {
-        guard let sql = database as? any SQLDatabase else {
-            throw HRRRPressureArtifactProbeError.databaseNotSQL
-        }
-
-        _ = try await sql.raw("""
-            INSERT INTO pressure_artifact_catalog (
-                id,
-                run_time,
-                forecast_hour,
-                valid_time,
-                product,
-                field_set_version,
-                status,
-                source,
-                last_checked_at,
-                error_summary
-            ) VALUES (
-                gen_random_uuid(),
-                \(bind: payload.runTime),
-                \(bind: payload.forecastHour),
-                \(bind: payload.validTime),
-                \(bind: payload.product.rawValue),
-                \(bind: payload.fieldSetVersion.rawValue),
-                \(bind: PressureArtifactCatalogStatus.failed.rawValue),
-                \(bind: PressureArtifactCatalogSource.aws.rawValue),
-                NOW(),
-                \(bind: makeUnavailableSummary(idxURL: idxURL, idxProbe: idxProbe))
-            )
-            ON CONFLICT (run_time, forecast_hour, product, field_set_version)
-            DO UPDATE SET
-                last_checked_at = NOW()
-            RETURNING id
-            """)
-            .first()
-    }
-
-    func markProbeFailure(
-        payload: PressureArtifactWarmJobPayload,
-        error: any Error,
-        on database: any Database
-    ) async throws {
-        guard let sql = database as? any SQLDatabase else {
-            throw HRRRPressureArtifactProbeError.databaseNotSQL
-        }
-
-        _ = try await sql.raw("""
-            UPDATE pressure_artifact_catalog
-            SET status = \(bind: PressureArtifactCatalogStatus.failed.rawValue),
-                source = \(bind: PressureArtifactCatalogSource.aws.rawValue),
-                last_checked_at = NOW(),
-                error_summary = \(bind: String(reflecting: error)),
-                local_path = NULL,
-                byte_size = NULL,
-                claim_token = NULL,
-                lease_expires_at = NULL
-            WHERE run_time = \(bind: payload.runTime)
-              AND forecast_hour = \(bind: payload.forecastHour)
-              AND product = \(bind: payload.product.rawValue)
-              AND field_set_version = \(bind: payload.fieldSetVersion.rawValue)
-            RETURNING id
-            """)
-            .first()
     }
 
     func isUsableReadyCatalogRow(_ row: PressureArtifactCatalogModel) async throws -> Bool {

--- a/Tests/AppTests/HRRRPressureArtifactProbeServiceTests.swift
+++ b/Tests/AppTests/HRRRPressureArtifactProbeServiceTests.swift
@@ -8,14 +8,17 @@ import Vapor
 
 @Suite("HRRR pressure artifact probe service", .serialized)
 struct HRRRPressureArtifactProbeServiceTests {
-    @Test("probe does not enqueue when idx is unavailable and updates lastCheckedAt")
-    func probeDoesNotEnqueueWhenIdxIsUnavailableAndUpdatesLastCheckedAt() async throws {
+    @Test("unavailable idx conflicts update only lastCheckedAt")
+    func unavailableIdxConflictsUpdateOnlyLastCheckedAt() async throws {
         try await withApp { app, _ in
             let surfaceCandidate = makeSurfaceCandidate()
             let pressureCandidate = makePressureCandidate(from: surfaceCandidate)
             let payload = makePayload(from: pressureCandidate)
             let remoteChecker = ProbeStubHrrrRemoteObjectChecking()
             let dispatcher = WarmJobDispatcherRecorder()
+            let originalLastCheckedAt = makeUTCDate(year: 2026, month: 6, day: 3, hour: 12)
+            let originalLeaseExpiresAt = makeUTCDate(year: 2026, month: 6, day: 3, hour: 14)
+            let originalClaimToken = UUID()
             let service = makeService(
                 remoteChecker: remoteChecker,
                 dispatcher: dispatcher,
@@ -24,7 +27,17 @@ struct HRRRPressureArtifactProbeServiceTests {
                 now: makeUTCDate(year: 2026, month: 6, day: 3, hour: 13)
             )
 
-            try await seedCatalogRow(status: .failed, payload: payload, lastCheckedAt: nil, on: app.db)
+            try await seedCatalogRow(
+                status: .warming,
+                payload: payload,
+                lastCheckedAt: originalLastCheckedAt,
+                leaseExpiresAt: originalLeaseExpiresAt,
+                claimToken: originalClaimToken,
+                localPath: "/tmp/preserved.grib2",
+                byteSize: 42,
+                errorSummary: "preserved error",
+                on: app.db
+            )
 
             try await service.probe(on: app, logger: app.logger)
 
@@ -37,9 +50,65 @@ struct HRRRPressureArtifactProbeServiceTests {
             ))
 
             #expect(dispatcher.dispatches.isEmpty)
-            #expect(row.status == .failed)
-            #expect(row.lastCheckedAt != nil)
+            #expect(row.status == .warming)
+            #expect(row.source == .unknown)
+            #expect(row.errorSummary == "preserved error")
+            #expect(row.localPath == "/tmp/preserved.grib2")
+            #expect(row.byteSize == 42)
+            #expect(row.claimToken == originalClaimToken)
+            #expect(row.leaseExpiresAt == originalLeaseExpiresAt)
+            #expect(try #require(row.lastCheckedAt) > originalLastCheckedAt)
             #expect(remoteChecker.requestedURLs == [makeIdxURL(for: pressureCandidate).absoluteString])
+        }
+    }
+
+    @Test("dispatch failure marks the row failed and rethrows the original error")
+    func dispatchFailureMarksRowFailedAndRethrowsOriginalError() async throws {
+        try await withApp { app, _ in
+            let surfaceCandidate = makeSurfaceCandidate()
+            let pressureCandidate = makePressureCandidate(from: surfaceCandidate)
+            let payload = makePayload(from: pressureCandidate)
+            let idxURL = makeIdxURL(for: pressureCandidate)
+            let dispatchError = ProbeWarmJobDispatcherError.dispatchFailed
+            let service = makeService(
+                remoteChecker: ProbeStubHrrrRemoteObjectChecking(availableURLs: [idxURL.absoluteString: true]),
+                dispatcher: ThrowingWarmJobDispatcher(error: dispatchError),
+                blockingWorkExecutor: makePressureArtifactBlockingWorkExecutor(application: app),
+                runResolution: HrrrRunResolution(targetValidTime: surfaceCandidate.validTime, candidates: [surfaceCandidate]),
+                now: makeUTCDate(year: 2026, month: 6, day: 3, hour: 13)
+            )
+
+            try await seedCatalogRow(
+                status: .failed,
+                payload: payload,
+                lastCheckedAt: makeUTCDate(year: 2026, month: 6, day: 3, hour: 12),
+                leaseExpiresAt: makeUTCDate(year: 2026, month: 6, day: 3, hour: 14),
+                claimToken: UUID(),
+                localPath: "/tmp/stale.grib2",
+                byteSize: 42,
+                errorSummary: "stale error",
+                on: app.db
+            )
+
+            await #expect(throws: ProbeWarmJobDispatcherError.self) {
+                try await service.probe(on: app, logger: app.logger)
+            }
+
+            let row = try #require(try await PressureArtifactCatalogModel.find(
+                runTime: payload.runTime,
+                forecastHour: payload.forecastHour,
+                product: payload.product,
+                fieldSetVersion: payload.fieldSetVersion,
+                on: app.db
+            ))
+
+            #expect(row.status == .failed)
+            #expect(row.source == .aws)
+            #expect(row.errorSummary == String(reflecting: dispatchError))
+            #expect(row.localPath == nil)
+            #expect(row.byteSize == nil)
+            #expect(row.claimToken == nil)
+            #expect(row.leaseExpiresAt == nil)
         }
     }
 
@@ -552,6 +621,7 @@ private extension HRRRPressureArtifactProbeServiceTests {
         claimToken: UUID? = nil,
         localPath: String? = nil,
         byteSize: Int64? = nil,
+        errorSummary: String? = nil,
         on db: any Database
     ) async throws {
         let row = PressureArtifactCatalogModel(
@@ -564,7 +634,8 @@ private extension HRRRPressureArtifactProbeServiceTests {
             localPath: localPath,
             byteSize: byteSize,
             claimToken: claimToken,
-            lastCheckedAt: lastCheckedAt
+            lastCheckedAt: lastCheckedAt,
+            errorSummary: errorSummary
         )
         row.leaseExpiresAt = leaseExpiresAt
         try await row.create(on: db)
@@ -661,6 +732,25 @@ private final class CancellingProbeHrrrRemoteObjectChecking: HrrrRemoteObjectChe
         }
 
         throw CancellationError()
+    }
+}
+
+private enum ProbeWarmJobDispatcherError: Error {
+    case dispatchFailed
+}
+
+private struct ThrowingWarmJobDispatcher: PressureArtifactWarmJobDispatching {
+    let error: ProbeWarmJobDispatcherError
+
+    func dispatch(
+        _ payload: PressureArtifactWarmJobPayload,
+        to queueName: QueueName,
+        on application: Application
+    ) async throws {
+        _ = payload
+        _ = queueName
+        _ = application
+        throw error
     }
 }
 

--- a/docs/plans/architecture-recovery-progress.md
+++ b/docs/plans/architecture-recovery-progress.md
@@ -41,7 +41,7 @@ This ledger tracks the sequential, behavior-preserving architecture recovery cam
 | 08 | [#161](https://github.com/justinrooks/arcus-signal/issues/161) | 8 | Extract NWS transaction script | 07 | `gpt-5.6-sol`, high + senior review | Pending |
 | 09 | [#162](https://github.com/justinrooks/arcus-signal/issues/162) | 9 | Recover explicit API dependency ownership | 02 | `gpt-5.6-sol`, high | READY FOR COMMIT |
 | 10 | [#163](https://github.com/justinrooks/arcus-signal/issues/163) | 10 | Own warm claim/completion SQL | 02 | `gpt-5.6-sol`, high | Pending |
-| 11 | [#164](https://github.com/justinrooks/arcus-signal/issues/164) | 11A | Own probe catalog transitions | 10 | `gpt-5.6-sol`, high | Pending |
+| 11 | [#164](https://github.com/justinrooks/arcus-signal/issues/164) | 11A | Own probe catalog transitions | 10 | `gpt-5.6-sol`, high | READY FOR COMMIT |
 | 12 | [#165](https://github.com/justinrooks/arcus-signal/issues/165) | 11B | Own cleanup catalog transitions | 10, 11 | `gpt-5.6-sol`, high + persistence/filesystem review | Pending |
 | 13 | [#166](https://github.com/justinrooks/arcus-signal/issues/166) | 12 | Move request cache I/O to bounded executor | 09 | `gpt-5.6-sol`, high | Pending |
 | 14 | [#167](https://github.com/justinrooks/arcus-signal/issues/167) | 13 | Clarify Storm Setup candidate attempts | 02, 09, 13 | `gpt-5.6-sol`, high | Pending |
@@ -195,11 +195,17 @@ This ledger tracks the sequential, behavior-preserving architecture recovery cam
 
 ### Issue #164 - 11: Own probe catalog transitions
 
-- **Status:** Pending
+- **Status:** READY FOR COMMIT
 - **Roadmap:** Slice 11A
 - **Execution profile:** `gpt-5.6-sol`, high reasoning
 - **Dependencies:** 10
 - **Stop condition:** Probe transition SQL has one owner; discovery unchanged.
+- **Files changed:** `Sources/App/Models/Data/PressureArtifactCatalogStore.swift`, `Sources/App/StormSetup/HRRRPressureArtifactProbeService.swift`, `Tests/AppTests/HRRRPressureArtifactProbeServiceTests.swift`, and this progress entry.
+- **Behavior:** The existing concrete, stateless catalog store now owns warmable-row claim/upsert, unusable-ready recovery, remote-unavailability persistence, and probe-failure persistence. The probe injects that store through a trailing defaulted initializer parameter, passes persistence-ready summaries, and retains candidate discovery and ordering, remote probing, model lookup, ready-file validation, recovery decisions, dispatch gating, cancellation, logging, and the existing `databaseNotSQL` error contract. The moved SQL preserves its predicates, bindings, mutations, `NOW()`, and `RETURNING` behavior.
+- **Coverage:** Strengthened the unavailable-conflict scenario to prove only `last_checked_at` changes while status, source, error, artifact metadata, claim token, and lease remain intact. Added deterministic dispatch-failure coverage proving the row becomes failed, artifact/fencing fields clear, the same reflected error is stored, and the original error is rethrown.
+- **Validation:** Pre-change `swift test --filter HRRRPressureArtifactProbeServiceTests` passed (10 tests), and the characterization-expanded suite passed before the SQL move (11 tests). Post-change probe tests passed (11 tests), `swift test --filter PressureArtifactDiagnosticsTests` passed (9 tests), and `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` passed with only the pre-existing `ArcusEvent.title` deprecation warning. Across three `swift test --parallel --num-workers 8` runs, one passed all 453 tests and two reported one issue; the reproducible unrelated failure was `DevicePresenceMigrationTests.rollback keeps expanded source values valid` with a PostgreSQL error, while that suite passed alone (1 test).
+- **Review:** Human review completed with no suggested changes. The independent defect reviewer reported no actionable findings after comparing all four moved transitions and independently reran the probe and diagnostics suites. The independent test auditor reported no actionable findings, mapped every acceptance criterion to sufficient evidence, and independently reran both focused suites. There were no disagreements, accepted findings, fixes, or affected-area re-review requirements. The auditor's two non-blocking test uncertainties were rejected as unsupported because `databaseNotSQL` and first-available control flow remain structurally unchanged; the unrelated parallel migration failure was deferred out of scope. Final full-diff review found no predicate, mutation, dispatch-order, candidate-order, cancellation, logging, concurrency, persistence, or scope drift.
+- **Residual risk / handoff:** Full parallel validation retains a pre-existing database-isolation failure outside pressure artifacts. Cleanup, warming, lookup, dashboard, model, schema, migration, queue, cache, HTTP, filesystem, and diagnostics-copy behavior are unchanged. No #165 work was included. Ready for commit.
 
 ### Issue #165 - 12: Own cleanup catalog transitions
 


### PR DESCRIPTION
# Summary
Moves pressure-probe catalog transition SQL into the shared `PressureArtifactCatalogStore` while preserving artifact discovery, candidate ordering, remote probing, dispatch control flow, and existing catalog predicates and mutations.

# What Changed
- Extended `PressureArtifactCatalogStore` with warmable-row claim, unusable-ready recovery, remote-unavailability persistence, and probe-failure transitions.
- Updated `HRRRPressureArtifactProbeService` to delegate those persistence operations while retaining discovery, probing, lookup, validation, dispatch, cancellation, logging, and error handling.
- Strengthened probe tests for conflict preservation and dispatch-failure state updates and error propagation.
- Updated the architecture recovery progress ledger for issue #164.

# User Impact
No intentional user-facing behavior change. Pressure-artifact discovery and probe decisions remain unchanged while catalog persistence has one owner.

# Testing
- `swift test --filter HRRRPressureArtifactProbeServiceTests` passed: 11 tests.
- `swift test --filter PressureArtifactDiagnosticsTests` passed: 9 tests.
- `swift test --parallel --num-workers 8` passed on rerun: 453 tests in 59 suites.
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` passed.
- `git diff --check` passed for the committed branch range.

# Notes
- The first full parallel-suite invocation reported one issue; the immediate rerun passed all 453 tests.
- Uncommitted edits in `docs/Sql/Device.sql`, `docs/audits/weekly-bug-scan.md`, and `docs/audits/weekly-test-gap-audit.md` were intentionally excluded.
- No cleanup, lookup, dashboard, state, lease, or schema work is included.

Closes #164