### PR TITLE
Add durable fenced failure-completion retries for pressure warming

### DIFF
--- a/Sources/App/Jobs/PressureArtifactFailureCompletionJob.swift
+++ b/Sources/App/Jobs/PressureArtifactFailureCompletionJob.swift
@@ -1,0 +1,195 @@
+import Foundation
+import Queues
+import Vapor
+
+struct PressureArtifactFailureCompletionJobPayload: Codable, Sendable {
+    let artifact: PressureArtifactWarmJobPayload
+    let claimToken: UUID
+    let errorSummary: String
+}
+
+struct PressureArtifactFailureCompletionRetryPolicy: Sendable, Equatable {
+    static let defaultDelaysSeconds = [15, 60, 300]
+
+    let delaysSeconds: [Int]
+
+    init(delaysSeconds: [Int] = defaultDelaysSeconds) {
+        self.delaysSeconds = delaysSeconds.isEmpty
+            || delaysSeconds.count > Self.defaultDelaysSeconds.count
+            || delaysSeconds.contains(where: { $0 <= 0 })
+            ? Self.defaultDelaysSeconds
+            : delaysSeconds
+    }
+
+    var maximumRetryCount: Int { delaysSeconds.count }
+
+    func delaySeconds(forAttempt attempt: Int) -> Int {
+        let index = min(max(0, attempt - 1), delaysSeconds.count - 1)
+        return delaysSeconds[index]
+    }
+}
+
+protocol PressureArtifactFailureCompletionJobDispatching: Sendable {
+    func dispatch(
+        _ payload: PressureArtifactFailureCompletionJobPayload,
+        on application: Application
+    ) async throws
+}
+
+struct DefaultPressureArtifactFailureCompletionJobDispatcher: PressureArtifactFailureCompletionJobDispatching {
+    func dispatch(
+        _ payload: PressureArtifactFailureCompletionJobPayload,
+        on application: Application
+    ) async throws {
+        let retryPolicy = application.stormSetupConfiguration
+            .pressureArtifactFailureCompletionRetryPolicy
+        try await application.queues
+            .queue(ArcusQueueLane.modelArtifacts.queueName)
+            .dispatch(
+                PressureArtifactFailureCompletionJob.self,
+                payload,
+                maxRetryCount: retryPolicy.maximumRetryCount
+            )
+    }
+}
+
+protocol PressureArtifactFailureCompleting: Sendable {
+    func complete(
+        _ payload: PressureArtifactFailureCompletionJobPayload,
+        on application: Application
+    ) async throws -> Bool
+}
+
+struct DefaultPressureArtifactFailureCompleter: PressureArtifactFailureCompleting {
+    private let catalogStore: PressureArtifactCatalogStore
+
+    init(catalogStore: PressureArtifactCatalogStore = PressureArtifactCatalogStore()) {
+        self.catalogStore = catalogStore
+    }
+
+    func complete(
+        _ payload: PressureArtifactFailureCompletionJobPayload,
+        on application: Application
+    ) async throws -> Bool {
+        try Task.checkCancellation()
+
+        do {
+            return try await catalogStore.markFailed(
+                payload: payload.artifact,
+                claimToken: payload.claimToken,
+                errorSummary: payload.errorSummary,
+                on: application.db
+            )
+        } catch {
+            try rethrowCancellationIfNeeded(error)
+            throw PressureArtifactFailureCompletionError.persistenceFailed(
+                errorType: String(describing: type(of: error))
+            )
+        }
+    }
+}
+
+enum PressureArtifactFailureCompletionError: Error, Sendable, CustomStringConvertible {
+    case persistenceFailed(errorType: String)
+    case dispatchFailed(errorType: String)
+
+    var description: String {
+        switch self {
+        case .persistenceFailed(let errorType):
+            return "Pressure artifact failure completion persistence failed (\(errorType))."
+        case .dispatchFailed(let errorType):
+            return "Pressure artifact failure completion dispatch failed (\(errorType))."
+        }
+    }
+}
+
+struct PressureArtifactFailureCompletionJob: AsyncJob {
+    typealias Payload = PressureArtifactFailureCompletionJobPayload
+
+    private let makeCompleter: @Sendable (Application) -> any PressureArtifactFailureCompleting
+    private let retryPolicy: PressureArtifactFailureCompletionRetryPolicy
+
+    init(
+        retryPolicy: PressureArtifactFailureCompletionRetryPolicy = .init(),
+        makeCompleter: @escaping @Sendable (Application) -> any PressureArtifactFailureCompleting = { _ in
+            DefaultPressureArtifactFailureCompleter()
+        }
+    ) {
+        self.retryPolicy = retryPolicy
+        self.makeCompleter = makeCompleter
+    }
+
+    init(
+        completer: any PressureArtifactFailureCompleting,
+        retryPolicy: PressureArtifactFailureCompletionRetryPolicy = .init()
+    ) {
+        self.init(retryPolicy: retryPolicy) { _ in completer }
+    }
+
+    func dequeue(_ context: QueueContext, _ payload: Payload) async throws {
+        try Task.checkCancellation()
+        let completed = try await makeCompleter(context.application).complete(
+            payload,
+            on: context.application
+        )
+
+        context.logger.info(
+            completed
+                ? "Pressure artifact failure completion succeeded."
+                : "Pressure artifact failure completion was already obsolete.",
+            metadata: artifactMetadata(payload.artifact)
+        )
+    }
+
+    func error(_ context: QueueContext, _ error: any Error, _ payload: Payload) async throws {
+        context.logger.error(
+            "Pressure artifact failure completion exhausted retries.",
+            metadata: artifactMetadata(payload.artifact).merging([
+                "errorType": .string(String(describing: type(of: error)))
+            ]) { _, new in new }
+        )
+    }
+
+    func nextRetryIn(attempt: Int) -> Int {
+        retryPolicy.delaySeconds(forAttempt: attempt)
+    }
+
+    private func artifactMetadata(_ payload: PressureArtifactWarmJobPayload) -> Logger.Metadata {
+        [
+            "runTime": .string(payload.runTime.ISO8601Format()),
+            "forecastHour": .stringConvertible(payload.forecastHour),
+            "validTime": .string(payload.validTime.ISO8601Format()),
+            "product": .string(payload.product.rawValue),
+            "fieldSetVersion": .string(payload.fieldSetVersion.rawValue)
+        ]
+    }
+}
+
+enum PressureArtifactFailureSummary {
+    static let maximumLength = 512
+
+    static func sanitized(from error: any Error, claimToken: UUID) -> String {
+        let tokenValues = [claimToken.uuidString, claimToken.uuidString.lowercased()]
+        var summary = String(reflecting: error)
+        for token in tokenValues {
+            summary = summary.replacingOccurrences(of: token, with: "[redacted-token]")
+        }
+
+        summary = summary
+            .split(whereSeparator: \Character.isWhitespace)
+            .map { component in
+                let value = String(component)
+                if value.contains("://") || value.contains("/") {
+                    return "[redacted-location]"
+                }
+                return value
+            }
+            .joined(separator: " ")
+
+        if summary.isEmpty {
+            summary = String(describing: type(of: error))
+        }
+
+        return String(summary.prefix(maximumLength))
+    }
+}

--- a/Sources/App/Jobs/PressureArtifactWarmJob.swift
+++ b/Sources/App/Jobs/PressureArtifactWarmJob.swift
@@ -25,6 +25,20 @@ struct PressureArtifactWarmJobPayload: Codable, Sendable {
     }
 }
 
