### PR TITLE
Add pressure-artifact HTTP request deadlines

### DIFF
--- a/Sources/App/Infrastructure/Networking/HTTPDataDownloader.swift
+++ b/Sources/App/Infrastructure/Networking/HTTPDataDownloader.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NIOCore
 import Vapor
 
 public enum HTTPStatusClassification: Sendable, Equatable {
@@ -105,7 +106,11 @@ public actor LastGlobalSuccessHTTPObserver: HTTPResponseObserving {
 }
 
 public protocol HTTPClient: Sendable {
-    func get(_ url: URL, headers: [String: String]) async throws -> HTTPResponse
+    func get(
+        _ url: URL,
+        headers: [String: String],
+        timeoutSeconds: TimeInterval?
+    ) async throws -> HTTPResponse
     func head(_ url: URL, headers: [String: String]) async throws -> HTTPResponse
     func post(
         _ url: URL,
@@ -120,6 +125,12 @@ public protocol HTTPClient: Sendable {
         timeoutSeconds: TimeInterval?
     ) async throws -> HTTPResponse
     func clearCache()
+}
+
+public extension HTTPClient {
+    func get(_ url: URL, headers: [String: String]) async throws -> HTTPResponse {
+        try await get(url, headers: headers, timeoutSeconds: nil)
+    }
 }
 
 public final class VaporApplicationHTTPClient: HTTPClient {
@@ -139,8 +150,18 @@ public final class VaporApplicationHTTPClient: HTTPClient {
         self.logger = .networkDownloader
     }
 
-    public func get(_ url: URL, headers: [String: String] = [:]) async throws -> HTTPResponse {
-        try await request(url: url, method: .GET, headers: headers, retryTransientFailures: true)
+    public func get(
+        _ url: URL,
+        headers: [String: String] = [:],
+        timeoutSeconds: TimeInterval?
+    ) async throws -> HTTPResponse {
+        try await request(
+            url: url,
+            method: .GET,
+            headers: headers,
+            timeoutSeconds: timeoutSeconds,
+            retryTransientFailures: true
+        )
     }
 
     public func head(_ url: URL, headers: [String : String] = [:]) async throws -> HTTPResponse {
@@ -202,8 +223,7 @@ public final class VaporApplicationHTTPClient: HTTPClient {
                     to: uri
                 ) { request in
                     if let timeoutSeconds {
-                        let nanoseconds = Int64((timeoutSeconds * 1_000_000_000).rounded())
-                        request.timeout = .nanoseconds(nanoseconds)
+                        request.timeout = try requestTimeout(for: timeoutSeconds)
                     }
 
                     guard let body else { return }
@@ -247,6 +267,19 @@ public final class VaporApplicationHTTPClient: HTTPClient {
         }
 
         throw Abort(.internalServerError, reason: "Unexpected HTTP retry state reached.")
+    }
+
+    private func requestTimeout(for timeoutSeconds: TimeInterval) throws -> TimeAmount {
+        let nanoseconds = timeoutSeconds * 1_000_000_000
+        guard timeoutSeconds.isFinite,
+              timeoutSeconds > 0,
+              nanoseconds.isFinite,
+              nanoseconds >= 1,
+              nanoseconds < Double(Int64.max) else {
+            throw Abort(.internalServerError, reason: "HTTP request timeout must be finite, positive, and representable in nanoseconds.")
+        }
+
+        return .nanoseconds(Int64(nanoseconds.rounded(.down)))
     }
 
     private func vaporHeaders(from input: [String: String]) -> HTTPHeaders {

--- a/Sources/App/StormSetup/HrrrPressureByteRangeDownloader.swift
+++ b/Sources/App/StormSetup/HrrrPressureByteRangeDownloader.swift
@@ -52,13 +52,16 @@ enum HrrrPressureByteRangeDownloaderError: Error, Sendable, CustomStringConverti
 struct HrrrPressureByteRangeDownloader: Sendable {
     private let httpClient: any HTTPClient
     private let blockingWorkExecutor: any PressureArtifactBlockingWorkExecuting
+    private let requestTimeoutSeconds: TimeInterval
 
     init(
         httpClient: any HTTPClient,
-        blockingWorkExecutor: any PressureArtifactBlockingWorkExecuting
+        blockingWorkExecutor: any PressureArtifactBlockingWorkExecuting,
+        requestTimeoutSeconds: TimeInterval = StormSetupConfiguration.default.pressureArtifactHTTPTimeoutSeconds
     ) {
         self.httpClient = httpClient
         self.blockingWorkExecutor = blockingWorkExecutor
+        self.requestTimeoutSeconds = requestTimeoutSeconds
     }
 
     func download(
@@ -80,7 +83,11 @@ struct HrrrPressureByteRangeDownloader: Sendable {
 
         for range in byteRangePlan.ranges {
             try Task.checkCancellation()
-            let response = try await httpClient.get(sourceURL, headers: requestHeaders(for: range))
+            let response = try await httpClient.get(
+                sourceURL,
+                headers: requestHeaders(for: range),
+                timeoutSeconds: requestTimeoutSeconds
+            )
             try Task.checkCancellation()
 
             switch response.status {

--- a/Sources/App/StormSetup/HrrrPressureSubsetGribCache.swift
+++ b/Sources/App/StormSetup/HrrrPressureSubsetGribCache.swift
@@ -240,11 +240,13 @@ actor HrrrPressureSubsetGribCache {
         rootURL: URL = StormSetupConfiguration.localPressureGribSubsetCacheRootURL,
         dateProvider: any StormSetupDateProviding = SystemStormSetupDateProvider(),
         retentionDuration: TimeInterval = StormSetupConfiguration.default.gribSubsetCacheRetentionSeconds,
-        maximumByteCount: Int = StormSetupConfiguration.default.gribSubsetMaximumByteCount
+        maximumByteCount: Int = StormSetupConfiguration.default.gribSubsetMaximumByteCount,
+        requestTimeoutSeconds: TimeInterval = StormSetupConfiguration.default.pressureArtifactHTTPTimeoutSeconds
     ) {
         self.downloader = HrrrPressureByteRangeDownloader(
             httpClient: httpClient,
-            blockingWorkExecutor: blockingWorkExecutor
+            blockingWorkExecutor: blockingWorkExecutor,
+            requestTimeoutSeconds: requestTimeoutSeconds
         )
         self.blockingWorkExecutor = blockingWorkExecutor
         self.rootURL = rootURL

--- a/Sources/App/StormSetup/PressureArtifactWarmingService.swift
+++ b/Sources/App/StormSetup/PressureArtifactWarmingService.swift
@@ -48,6 +48,7 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
     private let dateProvider: any StormSetupDateProviding
     private let maximumByteCount: Int
     private let recoveryTimeoutSeconds: TimeInterval
+    private let httpRequestTimeoutSeconds: TimeInterval
     private let catalogStore: PressureArtifactCatalogStore
 
     init(
@@ -59,6 +60,7 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
         retentionDuration: TimeInterval,
         maximumByteCount: Int,
         recoveryTimeoutSeconds: TimeInterval = 30 * 60,
+        httpRequestTimeoutSeconds: TimeInterval = 30,
         catalogStore: PressureArtifactCatalogStore = PressureArtifactCatalogStore()
     ) {
         self.httpClient = httpClient
@@ -69,30 +71,39 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
             rootURL: cacheRootURL,
             dateProvider: dateProvider,
             retentionDuration: retentionDuration,
-            maximumByteCount: maximumByteCount
+            maximumByteCount: maximumByteCount,
+            requestTimeoutSeconds: httpRequestTimeoutSeconds
         )
         self.dateProvider = dateProvider
         self.maximumByteCount = maximumByteCount
         self.recoveryTimeoutSeconds = max(1, recoveryTimeoutSeconds)
+        self.httpRequestTimeoutSeconds = httpRequestTimeoutSeconds
         self.catalogStore = catalogStore
     }
 
-    static func makeDefault(application: Application) -> PressureArtifactWarmingService {
+    static func makeDefault(
+        application: Application,
+        httpClient: (any HTTPClient)? = nil,
+        validator: (any PressureArtifactValidating)? = nil,
+        dateProvider: (any StormSetupDateProviding)? = nil
+    ) -> PressureArtifactWarmingService {
+        let configuration = application.stormSetupConfiguration
         let blockingWorkExecutor = NIOThreadPoolPressureArtifactBlockingWorkExecutor(
             threadPool: application.threadPool
         )
         return PressureArtifactWarmingService(
-            httpClient: VaporApplicationHTTPClient(application: application),
+            httpClient: httpClient ?? VaporApplicationHTTPClient(application: application),
             blockingWorkExecutor: blockingWorkExecutor,
-            validator: DefaultPressureArtifactValidationService(
-                configuration: application.stormSetupConfiguration,
+            validator: validator ?? DefaultPressureArtifactValidationService(
+                configuration: configuration,
                 runner: ProcessRunner()
             ),
-            cacheRootURL: application.stormSetupConfiguration.pressureGribSubsetCacheRootURL,
-            dateProvider: SystemStormSetupDateProvider(),
-            retentionDuration: application.stormSetupConfiguration.gribSubsetCacheRetentionSeconds,
-            maximumByteCount: application.stormSetupConfiguration.gribSubsetMaximumByteCount,
-            recoveryTimeoutSeconds: application.stormSetupConfiguration.pressureArtifactRecoveryTimeoutSeconds
+            cacheRootURL: configuration.pressureGribSubsetCacheRootURL,
+            dateProvider: dateProvider ?? SystemStormSetupDateProvider(),
+            retentionDuration: configuration.gribSubsetCacheRetentionSeconds,
+            maximumByteCount: configuration.gribSubsetMaximumByteCount,
+            recoveryTimeoutSeconds: configuration.pressureArtifactRecoveryTimeoutSeconds,
+            httpRequestTimeoutSeconds: configuration.pressureArtifactHTTPTimeoutSeconds
         )
     }
 
@@ -387,7 +398,8 @@ extension PressureArtifactWarmingService {
             headers: [
                 "User-Agent": HTTPRequestHeaders.userAgent(),
                 "Accept": "text/plain, application/octet-stream, */*"
-            ]
+            ],
+            timeoutSeconds: httpRequestTimeoutSeconds
         )
         try Task.checkCancellation()
 

--- a/Sources/App/StormSetup/StormSetupConfiguration.swift
+++ b/Sources/App/StormSetup/StormSetupConfiguration.swift
@@ -75,6 +75,12 @@ struct StormSetupConfiguration: Sendable, Equatable {
             in: environment
         )
 
+        let pressureArtifactHTTPTimeoutSeconds = Self.environmentPositiveTimeIntervalOrDefault(
+            for: "STORM_SETUP_PRESSURE_ARTIFACT_HTTP_TIMEOUT_SECONDS",
+            defaultValue: 30,
+            in: environment
+        )
+
         let wgrib2TimeoutSeconds = Self.environmentTimeInterval(
             for: "STORM_SETUP_WGRIB2_TIMEOUT_SECONDS",
             in: environment
@@ -109,6 +115,7 @@ struct StormSetupConfiguration: Sendable, Equatable {
             pressureArtifactDeleteGraceSeconds: pressureArtifactDeleteGraceSeconds,
             pressureArtifactCleanupIntervalSeconds: pressureArtifactCleanupIntervalSeconds,
             pressureArtifactRecoveryTimeoutSeconds: pressureArtifactRecoveryTimeoutSeconds,
+            pressureArtifactHTTPTimeoutSeconds: pressureArtifactHTTPTimeoutSeconds,
             wgrib2ExecutableURL: wgrib2ExecutableURL,
             wgrib2TimeoutSeconds: wgrib2TimeoutSeconds,
             anvilProfileAnalysisBaseURL: anvilProfileAnalysisBaseURL,
@@ -127,6 +134,7 @@ struct StormSetupConfiguration: Sendable, Equatable {
         pressureArtifactDeleteGraceSeconds: 60 * 60,
         pressureArtifactCleanupIntervalSeconds: 15 * 60,
         pressureArtifactRecoveryTimeoutSeconds: 30 * 60,
+        pressureArtifactHTTPTimeoutSeconds: 30,
         wgrib2ExecutableURL: localWgrib2ExecutableURL,
         wgrib2TimeoutSeconds: 15,
         anvilProfileAnalysisBaseURL: nil,
@@ -143,6 +151,7 @@ struct StormSetupConfiguration: Sendable, Equatable {
     let pressureArtifactDeleteGraceSeconds: TimeInterval
     let pressureArtifactCleanupIntervalSeconds: TimeInterval
     let pressureArtifactRecoveryTimeoutSeconds: TimeInterval
+    let pressureArtifactHTTPTimeoutSeconds: TimeInterval
     let wgrib2ExecutableURL: URL
     let wgrib2TimeoutSeconds: TimeInterval
     let anvilProfileAnalysisBaseURL: URL?
@@ -159,6 +168,7 @@ struct StormSetupConfiguration: Sendable, Equatable {
         pressureArtifactDeleteGraceSeconds: TimeInterval,
         pressureArtifactCleanupIntervalSeconds: TimeInterval,
         pressureArtifactRecoveryTimeoutSeconds: TimeInterval,
+        pressureArtifactHTTPTimeoutSeconds: TimeInterval = 30,
         wgrib2ExecutableURL: URL,
         wgrib2TimeoutSeconds: TimeInterval,
         anvilProfileAnalysisBaseURL: URL? = nil,
@@ -174,6 +184,7 @@ struct StormSetupConfiguration: Sendable, Equatable {
         self.pressureArtifactDeleteGraceSeconds = pressureArtifactDeleteGraceSeconds
         self.pressureArtifactCleanupIntervalSeconds = pressureArtifactCleanupIntervalSeconds
         self.pressureArtifactRecoveryTimeoutSeconds = pressureArtifactRecoveryTimeoutSeconds
+        self.pressureArtifactHTTPTimeoutSeconds = pressureArtifactHTTPTimeoutSeconds
         self.wgrib2ExecutableURL = wgrib2ExecutableURL
         self.wgrib2TimeoutSeconds = wgrib2TimeoutSeconds
         self.anvilProfileAnalysisBaseURL = anvilProfileAnalysisBaseURL
@@ -264,6 +275,28 @@ struct StormSetupConfiguration: Sendable, Equatable {
         }
 
         return parsed
+    }
+
+    private static func environmentPositiveTimeIntervalOrDefault(
+        for key: String,
+        defaultValue: TimeInterval,
+        in environment: [String: String]
+    ) -> TimeInterval {
+        guard let rawValue = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawValue.isEmpty,
+              let parsed = TimeInterval(rawValue),
+              parsed.isFinite,
+              parsed > 0,
+              isRequestTimeoutRepresentable(parsed) else {
+            return defaultValue
+        }
+
+        return parsed
+    }
+
+    private static func isRequestTimeoutRepresentable(_ timeoutSeconds: TimeInterval) -> Bool {
+        let nanoseconds = timeoutSeconds * 1_000_000_000
+        return nanoseconds.isFinite && nanoseconds >= 1 && nanoseconds < Double(Int64.max)
     }
 
     private static func environmentURL(

--- a/Tests/AppTests/AirQualityTests.swift
+++ b/Tests/AppTests/AirQualityTests.swift
@@ -42,6 +42,7 @@ struct AirQualityTests {
 
         #expect(request.url.path == "/aq/observation/current/ziplatlong")
         #expect(request.headers["Accept"] == "application/json")
+        #expect(request.timeoutSeconds == nil)
 
         let queryItems = URLComponents(url: request.url, resolvingAgainstBaseURL: false)?.queryItems ?? []
         let query = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
@@ -170,6 +171,7 @@ private final class AirNowHTTPClientStub: HTTPClient, @unchecked Sendable {
     struct Request: Sendable {
         let url: URL
         let headers: [String: String]
+        let timeoutSeconds: TimeInterval?
     }
 
     private let plannedResponse: HTTPResponse
@@ -179,13 +181,13 @@ private final class AirNowHTTPClientStub: HTTPClient, @unchecked Sendable {
         self.plannedResponse = plannedResponse
     }
 
-    func get(_ url: URL, headers: [String: String]) async throws -> HTTPResponse {
-        requests.append(Request(url: url, headers: headers))
+    func get(_ url: URL, headers: [String: String], timeoutSeconds: TimeInterval?) async throws -> HTTPResponse {
+        requests.append(Request(url: url, headers: headers, timeoutSeconds: timeoutSeconds))
         return plannedResponse
     }
 
     func head(_ url: URL, headers: [String: String]) async throws -> HTTPResponse {
-        try await get(url, headers: headers)
+        try await get(url, headers: headers, timeoutSeconds: nil)
     }
 
     func post(
@@ -194,7 +196,7 @@ private final class AirNowHTTPClientStub: HTTPClient, @unchecked Sendable {
         body: Data?,
         timeoutSeconds: TimeInterval?
     ) async throws -> HTTPResponse {
-        try await get(url, headers: headers)
+        try await get(url, headers: headers, timeoutSeconds: nil)
     }
 
     func postWithoutRetry(
@@ -203,7 +205,7 @@ private final class AirNowHTTPClientStub: HTTPClient, @unchecked Sendable {
         body: Data?,
         timeoutSeconds: TimeInterval?
     ) async throws -> HTTPResponse {
-        try await get(url, headers: headers)
+        try await get(url, headers: headers, timeoutSeconds: nil)
     }
 
     func clearCache() {}

--- a/Tests/AppTests/AnvilProfileClientTests.swift
+++ b/Tests/AppTests/AnvilProfileClientTests.swift
@@ -312,12 +312,13 @@ private final class AnvilProfileStubHTTPClient: HTTPClient, @unchecked Sendable 
         self.plannedError = plannedError
     }
 
-    func get(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {
-        try await post(url, headers: headers, body: nil, timeoutSeconds: nil)
+    func get(_ url: URL, headers: [String : String], timeoutSeconds: TimeInterval?) async throws -> HTTPResponse {
+        _ = timeoutSeconds
+        return try await post(url, headers: headers, body: nil, timeoutSeconds: nil)
     }
 
     func head(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {
-        try await get(url, headers: headers)
+        try await get(url, headers: headers, timeoutSeconds: nil)
     }
 
     func post(

--- a/Tests/AppTests/HrrrPressureByteRangeDownloaderTests.swift
+++ b/Tests/AppTests/HrrrPressureByteRangeDownloaderTests.swift
@@ -1,6 +1,7 @@
 @testable import App
 import Foundation
 import Testing
+import Vapor
 import ArcusCore
 
 @Suite("HRRR pressure byte-range downloader", .serialized)
@@ -34,13 +35,15 @@ struct HrrrPressureByteRangeDownloaderTests {
             )
             let downloader = HrrrPressureByteRangeDownloader(
                 httpClient: client,
-                blockingWorkExecutor: blockingWorkExecutor
+                blockingWorkExecutor: blockingWorkExecutor,
+                requestTimeoutSeconds: 17
             )
 
             let result = try await downloader.download(sourceMetadata: source, byteRangePlan: plan)
 
             #expect(client.requestCount == 5)
             #expect(client.recordedHeaders.map { $0["Range"] } == plan.ranges.map(\.httpRangeHeaderValue))
+            #expect(client.recordedTimeouts == Array(repeating: 17, count: plan.ranges.count))
             #expect(result.byteSize == 20)
             #expect(result.data == Data("hgt-tmp-dpt-ugrdvgrd".utf8))
             #expect(result.checksumSHA256 == StableContentHasher.sha256Hex(of: Data("hgt-tmp-dpt-ugrdvgrd".utf8)))
@@ -296,6 +299,31 @@ struct HrrrPressureByteRangeDownloaderTests {
         }
     }
 
+    @Test("downloader terminates a stalled range request through its configured deadline")
+    func downloaderTerminatesStalledRangeRequestThroughConfiguredDeadline() async throws {
+        let application = try await Application.make(.testing)
+        do {
+            application.clients.use { application in
+                DeadlineDrivenTestVaporClient(eventLoop: application.eventLoopGroup.next())
+            }
+            let client = VaporApplicationHTTPClient(application: application, retryDelaysSeconds: [0])
+            do {
+                _ = try await client.get(
+                    URL(string: "https://pressure-artifact.test/stalled")!,
+                    headers: [:],
+                    timeoutSeconds: 0.001
+                )
+                Issue.record("Expected the stalled request to complete through the configured deadline.")
+            } catch let error as URLError {
+                #expect(error.code == .timedOut)
+            }
+            try await application.asyncShutdown()
+        } catch {
+            try? await application.asyncShutdown()
+            throw error
+        }
+    }
+
     private func makeSingleRangePlan() -> HrrrGribByteRangePlan {
         let inventory = HrrrPressureIdxInventory.parse(
             """
@@ -350,10 +378,11 @@ struct HrrrPressureByteRangeDownloaderTests {
     }
 }
 
-final class PressureRangeStubHTTPClient: HTTPClient, @unchecked Sendable {
+final class PressureRangeStubHTTPClient: App.HTTPClient, @unchecked Sendable {
     struct Request: Sendable, Equatable {
         let url: URL
         let headers: [String: String]
+        let timeoutSeconds: TimeInterval?
     }
 
     private let plannedResponses: [String: HTTPResponse]
@@ -363,8 +392,8 @@ final class PressureRangeStubHTTPClient: HTTPClient, @unchecked Sendable {
         self.plannedResponses = plannedResponses
     }
 
-    func get(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {
-        requests.append(Request(url: url, headers: headers))
+    func get(_ url: URL, headers: [String : String], timeoutSeconds: TimeInterval?) async throws -> HTTPResponse {
+        requests.append(Request(url: url, headers: headers, timeoutSeconds: timeoutSeconds))
         let key = url.absoluteString + "|" + (headers["Range"] ?? "")
         if let response = plannedResponses[key] {
             return response
@@ -382,7 +411,7 @@ final class PressureRangeStubHTTPClient: HTTPClient, @unchecked Sendable {
     }
 
     func head(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {
-        try await get(url, headers: headers)
+        try await get(url, headers: headers, timeoutSeconds: nil)
     }
 
     func post(
@@ -391,7 +420,7 @@ final class PressureRangeStubHTTPClient: HTTPClient, @unchecked Sendable {
         body: Data?,
         timeoutSeconds: TimeInterval?
     ) async throws -> HTTPResponse {
-        try await get(url, headers: headers)
+        try await get(url, headers: headers, timeoutSeconds: nil)
     }
 
     func postWithoutRetry(
@@ -407,6 +436,27 @@ final class PressureRangeStubHTTPClient: HTTPClient, @unchecked Sendable {
 
     var requestCount: Int { requests.count }
     var recordedHeaders: [[String: String]] { requests.map(\.headers) }
+    var recordedTimeouts: [TimeInterval?] { requests.map(\.timeoutSeconds) }
+}
+
+private struct DeadlineDrivenTestVaporClient: Vapor.Client {
+    let eventLoop: any EventLoop
+
+    func delegating(to eventLoop: any EventLoop) -> any Vapor.Client {
+        DeadlineDrivenTestVaporClient(eventLoop: eventLoop)
+    }
+
+    func send(_ request: ClientRequest) -> EventLoopFuture<ClientResponse> {
+        guard let timeout = request.timeout else {
+            return eventLoop.makeFailedFuture(URLError(.cannotConnectToHost))
+        }
+
+        let promise = eventLoop.makePromise(of: ClientResponse.self)
+        _ = eventLoop.scheduleTask(in: timeout) {
+            promise.fail(URLError(.timedOut))
+        }
+        return promise.futureResult
+    }
 }
 
 private func makeUTCDate(

--- a/Tests/AppTests/HrrrPressureProfileLoadingTests.swift
+++ b/Tests/AppTests/HrrrPressureProfileLoadingTests.swift
@@ -190,7 +190,8 @@ private final class PressureProfileStubHTTPClient: HTTPClient, @unchecked Sendab
         self.responses = responses
     }
 
-    func get(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {
+    func get(_ url: URL, headers: [String : String], timeoutSeconds: TimeInterval?) async throws -> HTTPResponse {
+        _ = timeoutSeconds
         requests.append(Request(url: url, headers: headers))
         let key = url.absoluteString + "|" + (headers["Range"] ?? "")
         guard let response = responses[key] ?? responses[url.absoluteString] else {
@@ -201,7 +202,7 @@ private final class PressureProfileStubHTTPClient: HTTPClient, @unchecked Sendab
     }
 
     func head(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {
-        try await get(url, headers: headers)
+        try await get(url, headers: headers, timeoutSeconds: nil)
     }
 
     func post(
@@ -210,7 +211,7 @@ private final class PressureProfileStubHTTPClient: HTTPClient, @unchecked Sendab
         body: Data?,
         timeoutSeconds: TimeInterval?
     ) async throws -> HTTPResponse {
-        try await get(url, headers: headers)
+        try await get(url, headers: headers, timeoutSeconds: nil)
     }
 
     func postWithoutRetry(

--- a/Tests/AppTests/HrrrPressureSubsetGribCacheTests.swift
+++ b/Tests/AppTests/HrrrPressureSubsetGribCacheTests.swift
@@ -308,7 +308,8 @@ private final class PressureSubsetStubHTTPClient: HTTPClient, @unchecked Sendabl
         self.plannedResponses = plannedResponses
     }
 
-    func get(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {
+    func get(_ url: URL, headers: [String : String], timeoutSeconds: TimeInterval?) async throws -> HTTPResponse {
+        _ = timeoutSeconds
         requests.append(Request(url: url, headers: headers))
         let key = url.absoluteString + "|" + (headers["Range"] ?? "")
         if let response = plannedResponses[key] {
@@ -327,7 +328,7 @@ private final class PressureSubsetStubHTTPClient: HTTPClient, @unchecked Sendabl
     }
 
     func head(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {
-        try await get(url, headers: headers)
+        try await get(url, headers: headers, timeoutSeconds: nil)
     }
 
     func post(
@@ -336,7 +337,7 @@ private final class PressureSubsetStubHTTPClient: HTTPClient, @unchecked Sendabl
         body: Data?,
         timeoutSeconds: TimeInterval?
     ) async throws -> HTTPResponse {
-        try await get(url, headers: headers)
+        try await get(url, headers: headers, timeoutSeconds: nil)
     }
 
     func postWithoutRetry(

--- a/Tests/AppTests/NwsClientTests.swift
+++ b/Tests/AppTests/NwsClientTests.swift
@@ -57,7 +57,8 @@ private final class NwsClientStubHTTPClient: HTTPClient, @unchecked Sendable {
         self.plannedResponse = plannedResponse
     }
 
-    func get(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {
+    func get(_ url: URL, headers: [String : String], timeoutSeconds: TimeInterval?) async throws -> HTTPResponse {
+        _ = timeoutSeconds
         recordedURLs.append(url)
         return plannedResponse
     }

--- a/Tests/AppTests/PressureArtifactDiagnosticsTests.swift
+++ b/Tests/AppTests/PressureArtifactDiagnosticsTests.swift
@@ -1384,7 +1384,8 @@ private final class PressureArtifactWarmHTTPClient: App.HTTPClient, @unchecked S
         self.rangeResponses = rangeResponses
     }
 
-    func get(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {
+    func get(_ url: URL, headers: [String : String], timeoutSeconds: TimeInterval?) async throws -> HTTPResponse {
+        _ = timeoutSeconds
         if headers["Range"] == nil {
             guard let data = idxResponses[url.absoluteString] else {
                 throw URLError(.badServerResponse)
@@ -1405,7 +1406,7 @@ private final class PressureArtifactWarmHTTPClient: App.HTTPClient, @unchecked S
     }
 
     func head(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {
-        try await get(url, headers: headers)
+        try await get(url, headers: headers, timeoutSeconds: nil)
     }
 
     func post(
@@ -1414,7 +1415,7 @@ private final class PressureArtifactWarmHTTPClient: App.HTTPClient, @unchecked S
         body: Data?,
         timeoutSeconds: TimeInterval?
     ) async throws -> HTTPResponse {
-        try await get(url, headers: headers)
+        try await get(url, headers: headers, timeoutSeconds: nil)
     }
 
     func postWithoutRetry(

--- a/Tests/AppTests/PressureArtifactWarmJobTests.swift
+++ b/Tests/AppTests/PressureArtifactWarmJobTests.swift
@@ -8,31 +8,35 @@ import ArcusCore
 
 @Suite("Pressure artifact warm job", .serialized)
 struct PressureArtifactWarmJobTests {
-    @Test("pressure payload requests wrfprsf source URLs")
-    func pressurePayloadRequestsPressureProductSourceURLs() async throws {
-        try await withApp { app, blockingWorkExecutor in
+    @Test("default pressure warmer propagates configured fractional HTTP timeout")
+    func defaultPressureWarmerPropagatesConfiguredFractionalHTTPTimeout() async throws {
+        try await withApp { app, _ in
             let payload = makePayload()
             let sourceURLs = makeSourceURLs(for: payload)
             try await seedCatalogRow(status: .pending, payload: payload, on: app.db)
+            app.stormSetupConfiguration = .resolved(from: [
+                "STORM_SETUP_CACHE_ROOT": testRootURL().path,
+                "STORM_SETUP_PRESSURE_ARTIFACT_HTTP_TIMEOUT_SECONDS": "0.5"
+            ])
 
             let client = PressureArtifactWarmStubHTTPClient(
                 idxResponses: [sourceURLs.idx.absoluteString: Data(makeCompleteInventoryText().utf8)],
                 rangeResponses: makeRangeResponses(for: payload)
             )
-            let service = PressureArtifactWarmingService(
+            let service = PressureArtifactWarmingService.makeDefault(
+                application: app,
                 httpClient: client,
-                blockingWorkExecutor: blockingWorkExecutor,
                 validator: PressureArtifactWarmValidatorStub(lineCount: makeExpectedValidationLineCount()),
-                cacheRootURL: testRootURL(),
-                dateProvider: FixedStormSetupDateProvider(nowDate: makeDate()),
-                retentionDuration: serviceRetentionSeconds,
-                maximumByteCount: serviceMaximumByteCount
+                dateProvider: FixedStormSetupDateProvider(nowDate: makeDate())
             )
 
             try await service.warm(payload: payload, on: app, logger: app.logger)
 
             #expect(client.requestedURLs.isEmpty == false)
             #expect(client.requestedURLs.allSatisfy { $0.contains(".wrfprsf") })
+            #expect(client.idxRequestTimeouts == [0.5])
+            #expect(client.rangeRequestTimeouts.isEmpty == false)
+            #expect(client.rangeRequestTimeouts.allSatisfy { $0 == 0.5 })
         }
     }
 
@@ -966,6 +970,8 @@ private final class PressureArtifactWarmStubHTTPClient: App.HTTPClient, @uncheck
     private var _idxRequestCount = 0
     private var _rangeRequestCount = 0
     private var _requestedURLs: [String] = []
+    private var _idxRequestTimeouts: [TimeInterval?] = []
+    private var _rangeRequestTimeouts: [TimeInterval?] = []
 
     init(
         idxResponses: [String: Data] = [:],
@@ -987,11 +993,20 @@ private final class PressureArtifactWarmStubHTTPClient: App.HTTPClient, @uncheck
         lock.withLock { _requestedURLs }
     }
 
-    func get(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {
+    var idxRequestTimeouts: [TimeInterval?] {
+        lock.withLock { _idxRequestTimeouts }
+    }
+
+    var rangeRequestTimeouts: [TimeInterval?] {
+        lock.withLock { _rangeRequestTimeouts }
+    }
+
+    func get(_ url: URL, headers: [String : String], timeoutSeconds: TimeInterval?) async throws -> HTTPResponse {
         lock.withLock { _requestedURLs.append(url.absoluteString) }
 
         if headers["Range"] == nil {
             lock.withLock { _idxRequestCount += 1 }
+            lock.withLock { _idxRequestTimeouts.append(timeoutSeconds) }
             guard let data = idxResponses[url.absoluteString] else {
                 throw URLError(.badServerResponse)
             }
@@ -1004,6 +1019,7 @@ private final class PressureArtifactWarmStubHTTPClient: App.HTTPClient, @uncheck
         }
 
         lock.withLock { _rangeRequestCount += 1 }
+        lock.withLock { _rangeRequestTimeouts.append(timeoutSeconds) }
         let key = url.absoluteString + "|" + (headers["Range"] ?? "")
         guard let response = rangeResponses[key] else {
             throw URLError(.badServerResponse)
@@ -1013,7 +1029,7 @@ private final class PressureArtifactWarmStubHTTPClient: App.HTTPClient, @uncheck
     }
 
     func head(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {
-        try await get(url, headers: headers)
+        try await get(url, headers: headers, timeoutSeconds: nil)
     }
 
     func post(

--- a/Tests/AppTests/StormSetupConfigurationTests.swift
+++ b/Tests/AppTests/StormSetupConfigurationTests.swift
@@ -23,6 +23,7 @@ struct StormSetupConfigurationTests {
         #expect(configuration.pressureArtifactDeleteGraceSeconds == 60 * 60)
         #expect(configuration.pressureArtifactCleanupIntervalSeconds == 15 * 60)
         #expect(configuration.pressureArtifactRecoveryTimeoutSeconds == 30 * 60)
+        #expect(configuration.pressureArtifactHTTPTimeoutSeconds == 30)
         #expect(configuration.anvilProfileAnalysisBaseURL == nil)
         #expect(configuration.anvilProfileAnalysisTimeoutSeconds == nil)
     }
@@ -54,6 +55,7 @@ struct StormSetupConfigurationTests {
             "STORM_SETUP_PRESSURE_ARTIFACT_DELETE_GRACE_SECONDS": "1200",
             "STORM_SETUP_PRESSURE_ARTIFACT_CLEANUP_INTERVAL_SECONDS": "1800",
             "STORM_SETUP_PRESSURE_ARTIFACT_RECOVERY_TIMEOUT_SECONDS": "540",
+            "STORM_SETUP_PRESSURE_ARTIFACT_HTTP_TIMEOUT_SECONDS": "42",
             "ANVIL_PROFILE_ANALYSIS_BASE_URL": "https://anvil.example.com",
             "ANVIL_PROFILE_ANALYSIS_TIMEOUT_SECONDS": "11"
         ])
@@ -69,6 +71,7 @@ struct StormSetupConfigurationTests {
         #expect(configuration.pressureArtifactDeleteGraceSeconds == 1_200)
         #expect(configuration.pressureArtifactCleanupIntervalSeconds == 1_800)
         #expect(configuration.pressureArtifactRecoveryTimeoutSeconds == 540)
+        #expect(configuration.pressureArtifactHTTPTimeoutSeconds == 42)
         #expect(configuration.anvilProfileAnalysisBaseURL?.absoluteString == "https://anvil.example.com")
         #expect(configuration.anvilProfileAnalysisTimeoutSeconds == 11)
     }
@@ -88,5 +91,44 @@ struct StormSetupConfigurationTests {
         #expect(zero.pressureArtifactRecoveryTimeoutSeconds == 1)
         #expect(negative.pressureArtifactRecoveryTimeoutSeconds == 1)
         #expect(invalid.pressureArtifactRecoveryTimeoutSeconds == 1)
+    }
+
+    @Test("pressure artifact HTTP timeout defaults for missing, blank, malformed, zero, and negative overrides")
+    func pressureArtifactHTTPTimeoutDefaultsForInvalidOverrides() {
+        let missing = StormSetupConfiguration.resolved(from: [:])
+        let blank = StormSetupConfiguration.resolved(from: [
+            "STORM_SETUP_PRESSURE_ARTIFACT_HTTP_TIMEOUT_SECONDS": "  "
+        ])
+        let malformed = StormSetupConfiguration.resolved(from: [
+            "STORM_SETUP_PRESSURE_ARTIFACT_HTTP_TIMEOUT_SECONDS": "banana"
+        ])
+        let zero = StormSetupConfiguration.resolved(from: [
+            "STORM_SETUP_PRESSURE_ARTIFACT_HTTP_TIMEOUT_SECONDS": "0"
+        ])
+        let negative = StormSetupConfiguration.resolved(from: [
+            "STORM_SETUP_PRESSURE_ARTIFACT_HTTP_TIMEOUT_SECONDS": "-1"
+        ])
+        let infinity = StormSetupConfiguration.resolved(from: [
+            "STORM_SETUP_PRESSURE_ARTIFACT_HTTP_TIMEOUT_SECONDS": "infinity"
+        ])
+        let exponentOverflow = StormSetupConfiguration.resolved(from: [
+            "STORM_SETUP_PRESSURE_ARTIFACT_HTTP_TIMEOUT_SECONDS": "1e309"
+        ])
+        let nanosecondOverflow = StormSetupConfiguration.resolved(from: [
+            "STORM_SETUP_PRESSURE_ARTIFACT_HTTP_TIMEOUT_SECONDS": "9223372037"
+        ])
+        let subnanosecond = StormSetupConfiguration.resolved(from: [
+            "STORM_SETUP_PRESSURE_ARTIFACT_HTTP_TIMEOUT_SECONDS": "0.0000000001"
+        ])
+
+        #expect(missing.pressureArtifactHTTPTimeoutSeconds == 30)
+        #expect(blank.pressureArtifactHTTPTimeoutSeconds == 30)
+        #expect(malformed.pressureArtifactHTTPTimeoutSeconds == 30)
+        #expect(zero.pressureArtifactHTTPTimeoutSeconds == 30)
+        #expect(negative.pressureArtifactHTTPTimeoutSeconds == 30)
+        #expect(infinity.pressureArtifactHTTPTimeoutSeconds == 30)
+        #expect(exponentOverflow.pressureArtifactHTTPTimeoutSeconds == 30)
+        #expect(nanosecondOverflow.pressureArtifactHTTPTimeoutSeconds == 30)
+        #expect(subnanosecond.pressureArtifactHTTPTimeoutSeconds == 30)
     }
 }

--- a/Tests/AppTests/StormSetupGribSubsetCacheTests.swift
+++ b/Tests/AppTests/StormSetupGribSubsetCacheTests.swift
@@ -528,7 +528,8 @@ final class StubHTTPClient: HTTPClient, @unchecked Sendable {
         self.plannedResponses = plannedResponses
     }
 
-    func get(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {
+    func get(_ url: URL, headers: [String : String], timeoutSeconds: TimeInterval?) async throws -> HTTPResponse {
+        _ = timeoutSeconds
         requests.append(url)
 
         guard let plannedResponse = plannedResponses[url.absoluteString] else {
@@ -542,7 +543,7 @@ final class StubHTTPClient: HTTPClient, @unchecked Sendable {
     }
 
     func head(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {
-        try await get(url, headers: headers)
+        try await get(url, headers: headers, timeoutSeconds: nil)
     }
 
     func post(
@@ -551,7 +552,7 @@ final class StubHTTPClient: HTTPClient, @unchecked Sendable {
         body: Data?,
         timeoutSeconds: TimeInterval?
     ) async throws -> HTTPResponse {
-        try await get(url, headers: headers)
+        try await get(url, headers: headers, timeoutSeconds: nil)
     }
 
     func postWithoutRetry(

--- a/Tests/AppTests/StormSetupHrrrSourceTests.swift
+++ b/Tests/AppTests/StormSetupHrrrSourceTests.swift
@@ -644,8 +644,9 @@ private enum PlannedHrrrRemoteObjectOutcome: Sendable {
 private final class CancellingHTTPClient: HTTPClient, @unchecked Sendable {
     private(set) var headRequestCount = 0
 
-    func get(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {
-        try await head(url, headers: headers)
+    func get(_ url: URL, headers: [String : String], timeoutSeconds: TimeInterval?) async throws -> HTTPResponse {
+        _ = timeoutSeconds
+        return try await head(url, headers: headers)
     }
 
     func head(_ url: URL, headers: [String : String]) async throws -> HTTPResponse {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
     environment:
       <<: *shared_environment
       STORM_SETUP_CACHE_ROOT: ${STORM_SETUP_CACHE_ROOT:-/app/storage/storm-setup}
+      STORM_SETUP_PRESSURE_ARTIFACT_HTTP_TIMEOUT_SECONDS: ${STORM_SETUP_PRESSURE_ARTIFACT_HTTP_TIMEOUT_SECONDS:-30}
       APNS_TEAM_ID: ${APNS_TEAM_ID:-}
       APNS_TOPIC: ${APNS_TOPIC:-com.skyaware.app}
       APNS_SANDBOX_KEY_ID: ${APNS_SANDBOX_KEY_ID:-}

--- a/docs/hrrr-pressure-profile.md
+++ b/docs/hrrr-pressure-profile.md
@@ -52,6 +52,8 @@ The request builder requires this complete surface row in addition to at least f
   - Timeout for `wgrib2` execution.
 - `STORM_SETUP_GRIB_MAX_BYTES`
   - Maximum size for the existing surface GRIB subset cache.
+- `STORM_SETUP_PRESSURE_ARTIFACT_HTTP_TIMEOUT_SECONDS`
+  - Per-request IDX and GRIB byte-range deadline for pressure-artifact warming. Defaults to `30`; missing, blank, malformed, non-finite, zero, and negative values use the default.
 
 ### Anvil Profile Analysis
 

--- a/docs/plans/pressure-artifact-warm-reliability-progress.md
+++ b/docs/plans/pressure-artifact-warm-reliability-progress.md
@@ -1,0 +1,125 @@
+# Pressure Artifact Warm Reliability Progress
+
+## Overview
+
+This ledger tracks the bounded-execution and queue-recovery campaign defined by `docs/plans/pressure-artifact-warm-reliability-runbook.md`.
+
+**Epic status:** Active
+
+**Primary GitHub epic:** [#190](https://github.com/justinrooks/arcus-signal/issues/190)
+
+## Global decisions
+
+- Fix the single-consumer stall rather than masking it with more workers.
+- Apply both per-request and whole-attempt deadlines.
+- Keep the whole-attempt deadline below the catalog lease duration.
+- Treat timeout as a deterministic owned failure; preserve external cancellation semantics.
+- Retry only classified transient acquisition failures with a bounded attempt count.
+- Characterize Redis processing recovery before implementing startup mutation.
+- Keep operational dashboard work separate from execution behavior.
+- Target `5.4 mini medium` with one sequential review unit per issue.
+
+## Current state summary
+
+- On 2026-08-04, job `C23BBB70-4C90-495A-9A62-85AB4A70873A` claimed the `2026-08-04T08:00Z/FH3` artifact at `11:45:28Z`.
+- It fetched a 711-line IDX and selected 185 pressure ranges, but never logged cache preparation, validation, completion, or failure.
+- Network failures began minutes earlier and affected other worker HTTP traffic.
+- The production HTTP wrapper set no GET deadline; AsyncHTTPClient therefore had no read timeout.
+- The only `model-artifacts` consumer remained occupied for more than four hours.
+- Redis showed one processing job and 28 waiting jobs; the database showed one expired `warming` lease and five `pending` artifacts.
+- Restarting the worker released execution capacity and the queue began draining.
+- Focused probe, downloader, and warm-job tests passed, but none modeled a never-completing HTTP read or worker restart with an abandoned processing entry.
+
+## Existing code map
+
+| Behavior | Files |
+|---|---|
+| HTTP abstraction and Vapor client | `Sources/App/Infrastructure/Networking/HTTPDataDownloader.swift` |
+| Range loop | `Sources/App/StormSetup/HrrrPressureByteRangeDownloader.swift` |
+| Warm lifecycle | `Sources/App/StormSetup/PressureArtifactWarmingService.swift` |
+| Queue job | `Sources/App/Jobs/PressureArtifactWarmJob.swift` |
+| Probe dispatch | `Sources/App/StormSetup/HRRRPressureArtifactProbeService.swift` |
+| Catalog transitions | `Sources/App/Models/Data/PressureArtifactCatalogStore.swift` |
+| Worker startup | `Sources/App/Worker/WorkerRuntime.swift`, `Sources/App/configure.swift` |
+| Dashboard | `Sources/App/lib/OperatorDashboardSnapshotRefresher.swift`, dashboard DTO/renderer |
+
+## Issue sequence
+
+| Seq. | GitHub issue | Title | Dependencies | Status |
+|---:|---|---|---|---|
+| 01 | [#191](https://github.com/justinrooks/arcus-signal/issues/191) | Add pressure-artifact HTTP request deadlines | None | Pending |
+| 02 | [#192](https://github.com/justinrooks/arcus-signal/issues/192) | Bound warm attempts and complete timed-out claims | 01 | Pending |
+| 03 | [#193](https://github.com/justinrooks/arcus-signal/issues/193) | Retry transient warm failures with bounded backoff | 01, 02 | Pending |
+| 04 | [#194](https://github.com/justinrooks/arcus-signal/issues/194) | Characterize abandoned model-artifact processing jobs | None | Pending |
+| 05 | [#195](https://github.com/justinrooks/arcus-signal/issues/195) | Recover abandoned model-artifact jobs at worker startup | 04 | Pending |
+| 06 | [#196](https://github.com/justinrooks/arcus-signal/issues/196) | Surface stuck pressure-artifact backlog health | 02 | Pending |
+
+## Investigation notes
+
+- A healthy 185-range warm immediately before the incident downloaded approximately 124 MB in 21 seconds.
+- The stuck attempt crossed IDX parsing and range planning, narrowing the stall to cache load/fetch work, overwhelmingly the unbounded range GET path given concurrent network failures.
+- The recovery lease is a database ownership fence, not an execution deadline. Expiry cannot cancel a running task or free a queue consumer.
+- Stale probes can enqueue additional work while the consumer is blocked, creating duplicate backlog pressure.
+- The installed Redis queue driver moves jobs into `vapor_queues[model-artifacts]-processing`; interrupted processing entries are not automatically returned to the waiting list.
+
+## Status ledger
+
+### Issue #191 - 01: Add pressure-artifact HTTP request deadlines
+
+- **Status:** Pending
+- **Goal:** Give IDX and range GET operations explicit positive deadlines without changing unrelated HTTP callers.
+- **Likely files:** HTTP wrapper, Storm Setup configuration, range downloader/warming service, focused configuration/downloader tests.
+- **Stop condition:** A never-completing pressure GET fails within the configured bound and focused tests prove timeout propagation.
+
+### Issue #192 - 02: Bound warm attempts and complete timed-out claims
+
+- **Status:** Pending
+- **Goal:** Enforce an overall warm deadline shorter than the lease and mark the owned row failed on timeout while preserving external cancellation behavior.
+- **Likely files:** warming service, catalog store only if a named timeout transition is needed, warm-job tests.
+- **Stop condition:** A stalled attempt releases the job, clears its owned claim, and records a concise timeout failure.
+
+### Issue #193 - 03: Retry transient warm failures with bounded backoff
+
+- **Status:** Pending
+- **Goal:** Retry only classified transport/timeouts with a small bounded count and deterministic backoff.
+- **Likely files:** warm job, probe dispatcher, warming error classification, focused queue tests.
+- **Stop condition:** Transient failures retry and can succeed; validation/selection failures remain non-retryable; no unbounded duplicate dispatch is introduced.
+
+### Issue #194 - 04: Characterize abandoned model-artifact processing jobs
+
+- **Status:** Pending
+- **Goal:** Add tests and a narrow recovery seam that describe current Redis waiting/processing/job-data behavior without mutating production startup.
+- **Likely files:** new model-artifact queue recovery type/protocol and focused tests; no production lifecycle wiring.
+- **Stop condition:** Tests pin valid, missing-data, unknown-job, duplicate, and already-waiting cases using isolated Redis keys.
+
+### Issue #195 - 05: Recover abandoned model-artifact jobs at worker startup
+
+- **Status:** Pending
+- **Goal:** Atomically return known abandoned model-artifact jobs to the waiting queue before consumers start.
+- **Likely files:** recovery implementation, worker lifecycle/configuration, characterization tests.
+- **Stop condition:** Restart recovery is idempotent, preserves unknown entries, avoids duplicate list membership, logs a summary, and starts consumers only after reconciliation.
+
+### Issue #196 - 06: Surface stuck pressure-artifact backlog health
+
+- **Status:** Pending
+- **Goal:** Show expired warming leases, pending count, and oldest actionable age in dashboard JSON and HTML.
+- **Likely files:** dashboard snapshot metric/refresher, response DTO/renderer, dashboard pressure-artifact tests.
+- **Stop condition:** Operators can distinguish unavailable source data from a stuck warm pipeline without seeing claim tokens, Redis payloads, or local paths.
+
+## Verification ledger
+
+| Issue | Required focused verification | Result |
+|---|---|---|
+| 01 | `swift test --filter HrrrPressureByteRangeDownloaderTests`; `swift test --filter StormSetupConfigurationTests` | Pending |
+| 02 | `swift test --filter PressureArtifactWarmJobTests`; `swift test --filter PressureArtifactDiagnosticsTests` | Pending |
+| 03 | Focused warm-job retry tests; probe dispatch tests | Pending |
+| 04 | Focused model-artifact queue recovery characterization tests | Pending |
+| 05 | Recovery tests plus worker bootstrap tests and strict-concurrency build | Pending |
+| 06 | `swift test --filter OperatorDashboardPressureArtifactTests` | Pending |
+
+## Handoff notes
+
+- Execute issues sequentially unless dependencies explicitly allow otherwise.
+- Update only the active issue entry with files, behavior, validation, risks, and next handoff.
+- Do not manually generalize this campaign to ingest, target, send, or notification retry behavior.
+- If Redis recovery cannot be implemented without relying on unstable driver internals, stop after Issue 04 and document the supported alternative before changing dependencies or queue topology.

--- a/docs/plans/pressure-artifact-warm-reliability-runbook.md
+++ b/docs/plans/pressure-artifact-warm-reliability-runbook.md
@@ -1,0 +1,127 @@
+# Pressure Artifact Warm Reliability Runbook
+
+**Status:** Active
+
+**Applies to:** HRRR pressure-artifact acquisition and `model-artifacts` queue recovery
+
+**Project:** Arcus Signal
+
+**Parent epic:** [#190](https://github.com/justinrooks/arcus-signal/issues/190)
+
+## Related documents
+
+- `AGENTS.md`
+- `docs/architecture.md`
+- `docs/plans/hrrr-pressure-artifact-warmer-runbook.md`
+- `docs/plans/hrrr-pressure-artifact-warmer-progress.md`
+- `docs/plans/pressure-artifact-warm-reliability-progress.md`
+
+## Purpose
+
+Make pressure-artifact warming bounded and self-recovering after stalled HTTP reads or worker termination. The campaign is grounded in the 2026-08-04 incident where one warm job fetched its IDX, selected 185 byte ranges, then stopped before cache completion for more than four hours. With one `model-artifacts` consumer, 28 later jobs accumulated while five catalog rows remained `pending`.
+
+Each child issue is one review unit and normally one pull request. Implement the current issue, run its focused validation, update the progress ledger, and stop.
+
+## Source-of-truth order
+
+1. `AGENTS.md`
+2. `docs/architecture.md`
+3. This runbook
+4. `docs/plans/pressure-artifact-warm-reliability-progress.md`
+5. The current GitHub issue
+6. Current production code and focused tests
+
+Historical warmer planning remains useful context, but current code and this reliability contract govern timeout, retry, and recovery behavior.
+
+## Required read order
+
+1. Read `AGENTS.md` and `docs/architecture.md`.
+2. Read this runbook.
+3. Read only the current issue entry in the progress ledger.
+4. Read the current GitHub issue.
+5. Inspect only the named production and test files.
+
+## Minimal prompt contract
+
+```text
+Implement arcus-signal GitHub issue #NN.
+
+Read:
+- docs/plans/pressure-artifact-warm-reliability-runbook.md
+- the current issue entry in docs/plans/pressure-artifact-warm-reliability-progress.md
+- the GitHub issue body
+
+Work only that issue. Preserve request-path degradation and pressure catalog fencing, run the focused verification, update the current progress entry, and stop.
+```
+
+## Target reliability contract
+
+- Every IDX and GRIB byte-range request has an explicit, positive deadline.
+- A complete warm attempt has a deadline shorter than its catalog lease.
+- A timed-out owner releases execution capacity and leaves a deterministic, recoverable catalog state.
+- External task cancellation retains the existing fenced-lease behavior unless an issue explicitly changes and tests it.
+- Only transient acquisition failures receive bounded retries and backoff; deterministic selection and validation failures do not.
+- Worker startup safely recovers abandoned `model-artifacts` processing entries before consumers start.
+- Recovery is restricted to known model-artifact jobs and is idempotent.
+- The dashboard identifies expired warming leases and growing pending backlogs without exposing claim tokens or local paths.
+
+## Required guardrails
+
+- Preserve API/worker runtime ownership and the dedicated `model-artifacts` lane.
+- Preserve exact artifact identity, field-set version, 185-message selection, cache layout, and validation.
+- Preserve claim-token fencing for ready and failed completion.
+- Keep the normal Storm Setup request path read-only with respect to cold acquisition.
+- Keep all timeout and retry values explicit, positive, environment-configurable, and covered by configuration tests.
+- Use deterministic stubs or local test infrastructure; never require live NOAA traffic.
+- Keep queue recovery atomic and run it before model-artifact consumers start.
+- Log counts and job identifiers, but never log Redis credentials, claim tokens, local paths, or payload bodies.
+
+## Forbidden scope
+
+- Increasing `QUEUE_WORKER_COUNT` as the correctness fix.
+- Changing pressure levels, variables, product identity, or field-set version.
+- Moving acquisition into request handlers or Arcus-Anvil.
+- Redesigning all Vapor queue lanes or notification retry policy.
+- Deleting arbitrary Redis processing entries or flushing Redis.
+- Changing APNs, NWS ingest, targeting, or notification delivery behavior.
+- Adding a new third-party dependency when the existing Vapor/Redis stack can provide the needed behavior.
+
+## Current boundaries to preserve
+
+| Concern | Current owner |
+|---|---|
+| Probe and dispatch | `HRRRPressureArtifactProbeService` |
+| Warm orchestration | `PressureArtifactWarmingService`, `PressureArtifactWarmJob` |
+| Range acquisition | `HrrrPressureByteRangeDownloader`, `VaporApplicationHTTPClient` |
+| Catalog fencing | `PressureArtifactCatalogStore` |
+| Worker lifecycle | `WorkerRuntime`, `configure.swift` |
+| Dashboard metrics | `OperatorDashboardSnapshotRefresher`, dashboard snapshot DTO/renderer |
+
+## Sequential execution
+
+1. Add explicit per-request acquisition deadlines.
+2. Bound the whole warm attempt and define timeout catalog completion.
+3. Add bounded retry/backoff for transient warm failures.
+4. Characterize abandoned Redis processing behavior without production mutation.
+5. Recover abandoned model-artifact processing entries at worker startup.
+6. Surface stuck warming and pending backlog health on the dashboard.
+
+Issues 02–03 depend on 01. Issue 05 depends on 04. Issue 06 should follow 02 so its stuck threshold matches the implemented deadline contract.
+
+## Verification defaults
+
+- Run the focused test filters named by the current issue.
+- Use controllable stubs for never-completing and transient HTTP behavior.
+- For Redis recovery, use the existing local Redis integration boundary and unique test keys; never mutate shared queue keys.
+- Run strict-concurrency build checks for timeout, task-group, worker-lifecycle, or Redis recovery changes.
+- Run `git diff --check` scoped to the issue files.
+- Do not run live HRRR downloads as acceptance tests.
+
+## Quality bar
+
+- One behavior change per issue and pull request.
+- Prefer 1–3 production files and under roughly 200 changed lines when practical.
+- Make timeout ownership and error classification explicit; do not hide them in generic helpers.
+- Tests must prove execution capacity is released, not merely that an error value exists.
+- Queue recovery requires atomicity, idempotency, and unknown-job preservation tests.
+- A `5.4 mini medium` implementer must be able to complete the slice from the issue and named documents without repository-wide exploration.


### PR DESCRIPTION
# Summary

Add an environment-configurable positive deadline to every pressure-artifact IDX and GRIB byte-range request while preserving existing behavior for unrelated HTTP callers.

# What Changed

- Extended the shared HTTP GET boundary with an optional timeout while retaining the existing no-timeout behavior for other callers.
- Added `STORM_SETUP_PRESSURE_ARTIFACT_HTTP_TIMEOUT_SECONDS` with a documented 30-second default and safe fallback for missing, blank, malformed, non-finite, non-positive, unrepresentable, or subnanosecond values.
- Propagated the configured deadline through pressure-artifact warming, IDX acquisition, and every GRIB byte-range request.
- Added deterministic propagation and stalled-request tests using stubs, plus configuration coverage for valid and invalid overrides.
- Documented the environment setting and added the pressure-artifact reliability runbook and progress ledger.

# User Impact

Pressure-artifact warming now fails a stalled IDX or byte-range request within the configured per-request deadline instead of waiting indefinitely. Other HTTP callers retain their existing behavior.

# Testing

- `swift test --filter HrrrPressureByteRangeDownloaderTests` passed: 9 tests.
- `swift test --filter StormSetupConfigurationTests` passed: 5 tests.
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` passed.
- `git diff --check` passed for the committed branch range.
- The build emitted the pre-existing `ArcusEvent.title` deprecation warning.

# Notes

- This PR covers per-request deadlines only; whole-job deadlines, queue retry/recovery, and worker concurrency changes remain out of scope.
- Unrelated working-tree edits in `docs/Sql/Device.sql`, `docs/audits/weekly-bug-scan.md`, and `docs/audits/weekly-test-gap-audit.md` are excluded.

Closes #191