### PR TITLE
Give cleanup catalog transitions one owner

### DIFF
--- a/Sources/App/Models/Data/PressureArtifactCatalogStore.swift
+++ b/Sources/App/Models/Data/PressureArtifactCatalogStore.swift
@@ -4,6 +4,168 @@ import Foundation
 import Vapor
 
 struct PressureArtifactCatalogStore: Sendable {
+    func expireReadyArtifacts(
+        before cutoff: Date,
+        on database: any Database
+    ) async throws -> Int {
+        let readyRows = try await PressureArtifactCatalogModel.query(on: database)
+            .filter(\.$statusRaw == PressureArtifactCatalogStatus.ready.rawValue)
+            .all()
+
+        var expiredCount = 0
+        for row in readyRows where row.validTime < cutoff {
+            row.status = .expired
+            try await row.save(on: database)
+            expiredCount += 1
+        }
+
+        return expiredCount
+    }
+
+    func claimDeletionCandidate(
+        for row: PressureArtifactCatalogModel,
+        olderThan cutoff: Date,
+        cleanupLeaseExpiresAt: Date,
+        on database: any Database
+    ) async throws -> PressureArtifactCatalogModel? {
+        guard let rowID = row.id,
+              let sql = database as? any SQLDatabase else {
+            return nil
+        }
+
+        let claimToken = UUID()
+        let updatedRow = try await sql.raw("""
+            UPDATE pressure_artifact_catalog
+            SET claim_token = \(bind: claimToken),
+                lease_expires_at = \(bind: cleanupLeaseExpiresAt)
+            WHERE id = \(bind: rowID)
+              AND status = \(bind: PressureArtifactCatalogStatus.expired.rawValue)
+              AND updated_at <= \(bind: cutoff)
+              AND (
+                (
+                  claim_token IS NULL
+                  AND (
+                    lease_expires_at IS NULL
+                    OR lease_expires_at <= NOW()
+                  )
+                )
+                OR lease_expires_at <= NOW()
+              )
+            RETURNING id
+            """)
+            .first()
+
+        guard updatedRow != nil else {
+            return nil
+        }
+
+        return try await PressureArtifactCatalogModel.find(rowID, on: database)
+    }
+
+    func completeSuccessfulCleanup(
+        for row: PressureArtifactCatalogModel,
+        claimToken: UUID?,
+        on database: any Database
+    ) async throws -> Bool {
+        guard let claimToken,
+              let rowID = row.id,
+              let sql = database as? any SQLDatabase else {
+            return false
+        }
+
+        let updatedRow = try await sql.raw("""
+            UPDATE pressure_artifact_catalog
+            SET local_path = NULL,
+                byte_size = NULL,
+                error_summary = NULL,
+                claim_token = NULL,
+                lease_expires_at = NULL
+            WHERE id = \(bind: rowID)
+              AND status = \(bind: PressureArtifactCatalogStatus.expired.rawValue)
+              AND claim_token = \(bind: claimToken)
+            RETURNING id
+            """)
+            .first()
+
+        return updatedRow != nil
+    }
+
+    func completeFailedCleanup(
+        for row: PressureArtifactCatalogModel,
+        claimToken: UUID?,
+        reason: String,
+        on database: any Database
+    ) async throws -> Bool {
+        guard let claimToken,
+              let rowID = row.id,
+              let sql = database as? any SQLDatabase else {
+            return false
+        }
+
+        let updatedRow = try await sql.raw("""
+            UPDATE pressure_artifact_catalog
+            SET error_summary = \(bind: reason),
+                claim_token = NULL,
+                lease_expires_at = NULL
+            WHERE id = \(bind: rowID)
+              AND status = \(bind: PressureArtifactCatalogStatus.expired.rawValue)
+              AND claim_token = \(bind: claimToken)
+            RETURNING id
+            """)
+            .first()
+
+        return updatedRow != nil
+    }
+
+    func releaseCleanupClaim(
+        for row: PressureArtifactCatalogModel,
+        claimToken: UUID?,
+        on database: any Database
+    ) async throws -> Bool {
+        guard let claimToken,
+              let rowID = row.id,
+              let sql = database as? any SQLDatabase else {
+            return false
+        }
+
+        let updatedRow = try await sql.raw("""
+            UPDATE pressure_artifact_catalog
+            SET claim_token = NULL,
+                lease_expires_at = NULL
+            WHERE id = \(bind: rowID)
+              AND status = \(bind: PressureArtifactCatalogStatus.expired.rawValue)
+              AND claim_token = \(bind: claimToken)
+            RETURNING id
+            """)
+            .first()
+
+        return updatedRow != nil
+    }
+
+    func ownsCleanupClaim(
+        for row: PressureArtifactCatalogModel,
+        claimToken: UUID?,
+        on database: any Database
+    ) async throws -> Bool {
+        guard let claimToken,
+              let rowID = row.id,
+              let sql = database as? any SQLDatabase else {
+            return false
+        }
+
+        let currentRow = try await sql.raw("""
+            SELECT id
+            FROM pressure_artifact_catalog
+            WHERE id = \(bind: rowID)
+              AND status = \(bind: PressureArtifactCatalogStatus.expired.rawValue)
+              AND claim_token = \(bind: claimToken)
+            LIMIT 1
+            """)
+            .first()
+
+        return currentRow != nil
+    }
+
     func ensureCatalogRowExists(
         for payload: PressureArtifactWarmJobPayload,
         on database: any Database

--- a/Sources/App/StormSetup/PressureArtifactCleanupService.swift
+++ b/Sources/App/StormSetup/PressureArtifactCleanupService.swift
@@ -1,5 +1,4 @@
 import Fluent
-import FluentSQL
 import Foundation
 import Vapor
 
@@ -16,6 +15,7 @@ struct PressureArtifactCleanupService: PressureArtifactCleaning, @unchecked Send
     private let deleteGraceSeconds: TimeInterval
     private let recoveryTimeoutSeconds: TimeInterval
     private let beforePhysicalRemovalHook: @Sendable () async -> Void
+    private let catalogStore: PressureArtifactCatalogStore
 
     init(
         dateProvider: any StormSetupDateProviding,
@@ -25,7 +25,8 @@ struct PressureArtifactCleanupService: PressureArtifactCleaning, @unchecked Send
         maxStaleAgeSeconds: TimeInterval,
         deleteGraceSeconds: TimeInterval,
         recoveryTimeoutSeconds: TimeInterval,
-        beforePhysicalRemovalHook: @escaping @Sendable () async -> Void = {}
+        beforePhysicalRemovalHook: @escaping @Sendable () async -> Void = {},
+        catalogStore: PressureArtifactCatalogStore = PressureArtifactCatalogStore()
     ) {
         self.dateProvider = dateProvider
         self.blockingWorkExecutor = blockingWorkExecutor
@@ -35,6 +36,7 @@ struct PressureArtifactCleanupService: PressureArtifactCleaning, @unchecked Send
         self.deleteGraceSeconds = max(0, deleteGraceSeconds)
         self.recoveryTimeoutSeconds = max(1, recoveryTimeoutSeconds)
         self.beforePhysicalRemovalHook = beforePhysicalRemovalHook
+        self.catalogStore = catalogStore
     }
 
     static func makeDefault(application: Application) -> PressureArtifactCleanupService {
@@ -57,7 +59,16 @@ struct PressureArtifactCleanupService: PressureArtifactCleaning, @unchecked Send
         let cleanupLeaseExpiresAt = now.addingTimeInterval(recoveryTimeoutSeconds)
 
         let expiredRowsBeforeExpiration = try await loadExpiredRows(on: application.db)
-        try await expireReadyArtifacts(before: expirationCutoff, on: application.db, logger: logger)
+        let expiredCount = try await catalogStore.expireReadyArtifacts(
+            before: expirationCutoff,
+            on: application.db
+        )
+        if expiredCount > 0 {
+            logger.info(
+                "Pressure artifact cleanup expired ready rows.",
+                metadata: ["count": .stringConvertible(expiredCount)]
+            )
+        }
         let protectedPaths = try await loadProtectedPaths(on: application.db)
         try await deleteExpiredArtifacts(
             rows: expiredRowsBeforeExpiration,
@@ -71,30 +82,6 @@ struct PressureArtifactCleanupService: PressureArtifactCleaning, @unchecked Send
 }
 
 extension PressureArtifactCleanupService {
-    func expireReadyArtifacts(
-        before cutoff: Date,
-        on database: any Database,
-        logger: Logger
-    ) async throws {
-        let readyRows = try await PressureArtifactCatalogModel.query(on: database)
-            .filter(\.$statusRaw == PressureArtifactCatalogStatus.ready.rawValue)
-            .all()
-
-        var expiredCount = 0
-        for row in readyRows where row.validTime < cutoff {
-            row.status = .expired
-            try await row.save(on: database)
-            expiredCount += 1
-        }
-
-        if expiredCount > 0 {
-            logger.info(
-                "Pressure artifact cleanup expired ready rows.",
-                metadata: ["count": .stringConvertible(expiredCount)]
-            )
-        }
-    }
-
     func deleteExpiredArtifacts(
         rows expiredRows: [PressureArtifactCatalogModel],
         olderThan cutoff: Date,
@@ -111,7 +98,7 @@ extension PressureArtifactCleanupService {
                 continue
             }
 
-            guard let claimedRow = try await claimDeletionCandidate(
+            guard let claimedRow = try await catalogStore.claimDeletionCandidate(
                 for: row,
                 olderThan: cutoff,
                 cleanupLeaseExpiresAt: cleanupLeaseExpiresAt,
@@ -122,7 +109,7 @@ extension PressureArtifactCleanupService {
 
             guard let localPath = claimedRow.localPath?.trimmingCharacters(in: .whitespacesAndNewlines),
                   !localPath.isEmpty else {
-                if try await completeSuccessfulCleanup(for: claimedRow, claimToken: claimedRow.claimToken, on: database) {
+                if try await catalogStore.completeSuccessfulCleanup(for: claimedRow, claimToken: claimedRow.claimToken, on: database) {
                     logger.info(
                         "Pressure artifact cleanup cleared missing file metadata.",
                         metadata: [
@@ -144,7 +131,7 @@ extension PressureArtifactCleanupService {
 
             guard fileExists else {
                 guard localURL.path == canonicalRootPath || localURL.path.hasPrefix(canonicalRootPrefix) else {
-                    if try await completeFailedCleanup(
+                    if try await catalogStore.completeFailedCleanup(
                         for: claimedRow,
                         claimToken: claimedRow.claimToken,
                         reason: "cleanup path outside cache root",
@@ -167,7 +154,7 @@ extension PressureArtifactCleanupService {
                     continue
                 }
 
-                if try await completeSuccessfulCleanup(for: claimedRow, claimToken: claimedRow.claimToken, on: database) {
+                if try await catalogStore.completeSuccessfulCleanup(for: claimedRow, claimToken: claimedRow.claimToken, on: database) {
                     logger.info(
                         "Pressure artifact cleanup cleared missing file metadata.",
                         metadata: [
@@ -189,7 +176,7 @@ extension PressureArtifactCleanupService {
             let canonicalPath = try await canonicalPath(for: resolvedURL)
 
             guard canonicalPath == canonicalRootPath || canonicalPath.hasPrefix(canonicalRootPrefix) else {
-                if try await completeFailedCleanup(
+                if try await catalogStore.completeFailedCleanup(
                     for: claimedRow,
                     claimToken: claimedRow.claimToken,
                     reason: "cleanup path outside cache root",
@@ -213,7 +200,7 @@ extension PressureArtifactCleanupService {
             }
 
             guard !isProtectedPath(canonicalPath, protectedPaths: protectedPaths) else {
-                if try await releaseCleanupClaim(
+                if try await catalogStore.releaseCleanupClaim(
                     for: claimedRow,
                     claimToken: claimedRow.claimToken,
                     on: database
@@ -236,7 +223,7 @@ extension PressureArtifactCleanupService {
             }
 
             guard try await isPathCurrentlyProtected(canonicalPath, on: database) == false else {
-                if try await releaseCleanupClaim(
+                if try await catalogStore.releaseCleanupClaim(
                     for: claimedRow,
                     claimToken: claimedRow.claimToken,
                     on: database
@@ -259,7 +246,7 @@ extension PressureArtifactCleanupService {
             }
 
             guard try await isRegularFile(at: resolvedURL) else {
-                if try await completeFailedCleanup(
+                if try await catalogStore.completeFailedCleanup(
                     for: claimedRow,
                     claimToken: claimedRow.claimToken,
                     reason: "cleanup path is not a regular file",
@@ -284,7 +271,7 @@ extension PressureArtifactCleanupService {
 
             await beforePhysicalRemovalHook()
 
-            guard try await ownsCleanupClaim(for: claimedRow, claimToken: claimedRow.claimToken, on: database) else {
+            guard try await catalogStore.ownsCleanupClaim(for: claimedRow, claimToken: claimedRow.claimToken, on: database) else {
                 logger.info(
                     "Pressure artifact cleanup lost claim ownership.",
                     metadata: cleanupClaimLostMetadata(for: claimedRow)
@@ -294,7 +281,7 @@ extension PressureArtifactCleanupService {
 
             do {
                 try await removeItem(at: resolvedURL)
-                if try await completeSuccessfulCleanup(for: claimedRow, claimToken: claimedRow.claimToken, on: database) {
+                if try await catalogStore.completeSuccessfulCleanup(for: claimedRow, claimToken: claimedRow.claimToken, on: database) {
                     logger.info(
                         "Pressure artifact deleted from cache.",
                         metadata: [
@@ -311,7 +298,7 @@ extension PressureArtifactCleanupService {
                 }
             } catch {
                 try rethrowCancellationIfNeeded(error)
-                if try await completeFailedCleanup(
+                if try await catalogStore.completeFailedCleanup(
                     for: claimedRow,
                     claimToken: claimedRow.claimToken,
                     reason: "cleanup delete failed: \(String(describing: error))",
@@ -367,150 +354,6 @@ extension PressureArtifactCleanupService {
         }
 
         return protectedPaths
-    }
-
-    func claimDeletionCandidate(
-        for row: PressureArtifactCatalogModel,
-        olderThan cutoff: Date,
-        cleanupLeaseExpiresAt: Date,
-        on database: any Database
-    ) async throws -> PressureArtifactCatalogModel? {
-        guard let rowID = row.id,
-              let sql = database as? any SQLDatabase else {
-            return nil
-        }
-
-        let claimToken = UUID()
-        let updatedRow = try await sql.raw("""
-            UPDATE pressure_artifact_catalog
-            SET claim_token = \(bind: claimToken),
-                lease_expires_at = \(bind: cleanupLeaseExpiresAt)
-            WHERE id = \(bind: rowID)
-              AND status = \(bind: PressureArtifactCatalogStatus.expired.rawValue)
-              AND updated_at <= \(bind: cutoff)
-              AND (
-                (
-                  claim_token IS NULL
-                  AND (
-                    lease_expires_at IS NULL
-                    OR lease_expires_at <= NOW()
-                  )
-                )
-                OR lease_expires_at <= NOW()
-              )
-            RETURNING id
-            """)
-            .first()
-
-        guard updatedRow != nil else {
-            return nil
-        }
-
-        return try await PressureArtifactCatalogModel.find(rowID, on: database)
-    }
-
-    func completeSuccessfulCleanup(
-        for row: PressureArtifactCatalogModel,
-        claimToken: UUID?,
-        on database: any Database
-    ) async throws -> Bool {
-        guard let claimToken,
-              let rowID = row.id,
-              let sql = database as? any SQLDatabase else {
-            return false
-        }
-
-        let updatedRow = try await sql.raw("""
-            UPDATE pressure_artifact_catalog
-            SET local_path = NULL,
-                byte_size = NULL,
-                error_summary = NULL,
-                claim_token = NULL,
-                lease_expires_at = NULL
-            WHERE id = \(bind: rowID)
-              AND status = \(bind: PressureArtifactCatalogStatus.expired.rawValue)
-              AND claim_token = \(bind: claimToken)
-            RETURNING id
-            """)
-            .first()
-
-        return updatedRow != nil
-    }
-
-    func completeFailedCleanup(
-        for row: PressureArtifactCatalogModel,
-        claimToken: UUID?,
-        reason: String,
-        on database: any Database
-    ) async throws -> Bool {
-        guard let claimToken,
-              let rowID = row.id,
-              let sql = database as? any SQLDatabase else {
-            return false
-        }
-
-        let updatedRow = try await sql.raw("""
-            UPDATE pressure_artifact_catalog
-            SET error_summary = \(bind: reason),
-                claim_token = NULL,
-                lease_expires_at = NULL
-            WHERE id = \(bind: rowID)
-              AND status = \(bind: PressureArtifactCatalogStatus.expired.rawValue)
-              AND claim_token = \(bind: claimToken)
-            RETURNING id
-            """)
-            .first()
-
-        return updatedRow != nil
-    }
-
-    func releaseCleanupClaim(
-        for row: PressureArtifactCatalogModel,
-        claimToken: UUID?,
-        on database: any Database
-    ) async throws -> Bool {
-        guard let claimToken,
-              let rowID = row.id,
-              let sql = database as? any SQLDatabase else {
-            return false
-        }
-
-        let updatedRow = try await sql.raw("""
-            UPDATE pressure_artifact_catalog
-            SET claim_token = NULL,
-                lease_expires_at = NULL
-            WHERE id = \(bind: rowID)
-              AND status = \(bind: PressureArtifactCatalogStatus.expired.rawValue)
-              AND claim_token = \(bind: claimToken)
-            RETURNING id
-            """)
-            .first()
-
-        return updatedRow != nil
-    }
-
-    func ownsCleanupClaim(
-        for row: PressureArtifactCatalogModel,
-        claimToken: UUID?,
-        on database: any Database
-    ) async throws -> Bool {
-        guard let claimToken,
-              let rowID = row.id,
-              let sql = database as? any SQLDatabase else {
-            return false
-        }
-
-        let currentRow = try await sql.raw("""
-            SELECT id
-            FROM pressure_artifact_catalog
-            WHERE id = \(bind: rowID)
-              AND status = \(bind: PressureArtifactCatalogStatus.expired.rawValue)
-              AND claim_token = \(bind: claimToken)
-            LIMIT 1
-            """)
-            .first()
-
-        return currentRow != nil
     }
 
     func isPathCurrentlyProtected(

--- a/Tests/AppTests/PressureArtifactCleanupServiceTests.swift
+++ b/Tests/AppTests/PressureArtifactCleanupServiceTests.swift
@@ -104,9 +104,9 @@ struct PressureArtifactCleanupServiceTests {
 
     @Test("only one cleanup token owns a candidate")
     func onlyOneCleanupTokenOwnsACandidate() async throws {
-        try await withApp { app, rootURL, blockingWorkExecutor in
+        try await withApp { app, rootURL, _ in
             let now = makeUTCDate(year: 2026, month: 6, day: 3, hour: 22)
-            let service = makeService(rootURL: rootURL, now: now, blockingWorkExecutor: blockingWorkExecutor)
+            let catalogStore = PressureArtifactCatalogStore()
             let fileURL = makeTempRegularFile(in: rootURL, name: "concurrent.grib2", contents: Data("delete-me".utf8))
             let row = try await seedRow(
                 on: app.db,
@@ -119,13 +119,13 @@ struct PressureArtifactCleanupServiceTests {
 
             let deletionCutoff = now.addingTimeInterval(-60 * 60)
             let cleanupLeaseExpiresAt = makeUTCDate(year: 2030, month: 6, day: 30, hour: 22)
-            let firstClaim = try #require(try await service.claimDeletionCandidate(
+            let firstClaim = try #require(try await catalogStore.claimDeletionCandidate(
                 for: row,
                 olderThan: deletionCutoff,
                 cleanupLeaseExpiresAt: cleanupLeaseExpiresAt,
                 on: app.db
             ))
-            let secondClaim = try await service.claimDeletionCandidate(
+            let secondClaim = try await catalogStore.claimDeletionCandidate(
                 for: row,
                 olderThan: deletionCutoff,
                 cleanupLeaseExpiresAt: cleanupLeaseExpiresAt,
@@ -169,9 +169,9 @@ struct PressureArtifactCleanupServiceTests {
 
     @Test("old cleanup tokens cannot clear metadata after ownership changes")
     func oldCleanupTokensCannotClearMetadataAfterOwnershipChanges() async throws {
-        try await withApp { app, rootURL, blockingWorkExecutor in
+        try await withApp { app, rootURL, _ in
             let now = makeUTCDate(year: 2026, month: 6, day: 3, hour: 22)
-            let service = makeService(rootURL: rootURL, now: now, blockingWorkExecutor: blockingWorkExecutor)
+            let catalogStore = PressureArtifactCatalogStore()
             let fileURL = makeTempRegularFile(in: rootURL, name: "ownership.grib2", contents: Data("ownership".utf8))
             let row = try await seedRow(
                 on: app.db,
@@ -184,7 +184,7 @@ struct PressureArtifactCleanupServiceTests {
 
             let deletionCutoff = now.addingTimeInterval(-60 * 60)
             let cleanupLeaseExpiresAt = now.addingTimeInterval(30 * 60)
-            let claimedRow = try #require(try await service.claimDeletionCandidate(
+            let claimedRow = try #require(try await catalogStore.claimDeletionCandidate(
                 for: row,
                 olderThan: deletionCutoff,
                 cleanupLeaseExpiresAt: cleanupLeaseExpiresAt,
@@ -199,7 +199,7 @@ struct PressureArtifactCleanupServiceTests {
                 leaseExpiresAt: makeUTCDate(year: 2026, month: 6, day: 30, hour: 22)
             )
 
-            let didFinish = try await service.completeSuccessfulCleanup(
+            let didFinish = try await catalogStore.completeSuccessfulCleanup(
                 for: claimedRow,
                 claimToken: oldClaimToken,
                 on: app.db
@@ -212,6 +212,109 @@ struct PressureArtifactCleanupServiceTests {
             #expect(refreshed.byteSize == 9)
             #expect(refreshed.claimToken == newClaimToken)
             #expect(refreshed.leaseExpiresAt != nil)
+            #expect(FileManager.default.fileExists(atPath: fileURL.path))
+        }
+    }
+
+    @Test("stale cleanup tokens cannot fail or release a newer claim")
+    func staleCleanupTokensCannotFailOrReleaseANewerClaim() async throws {
+        try await withApp { app, rootURL, _ in
+            let now = makeUTCDate(year: 2026, month: 6, day: 3, hour: 22)
+            let catalogStore = PressureArtifactCatalogStore()
+            let fileURL = makeTempRegularFile(in: rootURL, name: "stale-claim.grib2", contents: Data("ownership".utf8))
+            let row = try await seedRow(
+                on: app.db,
+                status: .expired,
+                validTime: makeUTCDate(year: 2026, month: 6, day: 3, hour: 18),
+                localPath: fileURL.path,
+                byteSize: 9
+            )
+            try await backdateRow(row, updatedAt: now.addingTimeInterval(-7_200), on: app.db)
+
+            let claimedRow = try #require(try await catalogStore.claimDeletionCandidate(
+                for: row,
+                olderThan: now.addingTimeInterval(-60 * 60),
+                cleanupLeaseExpiresAt: now.addingTimeInterval(30 * 60),
+                on: app.db
+            ))
+            let oldClaimToken = try #require(claimedRow.claimToken)
+            let newClaimToken = UUID()
+            let newLeaseExpiresAt = makeUTCDate(year: 2026, month: 6, day: 30, hour: 22)
+            try await reclaimCleanupOwnership(
+                on: app.db,
+                rowID: try #require(row.id),
+                claimToken: newClaimToken,
+                leaseExpiresAt: newLeaseExpiresAt
+            )
+
+            let didFail = try await catalogStore.completeFailedCleanup(
+                for: claimedRow,
+                claimToken: oldClaimToken,
+                reason: "stale cleanup failure",
+                on: app.db
+            )
+            let didRelease = try await catalogStore.releaseCleanupClaim(
+                for: claimedRow,
+                claimToken: oldClaimToken,
+                on: app.db
+            )
+
+            #expect(didFail == false)
+            #expect(didRelease == false)
+
+            let refreshed = try #require(try await PressureArtifactCatalogModel.find(row.id, on: app.db))
+            #expect(refreshed.localPath == fileURL.path)
+            #expect(refreshed.byteSize == 9)
+            #expect(refreshed.errorSummary == nil)
+            #expect(refreshed.claimToken == newClaimToken)
+            #expect(refreshed.leaseExpiresAt == newLeaseExpiresAt)
+            #expect(FileManager.default.fileExists(atPath: fileURL.path))
+        }
+    }
+
+    @Test("ownership change before physical removal preserves the file and newer claim")
+    func ownershipChangeBeforePhysicalRemovalPreservesTheFileAndNewerClaim() async throws {
+        try await withApp { app, rootURL, blockingWorkExecutor in
+            let now = makeUTCDate(year: 2026, month: 6, day: 3, hour: 22)
+            let fileURL = makeTempRegularFile(in: rootURL, name: "ownership-recheck.grib2", contents: Data("ownership".utf8))
+            let row = try await seedRow(
+                on: app.db,
+                status: .expired,
+                validTime: makeUTCDate(year: 2026, month: 6, day: 3, hour: 18),
+                localPath: fileURL.path,
+                byteSize: 9
+            )
+            try await backdateRow(row, updatedAt: now.addingTimeInterval(-7_200), on: app.db)
+
+            let rowID = try #require(row.id)
+            let newClaimToken = UUID()
+            let newLeaseExpiresAt = makeUTCDate(year: 2026, month: 6, day: 30, hour: 22)
+            let service = makeService(
+                rootURL: rootURL,
+                now: now,
+                blockingWorkExecutor: blockingWorkExecutor,
+                beforePhysicalRemovalHook: {
+                    do {
+                        try await reclaimCleanupOwnership(
+                            on: app.db,
+                            rowID: rowID,
+                            claimToken: newClaimToken,
+                            leaseExpiresAt: newLeaseExpiresAt
+                        )
+                    } catch {
+                        Issue.record(error)
+                    }
+                }
+            )
+
+            try await service.cleanup(on: app, logger: app.logger)
+
+            let refreshed = try #require(try await PressureArtifactCatalogModel.find(row.id, on: app.db))
+            #expect(refreshed.localPath == fileURL.path)
+            #expect(refreshed.byteSize == 9)
+            #expect(refreshed.errorSummary == nil)
+            #expect(refreshed.claimToken == newClaimToken)
+            #expect(refreshed.leaseExpiresAt == newLeaseExpiresAt)
             #expect(FileManager.default.fileExists(atPath: fileURL.path))
         }
     }

--- a/docs/plans/architecture-recovery-progress.md
+++ b/docs/plans/architecture-recovery-progress.md
@@ -42,7 +42,7 @@ This ledger tracks the sequential, behavior-preserving architecture recovery cam
 | 09 | [#162](https://github.com/justinrooks/arcus-signal/issues/162) | 9 | Recover explicit API dependency ownership | 02 | `gpt-5.6-sol`, high | READY FOR COMMIT |
 | 10 | [#163](https://github.com/justinrooks/arcus-signal/issues/163) | 10 | Own warm claim/completion SQL | 02 | `gpt-5.6-sol`, high | Pending |
 | 11 | [#164](https://github.com/justinrooks/arcus-signal/issues/164) | 11A | Own probe catalog transitions | 10 | `gpt-5.6-sol`, high | READY FOR COMMIT |
-| 12 | [#165](https://github.com/justinrooks/arcus-signal/issues/165) | 11B | Own cleanup catalog transitions | 10, 11 | `gpt-5.6-sol`, high + persistence/filesystem review | Pending |
+| 12 | [#165](https://github.com/justinrooks/arcus-signal/issues/165) | 11B | Own cleanup catalog transitions | 10, 11 | `gpt-5.6-sol`, high + persistence/filesystem review | READY FOR COMMIT |
 | 13 | [#166](https://github.com/justinrooks/arcus-signal/issues/166) | 12 | Move request cache I/O to bounded executor | 09 | `gpt-5.6-sol`, high | Pending |
 | 14 | [#167](https://github.com/justinrooks/arcus-signal/issues/167) | 13 | Clarify Storm Setup candidate attempts | 02, 09, 13 | `gpt-5.6-sol`, high | Pending |
 | 15 | [#168](https://github.com/justinrooks/arcus-signal/issues/168) | 14 | Own child-process cancellation | 13 recommended | `gpt-5.6-sol`, high + manual runtime review | Pending |
@@ -209,11 +209,17 @@ This ledger tracks the sequential, behavior-preserving architecture recovery cam
 
 ### Issue #165 - 12: Own cleanup catalog transitions
 
-- **Status:** Pending
+- **Status:** READY FOR COMMIT
 - **Roadmap:** Slice 11B
 - **Execution profile:** `gpt-5.6-sol`, high reasoning with persistence/filesystem-safety review
 - **Dependencies:** 10, 11
 - **Stop condition:** Cleanup transition SQL has one owner; path safety unchanged.
+- **Files changed:** `Sources/App/Models/Data/PressureArtifactCatalogStore.swift`, `Sources/App/StormSetup/PressureArtifactCleanupService.swift`, `Tests/AppTests/PressureArtifactCleanupServiceTests.swift`, and this progress entry.
+- **Behavior:** The existing concrete, stateless catalog store now owns ready-row expiration, deletion claim, successful and failed cleanup completion, claim release, and ownership recheck. Cleanup injects the store through a trailing defaulted initializer parameter, delegates each transition at its original call position, and retains expiration logging, expired/protected-row reads, canonicalization, root confinement, protected-path rechecks, regular-file validation, bounded filesystem work, deletion, cancellation, and orchestration. Newly expired rows still wait for a later run because the service loads expired rows before delegating ready-row expiration.
+- **Coverage:** Retargeted direct claim and stale-success-token tests to the store. Added store-level fencing coverage proving stale tokens cannot record failure or release a newer claim. Added deterministic `beforePhysicalRemovalHook` coverage proving an ownership change after path validation prevents deletion and preserves the newer token and lease.
+- **Validation:** Pre-change `swift test --filter PressureArtifactCleanupServiceTests` passed (12 tests). Post-change cleanup tests passed (14 tests), `swift test --filter PressureArtifactDiagnosticsTests` passed (9 tests), and `swift test --parallel --num-workers 8` passed all 455 tests across 59 suites; the known unrelated `DevicePresenceMigrationTests` isolation failure did not reproduce. The four-file scoped whitespace check passed. Unscoped `git diff --check` remains blocked only by the pre-existing `docs/Sql/Device.sql:48` trailing whitespace.
+- **Review:** Human review completed with no suggested changes. The independent defect reviewer reported no actionable findings after comparing the moved SQL byte-for-byte and reviewing persistence fencing, filesystem ordering, cancellation, and scope. The independent test auditor reported no actionable findings, mapped every acceptance criterion to deterministic evidence, and independently reran the cleanup and diagnostics suites. There were no disagreements or code fixes. The reviewer's stale lifecycle-metadata uncertainty was accepted and resolved by this update. The auditor's lack of an independent full-suite rerun was already resolved by the primary full run; its non-blocking cancellation-test uncertainty was rejected as unsupported because cancellation code and ordering are unchanged. Final full-diff review found no path-check ordering, ownership-recheck, physical-deletion, successful-completion, cancellation, timing, predicate, token, lease, state, or scope drift.
+- **Residual risk / handoff:** The pre-existing unrelated changes in `docs/Sql/Device.sql`, `docs/audits/weekly-bug-scan.md`, and `docs/audits/weekly-test-gap-audit.md` were preserved and excluded. Warm, probe, lookup, dashboard, model, schema, migration, scheduler, queue, cache, HTTP, and #166 behavior are unchanged. No branch, commit, push, or pull request was created. Ready for commit.
 
 ### Issue #166 - 13: Move request cache I/O to bounded executor
 


### PR DESCRIPTION
# Summary
Moves pressure-artifact cleanup transition SQL into the shared `PressureArtifactCatalogStore` while preserving filesystem safety, cleanup ordering, claim fencing, and existing expiration timing.

# What Changed
- Added catalog-store ownership for ready-row expiration, deletion claims, successful and failed cleanup completion, claim release, and ownership rechecks.
- Updated `PressureArtifactCleanupService` to delegate persistence while retaining canonicalization, cache-root confinement, protected-path checks, regular-file validation, bounded deletion, cancellation, and logging.
- Added cleanup tests for stale-token fencing and ownership changes immediately before physical removal.
- Updated the architecture recovery progress ledger for issue #165.

# User Impact
No intentional user-facing behavior change. Cleanup continues to apply the same path-safety checks, state transitions, claim-token checks, and timing rules.

# Testing
- `swift test --filter PressureArtifactCleanupServiceTests` passed: 14 tests.
- `swift test --filter PressureArtifactDiagnosticsTests` passed: 9 tests.
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` passed.
- `git diff --check` passed for the committed branch range.
- `swift test --parallel --num-workers 8` ran 455 tests in 59 suites but reported one unrelated failure: `DevicePresenceMigrationTests.rollback keeps expanded source values valid`.

# Notes
- No probe, warm, lookup, dashboard, path-retention, schema, or same-run deletion changes are included.
- Uncommitted edits in `docs/Sql/Device.sql`, `docs/audits/weekly-bug-scan.md`, and `docs/audits/weekly-test-gap-audit.md` were intentionally excluded.

Closes #165