+enum PressureArtifactWarmJobError: Error, Sendable, CustomStringConvertible {
+    case warmAttemptTimedOut(seconds: TimeInterval)
+    case warmingFailed(errorType: String)
+
+    var description: String {
+        switch self {
+        case .warmAttemptTimedOut(let seconds):
+            return PressureArtifactWarmingError.warmAttemptTimedOut(seconds: seconds).description
+        case .warmingFailed(let errorType):
+            return "Pressure artifact warming failed (\(errorType))."
+        }
+    }
+}
+
 struct PressureArtifactWarmJob: AsyncJob {
     typealias Payload = PressureArtifactWarmJobPayload
 
@@ -55,7 +69,21 @@ struct PressureArtifactWarmJob: AsyncJob {
         )
 
         let warmingService = makeWarmingService(context.application)
-        try await warmingService.warm(payload: payload, on: context.application, logger: context.logger)
+        do {
+            try await warmingService.warm(
+                payload: payload,
+                on: context.application,
+                logger: context.logger
+            )
+        } catch {
+            try rethrowCancellationIfNeeded(error)
+            if case PressureArtifactWarmingError.warmAttemptTimedOut(let seconds) = error {
+                throw PressureArtifactWarmJobError.warmAttemptTimedOut(seconds: seconds)
+            }
+            throw PressureArtifactWarmJobError.warmingFailed(
+                errorType: String(describing: type(of: error))
+            )
+        }
 
         context.logger.info(
             "PressureArtifactWarmJob finished.",
@@ -78,7 +106,7 @@ struct PressureArtifactWarmJob: AsyncJob {
                 "validTime": .string(payload.validTime.ISO8601Format()),
                 "product": .string(payload.product.rawValue),
                 "fieldSetVersion": .string(payload.fieldSetVersion.rawValue),
-                "error": .string(String(reflecting: error))
+                "errorType": .string(String(describing: type(of: error)))
             ]
         )
     }

--- a/Sources/App/StormSetup/PressureArtifactWarmingService.swift
+++ b/Sources/App/StormSetup/PressureArtifactWarmingService.swift
@@ -73,6 +73,8 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
     private let httpRequestTimeoutSeconds: TimeInterval
     private let timeoutSleeper: any PressureArtifactWarmTimeoutSleeping
     private let catalogStore: PressureArtifactCatalogStore
+    private let failureCompleter: any PressureArtifactFailureCompleting
+    private let failureCompletionDispatcher: any PressureArtifactFailureCompletionJobDispatching
 
     init(
         httpClient: any HTTPClient,
@@ -86,7 +88,9 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
         warmTimeoutSeconds: TimeInterval = StormSetupConfiguration.defaultPressureArtifactWarmTimeoutSeconds,
         httpRequestTimeoutSeconds: TimeInterval = 30,
         timeoutSleeper: any PressureArtifactWarmTimeoutSleeping = SystemPressureArtifactWarmTimeoutSleeper(),
-        catalogStore: PressureArtifactCatalogStore = PressureArtifactCatalogStore()
+        catalogStore: PressureArtifactCatalogStore = PressureArtifactCatalogStore(),
+        failureCompleter: (any PressureArtifactFailureCompleting)? = nil,
+        failureCompletionDispatcher: any PressureArtifactFailureCompletionJobDispatching = DefaultPressureArtifactFailureCompletionJobDispatcher()
     ) {
         self.httpClient = httpClient
         self.validator = validator
@@ -111,6 +115,8 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
         self.httpRequestTimeoutSeconds = httpRequestTimeoutSeconds
         self.timeoutSleeper = timeoutSleeper
         self.catalogStore = catalogStore
+        self.failureCompleter = failureCompleter ?? DefaultPressureArtifactFailureCompleter(catalogStore: catalogStore)
+        self.failureCompletionDispatcher = failureCompletionDispatcher
     }
 
     static func makeDefault(
@@ -197,7 +203,6 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
                 "status": .string(PressureArtifactCatalogStatus.warming.rawValue),
                 "product": .string(payload.product.rawValue),
                 "fieldSetVersion": .string(payload.fieldSetVersion.rawValue),
-                "claimTokenPrefix": .string(String(claimToken.uuidString.prefix(8))),
                 "leaseExpiresAt": .string(claimedRow.leaseExpiresAt?.ISO8601Format() ?? "nil")
             ]
         )
@@ -298,7 +303,10 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
                         "product": .string(payload.product.rawValue),
                         "fieldSetVersion": .string(payload.fieldSetVersion.rawValue),
                         "status": .string(PressureArtifactCatalogStatus.failed.rawValue),
-                        "error": .string(String(reflecting: error))
+                        "error": .string(PressureArtifactFailureSummary.sanitized(
+                            from: error,
+                            claimToken: claimToken
+                        ))
                     ]
                 )
                 throw error
@@ -341,7 +349,6 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
                     "Pressure artifact warm completion lost claim.",
                     metadata: claimLostMetadata(
                         payload: payload,
-                        claimToken: claimToken,
                         state: "ready"
                     )
                 )
@@ -362,28 +369,57 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
             }
         } catch {
             try rethrowCancellationIfNeeded(error)
-            let timeoutSeconds = ownedTimeoutSeconds(from: error)
-            let errorSummary = timeoutSeconds == nil
-                ? String(reflecting: error)
-                : String(describing: error)
-            let completedFailure = try await catalogStore.markFailed(
-                payload: payload,
-                claimToken: claimToken,
-                errorSummary: errorSummary,
-                on: application.db
+            let acquisitionError = error
+            let timeoutSeconds = ownedTimeoutSeconds(from: acquisitionError)
+            let errorSummary = PressureArtifactFailureSummary.sanitized(
+                from: acquisitionError,
+                claimToken: claimToken
             )
+            let completionPayload = PressureArtifactFailureCompletionJobPayload(
+                artifact: payload,
+                claimToken: claimToken,
+                errorSummary: errorSummary
+            )
+            let completedFailure: Bool
+            do {
+                completedFailure = try await failureCompleter.complete(
+                    completionPayload,
+                    on: application
+                )
+            } catch {
+                try rethrowCancellationIfNeeded(error)
+                do {
+                    try await failureCompletionDispatcher.dispatch(
+                        completionPayload,
+                        on: application
+                    )
+                } catch {
+                    try rethrowCancellationIfNeeded(error)
+                    throw PressureArtifactFailureCompletionError.dispatchFailed(
+                        errorType: String(describing: type(of: error))
+                    )
+                }
+
+                logger.error(
+                    "Pressure artifact failure completion deferred to durable queue work.",
+                    metadata: claimLostMetadata(
+                        payload: payload,
+                        state: "failure completion deferred"
+                    )
+                )
+                throw acquisitionError
+            }
 
             guard completedFailure else {
                 logger.info(
                     "Pressure artifact warm completion lost claim.",
                     metadata: claimLostMetadata(
                         payload: payload,
-                        claimToken: claimToken,
                         state: "failed"
                     )
                 )
                 if timeoutSeconds != nil {
-                    throw error
+                    throw acquisitionError
                 }
                 return
             }
@@ -416,7 +452,7 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
                     ]
                 )
             }
-            throw error
+            throw acquisitionError
         }
     }
 }
@@ -518,7 +554,6 @@ extension PressureArtifactWarmingService {
 
     func claimLostMetadata(
         payload: PressureArtifactWarmJobPayload,
-        claimToken: UUID,
         state: String
     ) -> Logger.Metadata {
         [
@@ -527,7 +562,6 @@ extension PressureArtifactWarmingService {
             "validTime": .string(payload.validTime.ISO8601Format()),
             "product": .string(payload.product.rawValue),
             "fieldSetVersion": .string(payload.fieldSetVersion.rawValue),
-            "claimTokenPrefix": .string(String(claimToken.uuidString.prefix(8))),
             "lostClaimState": .string(state)
         ]
     }

--- a/Sources/App/StormSetup/StormSetupConfiguration.swift
+++ b/Sources/App/StormSetup/StormSetupConfiguration.swift
@@ -89,6 +89,14 @@ struct StormSetupConfiguration: Sendable, Equatable {
             in: environment
         )
 
+        let pressureArtifactFailureCompletionRetryPolicy = PressureArtifactFailureCompletionRetryPolicy(
+            delaysSeconds: Self.environmentPositiveIntList(
+                for: "STORM_SETUP_PRESSURE_ARTIFACT_FAILURE_COMPLETION_RETRY_DELAYS_SECONDS",
+                defaultValue: PressureArtifactFailureCompletionRetryPolicy.defaultDelaysSeconds,
+                in: environment
+            )
+        )
+
         let wgrib2TimeoutSeconds = Self.environmentTimeInterval(
             for: "STORM_SETUP_WGRIB2_TIMEOUT_SECONDS",
             in: environment
@@ -125,6 +133,7 @@ struct StormSetupConfiguration: Sendable, Equatable {
             pressureArtifactRecoveryTimeoutSeconds: pressureArtifactRecoveryTimeoutSeconds,
             pressureArtifactWarmTimeoutSeconds: pressureArtifactWarmTimeoutSeconds,
             pressureArtifactHTTPTimeoutSeconds: pressureArtifactHTTPTimeoutSeconds,
+            pressureArtifactFailureCompletionRetryPolicy: pressureArtifactFailureCompletionRetryPolicy,
             wgrib2ExecutableURL: wgrib2ExecutableURL,
             wgrib2TimeoutSeconds: wgrib2TimeoutSeconds,
             anvilProfileAnalysisBaseURL: anvilProfileAnalysisBaseURL,
@@ -145,6 +154,7 @@ struct StormSetupConfiguration: Sendable, Equatable {
         pressureArtifactRecoveryTimeoutSeconds: defaultPressureArtifactRecoveryTimeoutSeconds,
         pressureArtifactWarmTimeoutSeconds: defaultPressureArtifactWarmTimeoutSeconds,
         pressureArtifactHTTPTimeoutSeconds: 30,
+        pressureArtifactFailureCompletionRetryPolicy: .init(),
         wgrib2ExecutableURL: localWgrib2ExecutableURL,
         wgrib2TimeoutSeconds: 15,
         anvilProfileAnalysisBaseURL: nil,
@@ -163,6 +173,7 @@ struct StormSetupConfiguration: Sendable, Equatable {
     let pressureArtifactRecoveryTimeoutSeconds: TimeInterval
     let pressureArtifactWarmTimeoutSeconds: TimeInterval
     let pressureArtifactHTTPTimeoutSeconds: TimeInterval
+    let pressureArtifactFailureCompletionRetryPolicy: PressureArtifactFailureCompletionRetryPolicy
     let wgrib2ExecutableURL: URL
     let wgrib2TimeoutSeconds: TimeInterval
     let anvilProfileAnalysisBaseURL: URL?
@@ -181,6 +192,7 @@ struct StormSetupConfiguration: Sendable, Equatable {
         pressureArtifactRecoveryTimeoutSeconds: TimeInterval,
         pressureArtifactWarmTimeoutSeconds: TimeInterval = defaultPressureArtifactWarmTimeoutSeconds,
         pressureArtifactHTTPTimeoutSeconds: TimeInterval = 30,
+        pressureArtifactFailureCompletionRetryPolicy: PressureArtifactFailureCompletionRetryPolicy = .init(),
         wgrib2ExecutableURL: URL,
         wgrib2TimeoutSeconds: TimeInterval,
         anvilProfileAnalysisBaseURL: URL? = nil,
@@ -204,6 +216,7 @@ struct StormSetupConfiguration: Sendable, Equatable {
             recoveryTimeoutSeconds: recoveryTimeoutSeconds
         )
         self.pressureArtifactHTTPTimeoutSeconds = pressureArtifactHTTPTimeoutSeconds
+        self.pressureArtifactFailureCompletionRetryPolicy = pressureArtifactFailureCompletionRetryPolicy
         self.wgrib2ExecutableURL = wgrib2ExecutableURL
         self.wgrib2TimeoutSeconds = wgrib2TimeoutSeconds
         self.anvilProfileAnalysisBaseURL = anvilProfileAnalysisBaseURL
@@ -313,6 +326,29 @@ struct StormSetupConfiguration: Sendable, Equatable {
         }
 
         return parsed
+    }
+
+    private static func environmentPositiveIntList(
+        for key: String,
+        defaultValue: [Int],
+        in environment: [String: String]
+    ) -> [Int] {
+        guard let rawValue = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawValue.isEmpty else {
+            return defaultValue
+        }
+
+        let components = rawValue.split(separator: ",", omittingEmptySubsequences: false)
+        let values = components.compactMap { component in
+            Int(component.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        guard values.count == components.count,
+              values.isEmpty == false,
+              values.allSatisfy({ $0 > 0 }) else {
+            return defaultValue
+        }
+
+        return values
     }
 
     private static func isRequestTimeoutRepresentable(_ timeoutSeconds: TimeInterval) -> Bool {

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -43,6 +43,9 @@ public func configure(_ app: Application, mode: AppRuntimeMode) async throws {
     app.queues.add(TargetEventRevisionJob())
     app.queues.add(NotificationSendJob())
     app.queues.add(PressureArtifactWarmJob())
+    app.queues.add(PressureArtifactFailureCompletionJob(
+        retryPolicy: app.stormSetupConfiguration.pressureArtifactFailureCompletionRetryPolicy
+    ))
     app.queues.add(CleanupPressureArtifactsJob())
 
     let decoder = JSONDecoder()

--- a/Tests/AppTests/PressureArtifactFailureCompletionJobTests.swift
+++ b/Tests/AppTests/PressureArtifactFailureCompletionJobTests.swift
@@ -1,0 +1,525 @@
+@testable import App
+import FluentSQL
+import Foundation
+import Queues
+import Testing
+import Vapor
+import XCTQueues
+import ArcusCore
+
+@Suite("Pressure artifact failure completion job", .serialized)
+struct PressureArtifactFailureCompletionJobTests {
+    @Test("failed fenced completion is durably retried and later succeeds")
+    func failedCompletionIsDurablyRetriedAndLaterSucceeds() async throws {
+        try await withApp { app, blockingWorkExecutor in
+            let completer = SequencedFailureCompleter(failuresBeforeSuccess: 2)
+            app.queues.add(PressureArtifactFailureCompletionJob(completer: completer))
+            let artifact = makeArtifactPayload()
+            try await seedCatalogRow(status: .pending, artifact: artifact, on: app.db)
+
+            let service = PressureArtifactWarmingService(
+                httpClient: IncompleteInventoryHTTPClient(),
+                blockingWorkExecutor: blockingWorkExecutor,
+                validator: UnusedPressureArtifactValidator(),
+                cacheRootURL: testRootURL(),
+                dateProvider: FixedFailureCompletionDateProvider(nowDate: artifact.runTime),
+                retentionDuration: 12 * 60 * 60,
+                maximumByteCount: 1024,
+                failureCompleter: completer
+            )
+
+            await #expect(throws: PressureArtifactWarmingError.self) {
+                try await service.warm(payload: artifact, on: app, logger: app.logger)
+            }
+
+            let queuedPayload = try #require(
+                app.queues.test.first(PressureArtifactFailureCompletionJob.self)
+            )
+            var row = try #require(try await findCatalogRow(artifact, on: app.db))
+            #expect(row.status == .warming)
+            #expect(row.claimToken == queuedPayload.claimToken)
+            #expect(row.leaseExpiresAt != nil)
+
+            let queue = app.queues.queue(ArcusQueueLane.modelArtifacts.queueName)
+            try await queue.worker.run()
+            #expect(await completer.attemptCount == 2)
+            #expect(app.queues.test.contains(PressureArtifactFailureCompletionJob.self))
+
+            makeDelayedCompletionJobsReady(on: app)
+            try await queue.worker.run()
+
+            row = try #require(try await findCatalogRow(artifact, on: app.db))
+            #expect(await completer.attemptCount == 3)
+            #expect(row.status == .failed)
+            #expect(row.claimToken == nil)
+            #expect(row.leaseExpiresAt == nil)
+            #expect(row.errorSummary == queuedPayload.errorSummary)
+            #expect(app.queues.test.contains(PressureArtifactFailureCompletionJob.self) == false)
+        }
+    }
+
+    @Test("failed durable dispatch remains an explicit warm failure")
+    func failedDurableDispatchRemainsExplicitWarmFailure() async throws {
+        try await withApp { app, blockingWorkExecutor in
+            let artifact = makeArtifactPayload()
+            try await seedCatalogRow(status: .pending, artifact: artifact, on: app.db)
+            let service = PressureArtifactWarmingService(
+                httpClient: IncompleteInventoryHTTPClient(),
+                blockingWorkExecutor: blockingWorkExecutor,
+                validator: UnusedPressureArtifactValidator(),
+                cacheRootURL: testRootURL(),
+                dateProvider: FixedFailureCompletionDateProvider(nowDate: artifact.runTime),
+                retentionDuration: 12 * 60 * 60,
+                maximumByteCount: 1024,
+                failureCompleter: SequencedFailureCompleter(failuresBeforeSuccess: .max),
+                failureCompletionDispatcher: ThrowingFailureCompletionDispatcher()
+            )
+
+            do {
+                try await service.warm(payload: artifact, on: app, logger: app.logger)
+                Issue.record("Expected durable completion dispatch to fail.")
+            } catch let error as PressureArtifactFailureCompletionError {
+                guard case .dispatchFailed(let errorType) = error else {
+                    Issue.record("Expected dispatch failure but received \(error).")
+                    return
+                }
+                #expect(errorType == String(describing: FailureCompletionTestError.self))
+            }
+
+            let row = try #require(try await findCatalogRow(artifact, on: app.db))
+            #expect(row.status == .warming)
+            #expect(row.claimToken != nil)
+            #expect(row.leaseExpiresAt != nil)
+            #expect(app.queues.test.jobs.isEmpty)
+        }
+    }
+
+    @Test("duplicate completion jobs are idempotent")
+    func duplicateCompletionJobsAreIdempotent() async throws {
+        try await withApp { app, _ in
+            let artifact = makeArtifactPayload()
+            let claimToken = UUID()
+            try await seedCatalogRow(
+                status: .warming,
+                artifact: artifact,
+                claimToken: claimToken,
+                on: app.db
+            )
+            let payload = makeCompletionPayload(artifact: artifact, claimToken: claimToken)
+            let dispatcher = DefaultPressureArtifactFailureCompletionJobDispatcher()
+
+            try await dispatcher.dispatch(payload, on: app)
+            try await dispatcher.dispatch(payload, on: app)
+            try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
+
+            let row = try #require(try await findCatalogRow(artifact, on: app.db))
+            #expect(row.status == .failed)
+            #expect(row.claimToken == nil)
+            #expect(row.leaseExpiresAt == nil)
+            #expect(row.errorSummary == payload.errorSummary)
+            #expect(app.queues.test.jobs.isEmpty)
+        }
+    }
+
+    @Test("stale completion cannot mutate a newer owner")
+    func staleCompletionCannotMutateNewerOwner() async throws {
+        try await withApp { app, _ in
+            let artifact = makeArtifactPayload()
+            let newerClaimToken = UUID()
+            let leaseExpiresAt = artifact.runTime.addingTimeInterval(1_800)
+            try await seedCatalogRow(
+                status: .warming,
+                artifact: artifact,
+                claimToken: newerClaimToken,
+                leaseExpiresAt: leaseExpiresAt,
+                on: app.db
+            )
+
+            try await DefaultPressureArtifactFailureCompletionJobDispatcher().dispatch(
+                makeCompletionPayload(artifact: artifact, claimToken: UUID()),
+                on: app
+            )
+            try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
+
+            let row = try #require(try await findCatalogRow(artifact, on: app.db))
+            #expect(row.status == .warming)
+            #expect(row.claimToken == newerClaimToken)
+            #expect(row.leaseExpiresAt == leaseExpiresAt)
+            #expect(row.errorSummary == nil)
+        }
+    }
+
+    @Test("retry exhaustion preserves lease recovery and emits safe evidence")
+    func retryExhaustionPreservesLeaseRecoveryAndEmitsSafeEvidence() async throws {
+        try await withApp { app, _ in
+            let loggerContext = makeCapturingLogger(label: "failure-completion-exhaustion")
+            app.logger = loggerContext.logger
+            let completer = SequencedFailureCompleter(failuresBeforeSuccess: .max)
+            app.queues.add(PressureArtifactFailureCompletionJob(completer: completer))
+            let artifact = makeArtifactPayload()
+            let claimToken = UUID()
+            let leaseExpiresAt = artifact.runTime.addingTimeInterval(1_800)
+            try await seedCatalogRow(
+                status: .warming,
+                artifact: artifact,
+                claimToken: claimToken,
+                leaseExpiresAt: leaseExpiresAt,
+                on: app.db
+            )
+            let sensitivePath = "/private/tmp/secret-pressure-artifact.grib2"
+            let rawFailure = SensitiveFailure(
+                description: "failed at \(sensitivePath) for \(claimToken.uuidString)"
+            )
+            let payload = PressureArtifactFailureCompletionJobPayload(
+                artifact: artifact,
+                claimToken: claimToken,
+                errorSummary: PressureArtifactFailureSummary.sanitized(
+                    from: rawFailure,
+                    claimToken: claimToken
+                )
+            )
+
+            try await DefaultPressureArtifactFailureCompletionJobDispatcher().dispatch(payload, on: app)
+            let queue = app.queues.queue(ArcusQueueLane.modelArtifacts.queueName)
+            let retryPolicy = PressureArtifactFailureCompletionRetryPolicy()
+            for attempt in 0...retryPolicy.maximumRetryCount {
+                try await queue.worker.run()
+                if attempt < retryPolicy.maximumRetryCount {
+                    makeDelayedCompletionJobsReady(on: app)
+                }
+            }
+
+            let row = try #require(try await findCatalogRow(artifact, on: app.db))
+            #expect(await completer.attemptCount == retryPolicy.maximumRetryCount + 1)
+            #expect(row.status == .warming)
+            #expect(row.claimToken == claimToken)
+            #expect(row.leaseExpiresAt == leaseExpiresAt)
+            #expect(row.errorSummary == nil)
+            #expect(app.queues.test.jobs.isEmpty)
+            #expect(loggerContext.events.contains {
+                $0.message == "Pressure artifact failure completion exhausted retries."
+            })
+            assertLogsDoNotContain(
+                [claimToken.uuidString, sensitivePath, payload.errorSummary],
+                events: loggerContext.events
+            )
+        }
+    }
+
+    @Test("completion propagates cancellation")
+    func completionPropagatesCancellation() async throws {
+        let app = try await Application.make(.testing)
+        let job = PressureArtifactFailureCompletionJob(
+            completer: CancellingFailureCompleter()
+        )
+
+        await #expect(throws: CancellationError.self) {
+            try await job.dequeue(
+                makeQueueContext(app: app),
+                makeCompletionPayload(artifact: makeArtifactPayload(), claimToken: UUID())
+            )
+        }
+
+        try await app.asyncShutdown()
+    }
+
+    @Test("retry schedule and summary sanitization are bounded")
+    func retryScheduleAndSummarySanitizationAreBounded() {
+        let retryPolicy = PressureArtifactFailureCompletionRetryPolicy()
+        let job = PressureArtifactFailureCompletionJob(retryPolicy: retryPolicy)
+        #expect((1...3).map(job.nextRetryIn(attempt:)) == [15, 60, 300])
+        #expect(retryPolicy.maximumRetryCount == 3)
+        #expect(retryPolicy.delaysSeconds.allSatisfy { $0 > 0 })
+
+        let claimToken = UUID()
+        let path = "/private/tmp/secret.grib2"
+        let url = "https://example.com/private-source"
+        let longReason = String(repeating: "x", count: 600)
+        let summary = PressureArtifactFailureSummary.sanitized(
+            from: SensitiveFailure(
+                description: "\(claimToken.uuidString) \(path) \(url) \(longReason)"
+            ),
+            claimToken: claimToken
+        )
+
+        #expect(summary.contains(claimToken.uuidString) == false)
+        #expect(summary.contains(path) == false)
+        #expect(summary.contains(url) == false)
+        #expect(summary.count == PressureArtifactFailureSummary.maximumLength)
+    }
+
+    @Test("configured retry schedule controls job delays and dispatch retry count")
+    func configuredRetryScheduleControlsJobAndDispatch() async throws {
+        try await withApp { app, _ in
+            let configuration = StormSetupConfiguration.resolved(from: [
+                "STORM_SETUP_PRESSURE_ARTIFACT_FAILURE_COMPLETION_RETRY_DELAYS_SECONDS": "4, 9"
+            ])
+            app.stormSetupConfiguration = configuration
+            let retryPolicy = configuration.pressureArtifactFailureCompletionRetryPolicy
+            let job = PressureArtifactFailureCompletionJob(retryPolicy: retryPolicy)
+            app.queues.add(job)
+
+            try await DefaultPressureArtifactFailureCompletionJobDispatcher().dispatch(
+                makeCompletionPayload(artifact: makeArtifactPayload(), claimToken: UUID()),
+                on: app
+            )
+
+            let queued = try #require(
+                app.queues.test.jobs.values.first {
+                    $0.jobName == PressureArtifactFailureCompletionJob.name
+                }
+            )
+            #expect(queued.maxRetryCount == retryPolicy.maximumRetryCount)
+            #expect((1...2).map(job.nextRetryIn(attempt:)) == [4, 9])
+        }
+    }
+}
+
+private extension PressureArtifactFailureCompletionJobTests {
+    func withApp(
+        test: (Application, NIOThreadPoolPressureArtifactBlockingWorkExecutor) async throws -> Void
+    ) async throws {
+        try await PressureArtifactCatalogTestGate.shared.withExclusiveAccess {
+            let app = try await Application.make(.testing)
+            do {
+                try await configure(app, mode: .api)
+                try await app.autoMigrate()
+                try await clearCatalog(on: app.db)
+                app.queues.use(.test)
+                try await test(
+                    app,
+                    makePressureArtifactBlockingWorkExecutor(application: app)
+                )
+            } catch {
+                try? await app.asyncShutdown()
+                throw error
+            }
+            try await app.asyncShutdown()
+        }
+    }
+
+    func clearCatalog(on database: any Database) async throws {
+        guard let sql = database as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+        try await sql.raw("DELETE FROM pressure_artifact_catalog;").run()
+    }
+
+    func seedCatalogRow(
+        status: PressureArtifactCatalogStatus,
+        artifact: PressureArtifactWarmJobPayload,
+        claimToken: UUID? = nil,
+        leaseExpiresAt: Date? = nil,
+        on database: any Database
+    ) async throws {
+        try await PressureArtifactCatalogModel(
+            runTime: artifact.runTime,
+            forecastHour: artifact.forecastHour,
+            validTime: artifact.validTime,
+            product: artifact.product,
+            fieldSetVersion: artifact.fieldSetVersion,
+            status: status,
+            claimToken: claimToken,
+            leaseExpiresAt: leaseExpiresAt
+        ).create(on: database)
+    }
+
+    func findCatalogRow(
+        _ artifact: PressureArtifactWarmJobPayload,
+        on database: any Database
+    ) async throws -> PressureArtifactCatalogModel? {
+        try await PressureArtifactCatalogModel.find(
+            runTime: artifact.runTime,
+            forecastHour: artifact.forecastHour,
+            product: artifact.product,
+            fieldSetVersion: artifact.fieldSetVersion,
+            on: database
+        )
+    }
+
+    func makeArtifactPayload() -> PressureArtifactWarmJobPayload {
+        let runTime = Date(timeIntervalSince1970: 1_780_488_000)
+        return PressureArtifactWarmJobPayload(
+            runTime: runTime,
+            forecastHour: 9,
+            validTime: runTime.addingTimeInterval(9 * 3_600),
+            product: .wrfprsf,
+            fieldSetVersion: .tornadoPressureV2
+        )
+    }
+
+    func makeCompletionPayload(
+        artifact: PressureArtifactWarmJobPayload,
+        claimToken: UUID
+    ) -> PressureArtifactFailureCompletionJobPayload {
+        PressureArtifactFailureCompletionJobPayload(
+            artifact: artifact,
+            claimToken: claimToken,
+            errorSummary: "pressure acquisition failed"
+        )
+    }
+
+    func makeQueueContext(app: Application) -> QueueContext {
+        QueueContext(
+            queueName: ArcusQueueLane.modelArtifacts.queueName,
+            configuration: app.queues.configuration,
+            application: app,
+            logger: app.logger,
+            on: app.eventLoopGroup.any()
+        )
+    }
+
+    func makeDelayedCompletionJobsReady(on app: Application) {
+        var jobs = app.queues.test.jobs
+        for (identifier, data) in jobs where data.jobName == PressureArtifactFailureCompletionJob.name {
+            jobs[identifier] = JobData(
+                payload: data.payload,
+                maxRetryCount: data.maxRetryCount,
+                jobName: data.jobName,
+                delayUntil: nil,
+                queuedAt: data.queuedAt,
+                attempts: data.attempts ?? 0
+            )
+        }
+        app.queues.test.jobs = jobs
+    }
+
+    func testRootURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("failure-completion-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    func assertLogsDoNotContain(_ sensitiveValues: [String], events: [CapturedLogEvent]) {
+        for event in events {
+            let rendered = event.message + String(describing: event.metadata)
+            for (index, value) in sensitiveValues.enumerated() {
+                #expect(
+                    rendered.contains(value) == false,
+                    "Sensitive value category \(index) appeared in \(event.message)."
+                )
+            }
+        }
+    }
+}
+
+private actor SequencedFailureCompleter: PressureArtifactFailureCompleting {
+    private let failuresBeforeSuccess: Int
+    private(set) var attemptCount = 0
+
+    init(failuresBeforeSuccess: Int) {
+        self.failuresBeforeSuccess = failuresBeforeSuccess
+    }
+
+    func complete(
+        _ payload: PressureArtifactFailureCompletionJobPayload,
+        on application: Application
+    ) async throws -> Bool {
+        attemptCount += 1
+        if attemptCount <= failuresBeforeSuccess {
+            throw FailureCompletionTestError.persistenceUnavailable
+        }
+
+        return try await PressureArtifactCatalogStore().markFailed(
+            payload: payload.artifact,
+            claimToken: payload.claimToken,
+            errorSummary: payload.errorSummary,
+            on: application.db
+        )
+    }
+}
+
+private struct CancellingFailureCompleter: PressureArtifactFailureCompleting {
+    func complete(
+        _ payload: PressureArtifactFailureCompletionJobPayload,
+        on application: Application
+    ) async throws -> Bool {
+        throw CancellationError()
+    }
+}
+
+private struct ThrowingFailureCompletionDispatcher: PressureArtifactFailureCompletionJobDispatching {
+    func dispatch(
+        _ payload: PressureArtifactFailureCompletionJobPayload,
+        on application: Application
+    ) async throws {
+        throw FailureCompletionTestError.dispatchUnavailable
+    }
+}
+
+private enum FailureCompletionTestError: Error {
+    case persistenceUnavailable
+    case dispatchUnavailable
+}
+
+private struct SensitiveFailure: Error, CustomStringConvertible {
+    let description: String
+}
+
+private struct FixedFailureCompletionDateProvider: StormSetupDateProviding {
+    let nowDate: Date
+
+    func now() -> Date { nowDate }
+}
+
+private struct UnusedPressureArtifactValidator: PressureArtifactValidating {
+    func validate(localFileURL: URL) async throws -> PressureArtifactValidationResult {
+        PressureArtifactValidationResult(stdoutLineCount: 0)
+    }
+}
+
+private struct IncompleteInventoryHTTPClient: App.HTTPClient {
+    func get(
+        _ url: URL,
+        headers: [String: String],
+        timeoutSeconds: TimeInterval?
+    ) async throws -> HTTPResponse {
+        HTTPResponse(
+            status: 200,
+            headers: ["Content-Type": "text/plain"],
+            data: Data("1:0:d=2026060313:HGT:1000 mb:9 hour fcst:".utf8)
+        )
+    }
+
+    func head(_ url: URL, headers: [String: String]) async throws -> HTTPResponse {
+        try await get(url, headers: headers, timeoutSeconds: nil)
+    }
+
+    func post(
+        _ url: URL,
+        headers: [String: String],
+        body: Data?,
+        timeoutSeconds: TimeInterval?
+    ) async throws -> HTTPResponse {
+        try await get(url, headers: headers, timeoutSeconds: timeoutSeconds)
+    }
+
+    func postWithoutRetry(
+        _ url: URL,
+        headers: [String: String],
+        body: Data?,
+        timeoutSeconds: TimeInterval?
+    ) async throws -> HTTPResponse {
+        try await post(url, headers: headers, body: body, timeoutSeconds: timeoutSeconds)
+    }
+
+    func clearCache() {}
+}
+
+private final class FailureCompletionCapturingLoggerContext: @unchecked Sendable {
+    let logger: Logger
+    private let handler: CapturingLogHandler
+
+    init(label: String) {
+        let handler = CapturingLogHandler()
+        self.handler = handler
+        var logger = Logger(label: label, factory: { _ in handler })
+        logger.logLevel = .info
+        self.logger = logger
+    }
+
+    var events: [CapturedLogEvent] { handler.events }
+}
+
+private func makeCapturingLogger(label: String) -> FailureCompletionCapturingLoggerContext {
+    FailureCompletionCapturingLoggerContext(label: label)
+}

--- a/Tests/AppTests/PressureArtifactWarmJobTests.swift
+++ b/Tests/AppTests/PressureArtifactWarmJobTests.swift
@@ -4,6 +4,7 @@ import Foundation
 import Queues
 import Testing
 import Vapor
+import XCTQueues
 import ArcusCore
 
 @Suite("Pressure artifact warm job", .serialized)
@@ -160,7 +161,7 @@ struct PressureArtifactWarmJobTests {
             )
             let job = PressureArtifactWarmJob(warmingService: service)
 
-            await #expect(throws: PressureArtifactWarmValidatorStubError.self) {
+            await #expect(throws: PressureArtifactWarmJobError.self) {
                 try await job.dequeue(makeQueueContext(app: app), payload)
             }
 
@@ -176,6 +177,53 @@ struct PressureArtifactWarmJobTests {
             #expect(row.errorSummary?.contains("failedValidation") == true)
             #expect(row.localPath == nil)
             #expect(row.byteSize == nil)
+        }
+    }
+
+    @Test("queue-facing validation failure does not log its local path")
+    func queueFacingValidationFailureDoesNotLogLocalPath() async throws {
+        try await withApp { app, blockingWorkExecutor in
+            app.queues.use(.test)
+            let payload = makePayload()
+            let sourceURLs = makeSourceURLs(for: payload)
+            try await seedCatalogRow(status: .pending, payload: payload, on: app.db)
+            let sentinelURL = URL(
+                fileURLWithPath: "/private/tmp/arcus-private-sentinel/subset.grib2"
+            )
+            let client = PressureArtifactWarmStubHTTPClient(
+                idxResponses: [sourceURLs.idx.absoluteString: Data(makeCompleteInventoryText().utf8)],
+                rangeResponses: makeRangeResponses(for: payload)
+            )
+            let service = PressureArtifactWarmingService(
+                httpClient: client,
+                blockingWorkExecutor: blockingWorkExecutor,
+                validator: PressureArtifactWarmValidatorStub(
+                    error: PressureArtifactValidationError.emptyOutput(sentinelURL),
+                    lineCount: makeExpectedValidationLineCount()
+                ),
+                cacheRootURL: testRootURL(),
+                dateProvider: FixedStormSetupDateProvider(nowDate: makeDate()),
+                retentionDuration: serviceRetentionSeconds,
+                maximumByteCount: serviceMaximumByteCount,
+                failureCompleter: AlwaysFailingPressureArtifactFailureCompleter()
+            )
+            let logHandler = CapturingLogHandler()
+            var logger = Logger(label: "pressure-path-safety", factory: { _ in logHandler })
+            logger.logLevel = .info
+            app.logger = logger
+            app.queues.add(PressureArtifactWarmJob(warmingService: service))
+
+            let queue = app.queues.queue(ArcusQueueLane.modelArtifacts.queueName)
+            try await queue.dispatch(PressureArtifactWarmJob.self, payload)
+            try await queue.worker.run()
+
+            let renderedLogs = logHandler.events.map {
+                $0.message + String(describing: $0.metadata)
+            }.joined(separator: "\n")
+            #expect(renderedLogs.contains(sentinelURL.path) == false)
+            #expect(renderedLogs.contains(sentinelURL.absoluteString) == false)
+            #expect(renderedLogs.contains("Pressure artifact validation failed."))
+            #expect(renderedLogs.contains("Job failed"))
         }
     }
 
@@ -266,7 +314,7 @@ struct PressureArtifactWarmJobTests {
             do {
                 try await dequeueTask.value
                 Issue.record("Expected the queue-facing dequeue call to throw a warm timeout.")
-            } catch PressureArtifactWarmingError.warmAttemptTimedOut(let seconds) {
+            } catch PressureArtifactWarmJobError.warmAttemptTimedOut(let seconds) {
                 #expect(seconds == 12)
             } catch {
                 Issue.record("Expected a distinct warm timeout, got \(String(reflecting: error)).")
@@ -336,7 +384,7 @@ struct PressureArtifactWarmJobTests {
             do {
                 try await dequeueTask.value
                 Issue.record("Expected the stale owner to surface its warm timeout.")
-            } catch PressureArtifactWarmingError.warmAttemptTimedOut(let seconds) {
+            } catch PressureArtifactWarmJobError.warmAttemptTimedOut(let seconds) {
                 #expect(seconds == 12)
             } catch {
                 Issue.record("Expected a distinct warm timeout, got \(String(reflecting: error)).")
@@ -845,7 +893,7 @@ struct PressureArtifactWarmJobTests {
             )
             let job = PressureArtifactWarmJob(warmingService: service)
 
-            await #expect(throws: PressureArtifactWarmingError.self) {
+            await #expect(throws: PressureArtifactWarmJobError.self) {
                 try await job.dequeue(makeQueueContext(app: app), payload)
             }
 
@@ -886,7 +934,7 @@ struct PressureArtifactWarmJobTests {
             )
             let job = PressureArtifactWarmJob(warmingService: service)
 
-            await #expect(throws: PressureArtifactWarmingError.self) {
+            await #expect(throws: PressureArtifactWarmJobError.self) {
                 try await job.dequeue(makeQueueContext(app: app), payload)
             }
 
@@ -1155,6 +1203,15 @@ private extension PressureArtifactWarmJobTests {
 
     var serviceRetentionSeconds: TimeInterval { 12 * 60 * 60 }
     var serviceMaximumByteCount: Int { 1024 }
+}
+
+private struct AlwaysFailingPressureArtifactFailureCompleter: PressureArtifactFailureCompleting {
+    func complete(
+        _ payload: PressureArtifactFailureCompletionJobPayload,
+        on application: Application
+    ) async throws -> Bool {
+        throw PressureArtifactWarmValidatorStubError.failedValidation
+    }
 }
 
 private actor ControllablePressureArtifactWarmTimeoutSleeper: PressureArtifactWarmTimeoutSleeping {

--- a/Tests/AppTests/StormSetupConfigurationTests.swift
+++ b/Tests/AppTests/StormSetupConfigurationTests.swift
@@ -26,6 +26,7 @@ struct StormSetupConfigurationTests {
         #expect(configuration.pressureArtifactWarmTimeoutSeconds == 15 * 60)
         #expect(configuration.pressureArtifactWarmTimeoutSeconds < configuration.pressureArtifactRecoveryTimeoutSeconds)
         #expect(configuration.pressureArtifactHTTPTimeoutSeconds == 30)
+        #expect(configuration.pressureArtifactFailureCompletionRetryPolicy.delaysSeconds == [15, 60, 300])
         #expect(configuration.anvilProfileAnalysisBaseURL == nil)
         #expect(configuration.anvilProfileAnalysisTimeoutSeconds == nil)
     }
@@ -59,6 +60,7 @@ struct StormSetupConfigurationTests {
             "STORM_SETUP_PRESSURE_ARTIFACT_RECOVERY_TIMEOUT_SECONDS": "540",
             "STORM_SETUP_PRESSURE_ARTIFACT_WARM_TIMEOUT_SECONDS": "240",
             "STORM_SETUP_PRESSURE_ARTIFACT_HTTP_TIMEOUT_SECONDS": "42",
+            "STORM_SETUP_PRESSURE_ARTIFACT_FAILURE_COMPLETION_RETRY_DELAYS_SECONDS": "5, 20, 90",
             "ANVIL_PROFILE_ANALYSIS_BASE_URL": "https://anvil.example.com",
             "ANVIL_PROFILE_ANALYSIS_TIMEOUT_SECONDS": "11"
         ])
@@ -76,6 +78,7 @@ struct StormSetupConfigurationTests {
         #expect(configuration.pressureArtifactRecoveryTimeoutSeconds == 540)
         #expect(configuration.pressureArtifactWarmTimeoutSeconds == 240)
         #expect(configuration.pressureArtifactHTTPTimeoutSeconds == 42)
+        #expect(configuration.pressureArtifactFailureCompletionRetryPolicy.delaysSeconds == [5, 20, 90])
         #expect(configuration.anvilProfileAnalysisBaseURL?.absoluteString == "https://anvil.example.com")
         #expect(configuration.anvilProfileAnalysisTimeoutSeconds == 11)
     }
@@ -167,5 +170,25 @@ struct StormSetupConfigurationTests {
         #expect(exponentOverflow.pressureArtifactHTTPTimeoutSeconds == 30)
         #expect(nanosecondOverflow.pressureArtifactHTTPTimeoutSeconds == 30)
         #expect(subnanosecond.pressureArtifactHTTPTimeoutSeconds == 30)
+    }
+
+    @Test("failure completion retry delays default for missing or invalid overrides")
+    func failureCompletionRetryDelaysDefaultForInvalidOverrides() {
+        let key = "STORM_SETUP_PRESSURE_ARTIFACT_FAILURE_COMPLETION_RETRY_DELAYS_SECONDS"
+        let invalidValues = [
+            "  ", "banana", "0", "-1", "15,0,60", "15,,60", "1,2,3,4"
+        ]
+
+        #expect(
+            StormSetupConfiguration.resolved(from: [:])
+                .pressureArtifactFailureCompletionRetryPolicy.delaysSeconds == [15, 60, 300]
+        )
+        for value in invalidValues {
+            let configuration = StormSetupConfiguration.resolved(from: [key: value])
+            #expect(
+                configuration.pressureArtifactFailureCompletionRetryPolicy.delaysSeconds
+                    == [15, 60, 300]
+            )
+        }
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,7 @@ The arrows are distinct boundaries. A durable intent, successful queue enqueue, 
 
 ### Queue retries and replay limits
 
-Production `.dispatch(...)` calls do not pass `maxRetryCount`. The installed Vapor Queues API defaults it to `0`, so a dequeued job failure is not retried by Vapor Queues. Outbox drain attempts are not a substitute for queue replay or APNs retry.
+Production `.dispatch(...)` calls default to Vapor Queues' `maxRetryCount` of `0`, so most dequeued job failures are not retried by Vapor Queues. `PressureArtifactFailureCompletionJob` is the narrow exception: it uses the configured positive completion schedule on the `model-artifacts` lane to retry the existing fenced failure transition. Outbox drain attempts are not a substitute for queue replay or APNs retry.
 
 ## Candidate selection, claim, and APNs delivery
 

--- a/docs/plans/pressure-artifact-warm-reliability-progress.md
+++ b/docs/plans/pressure-artifact-warm-reliability-progress.md
@@ -53,6 +53,7 @@ This ledger tracks the bounded-execution and queue-recovery campaign defined by 
 | 04 | [#194](https://github.com/justinrooks/arcus-signal/issues/194) | Characterize abandoned model-artifact processing jobs | None | Pending |
 | 05 | [#195](https://github.com/justinrooks/arcus-signal/issues/195) | Recover abandoned model-artifact jobs at worker startup | 04 | Pending |
 | 06 | [#196](https://github.com/justinrooks/arcus-signal/issues/196) | Surface stuck pressure-artifact backlog health | 02 | Pending |
+| 07 | [#201](https://github.com/justinrooks/arcus-signal/issues/201) | Add durable fenced failure-completion retries | 01, 02 | Implemented — ready for publication |
 
 ## Investigation notes
 
@@ -106,6 +107,16 @@ This ledger tracks the bounded-execution and queue-recovery campaign defined by 
 - **Likely files:** dashboard snapshot metric/refresher, response DTO/renderer, dashboard pressure-artifact tests.
 - **Stop condition:** Operators can distinguish unavailable source data from a stuck warm pipeline without seeing claim tokens, Redis payloads, or local paths.
 
+### Issue #201 - 07: Add durable fenced failure-completion retries
+
+- **Status:** Implemented — ready for publication
+- **Behavior:** A thrown owned `markFailed` write dispatches a pressure-specific completion payload containing only artifact identity, the original claim token, and a bounded sanitized summary. The job reuses the existing fenced store transition and treats stale tokens as successful no-ops.
+- **Retry contract:** The first completion attempt is immediate. Vapor Queues owns up to three configured delayed retries on `model-artifacts`, defaulting to 15, 60, and 300 seconds.
+- **Exhaustion:** The completion job records explicit queue/log failure, leaves the warming claim and lease unchanged, and relies on the existing lease/probe recovery path.
+- **Review:** Human review completed. Independent defect and test audits reached `READY` after path-safe queue errors, configurable retry policy, and canonical documentation were verified.
+- **Sequencing:** Land this issue before resuming #193. Add the completion job name to #195's known model-artifact recovery set when that work begins.
+- **Focused verification:** `swift test --filter PressureArtifactFailureCompletionJobTests`; `swift test --filter PressureArtifactWarmJobTests`; `swift test --filter StormSetupConfigurationTests`; `swift test --filter PressureArtifactDiagnosticsTests`; strict-concurrency build; `git diff --check`.
+
 ## Verification ledger
 
 | Issue | Required focused verification | Result |
@@ -116,6 +127,7 @@ This ledger tracks the bounded-execution and queue-recovery campaign defined by 
 | 04 | Focused model-artifact queue recovery characterization tests | Pending |
 | 05 | Recovery tests plus worker bootstrap tests and strict-concurrency build | Pending |
 | 06 | `swift test --filter OperatorDashboardPressureArtifactTests` | Pending |
+| 07 | Completion-job queue/PostgreSQL tests; warm and diagnostics regressions; strict-concurrency build | Passed |
 
 ## Handoff notes
 

--- a/docs/plans/pressure-artifact-warm-reliability-runbook.md
+++ b/docs/plans/pressure-artifact-warm-reliability-runbook.md
@@ -59,6 +59,10 @@ Work only that issue. Preserve request-path degradation and pressure catalog fen
 - Every IDX and GRIB byte-range request has an explicit, positive deadline.
 - A complete warm attempt has a deadline shorter than its catalog lease.
 - A timed-out owner releases execution capacity and leaves a deterministic, recoverable catalog state.
+- If the fenced failed-state write cannot complete, the original artifact identity, claim token, and sanitized failure summary move to a dedicated durable completion job on `model-artifacts`.
+- Failure completion retries only the original fenced `markFailed` transition: one immediate attempt followed by at most three retries, defaulting to delays of 15, 60, and 300 seconds.
+- `STORM_SETUP_PRESSURE_ARTIFACT_FAILURE_COMPLETION_RETRY_DELAYS_SECONDS` overrides that schedule with one to three comma-separated positive integer seconds; missing or invalid values use `15,60,300`.
+- A stale completion token is an idempotent no-op; retry exhaustion leaves the original lease for probe recovery.
 - External task cancellation retains the existing fenced-lease behavior unless an issue explicitly changes and tests it.
 - Only transient acquisition failures receive bounded retries and backoff; deterministic selection and validation failures do not.
 - Worker startup safely recovers abandoned `model-artifacts` processing entries before consumers start.
@@ -92,6 +96,7 @@ Work only that issue. Preserve request-path degradation and pressure catalog fen
 |---|---|
 | Probe and dispatch | `HRRRPressureArtifactProbeService` |
 | Warm orchestration | `PressureArtifactWarmingService`, `PressureArtifactWarmJob` |
+| Durable failed-state completion | `PressureArtifactFailureCompletionJob`, `PressureArtifactCatalogStore.markFailed` |
 | Range acquisition | `HrrrPressureByteRangeDownloader`, `VaporApplicationHTTPClient` |
 | Catalog fencing | `PressureArtifactCatalogStore` |
 | Worker lifecycle | `WorkerRuntime`, `configure.swift` |
@@ -107,6 +112,8 @@ Work only that issue. Preserve request-path degradation and pressure catalog fen
 6. Surface stuck warming and pending backlog health on the dashboard.
 
 Issues 02–03 depend on 01. Issue 05 depends on 04. Issue 06 should follow 02 so its stuck threshold matches the implemented deadline contract.
+
+Issue [#201](https://github.com/justinrooks/arcus-signal/issues/201) is a prerequisite to resuming Issue 03. Its completion job deliberately uses a retry schedule distinct from Issue 03's 30/120-second acquisition schedule. When Issue 05 is implemented, its known model-artifact job set must include `PressureArtifactFailureCompletionJob`.
 
 ## Verification defaults
 


### PR DESCRIPTION
# Summary
This branch makes pressure warm failure completion durable when the fenced `markFailed` persistence step fails. The warm path now sanitizes failure summaries, hands off retryable completion work to a dedicated queue job, and keeps claim ownership fences intact. It also adds config-driven retry delays plus tests and docs updates for the new contract.

# What Changed
- Added `PressureArtifactFailureCompletionJob` to retry only the original fenced failure transition on the `model-artifacts` queue lane.
- Updated `PressureArtifactWarmingService` to enqueue durable completion work when owned `markFailed` persistence fails, while preserving the original claim token and recovery semantics.
- Added a configurable retry policy via `STORM_SETUP_PRESSURE_ARTIFACT_FAILURE_COMPLETION_RETRY_DELAYS_SECONDS`.
- Sanitized warm-failure summaries and trimmed logging so claim tokens and local paths are not emitted.
- Expanded tests for the new completion job, warm-job failure behavior, and configuration parsing.
- Updated the architecture note and pressure warm reliability runbook/progress docs.

# User Impact
No direct API or UI change. Pressure artifact warming is more resilient after transient persistence failures, so users should see fewer missed or silently dropped pressure warm completions.

# Testing
- `swift test --filter PressureArtifactFailureCompletionJobTests`
- `swift test --filter PressureArtifactWarmJobTests`
- `swift test --filter StormSetupConfigurationTests`
- `swift test` failed with 1 issue in the full suite after building 486 tests in 62 suites.

# Notes
- The new completion job is intentionally narrow: it retries the original fenced failure transition only.
- The full suite still reports one failing issue outside the targeted pressure-warming coverage.