### PR TITLE
Retry transient pressure warm failures with bounded backoff

### DIFF
--- a/Sources/App/Infrastructure/Networking/HTTPDataDownloader.swift
+++ b/Sources/App/Infrastructure/Networking/HTTPDataDownloader.swift
@@ -133,6 +133,41 @@ public extension HTTPClient {
     }
 }
 
+enum HTTPTransportFailureClassifier {
+    static func isTransient(_ error: any Error) -> Bool {
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .timedOut,
+                 .cannotFindHost,
+                 .cannotConnectToHost,
+                 .networkConnectionLost,
+                 .dnsLookupFailed,
+                 .resourceUnavailable,
+                 .notConnectedToInternet,
+                 .internationalRoamingOff,
+                 .callIsActive,
+                 .dataNotAllowed,
+                 .requestBodyStreamExhausted:
+                return true
+            default:
+                break
+            }
+        }
+
+        let message = String(describing: error).lowercased()
+        let transientTokens = [
+            "timed out",
+            "connection reset",
+            "connection refused",
+            "temporarily unavailable",
+            "network is unreachable",
+            "broken pipe",
+            "dns"
+        ]
+        return transientTokens.contains { message.contains($0) }
+    }
+}
+
 public final class VaporApplicationHTTPClient: HTTPClient {
     private let application: Application
     private let delays: [UInt64]
@@ -247,7 +282,7 @@ public final class VaporApplicationHTTPClient: HTTPClient {
                     throw CancellationError()
                 }
 
-                if isTransient(error), attempt < retryDelays.count - 1 {
+                if HTTPTransportFailureClassifier.isTransient(error), attempt < retryDelays.count - 1 {
                     let wait = retryDelays[attempt + 1]
                     logger.debug(
                         "Retrying transient HTTP failure.",
@@ -314,36 +349,4 @@ public final class VaporApplicationHTTPClient: HTTPClient {
         return output
     }
 
-    private func isTransient(_ error: any Error) -> Bool {
-        if let urlError = error as? URLError {
-            switch urlError.code {
-            case .timedOut,
-                 .cannotFindHost,
-                 .cannotConnectToHost,
-                 .networkConnectionLost,
-                 .dnsLookupFailed,
-                 .resourceUnavailable,
-                 .notConnectedToInternet,
-                 .internationalRoamingOff,
-                 .callIsActive,
-                 .dataNotAllowed,
-                 .requestBodyStreamExhausted:
-                return true
-            default:
-                break
-            }
-        }
-
-        let message = String(describing: error).lowercased()
-        let transientTokens = [
-            "timed out",
-            "connection reset",
-            "connection refused",
-            "temporarily unavailable",
-            "network is unreachable",
-            "broken pipe",
-            "dns"
-        ]
-        return transientTokens.contains { message.contains($0) }
-    }
 }

--- a/Sources/App/Jobs/PressureArtifactWarmJob.swift
+++ b/Sources/App/Jobs/PressureArtifactWarmJob.swift
@@ -9,51 +9,200 @@ struct PressureArtifactWarmJobPayload: Codable, Sendable {
     let validTime: Date
     let product: HrrrProduct
     let fieldSetVersion: HrrrFieldSetVersion
+    let acquisitionAttempt: Int
 
     init(
         runTime: Date,
         forecastHour: Int,
         validTime: Date,
         product: HrrrProduct,
-        fieldSetVersion: HrrrFieldSetVersion
+        fieldSetVersion: HrrrFieldSetVersion,
+        acquisitionAttempt: Int = 0
     ) {
         self.runTime = runTime
         self.forecastHour = forecastHour
         self.validTime = validTime
         self.product = product
         self.fieldSetVersion = fieldSetVersion
+        self.acquisitionAttempt = max(0, acquisitionAttempt)
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            runTime: try container.decode(Date.self, forKey: .runTime),
+            forecastHour: try container.decode(Int.self, forKey: .forecastHour),
+            validTime: try container.decode(Date.self, forKey: .validTime),
+            product: try container.decode(HrrrProduct.self, forKey: .product),
+            fieldSetVersion: try container.decode(HrrrFieldSetVersion.self, forKey: .fieldSetVersion),
+            acquisitionAttempt: try container.decodeIfPresent(Int.self, forKey: .acquisitionAttempt) ?? 0
+        )
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case runTime
+        case forecastHour
+        case validTime
+        case product
+        case fieldSetVersion
+        case acquisitionAttempt
     }
 }
 
 enum PressureArtifactWarmJobError: Error, Sendable, CustomStringConvertible {
-    case warmAttemptTimedOut(seconds: TimeInterval)
+    case retryDispatchFailed(errorType: String)
     case warmingFailed(errorType: String)
 
     var description: String {
         switch self {
-        case .warmAttemptTimedOut(let seconds):
-            return PressureArtifactWarmingError.warmAttemptTimedOut(seconds: seconds).description
+        case .retryDispatchFailed(let errorType):
+            return "Pressure artifact acquisition retry dispatch failed (\(errorType))."
         case .warmingFailed(let errorType):
             return "Pressure artifact warming failed (\(errorType))."
         }
     }
 }
 
+struct PressureArtifactWarmRetryContinuation: Sendable {
+    let payload: PressureArtifactWarmJobPayload
+    let delaySeconds: Int
+}
+
+enum PressureArtifactWarmRetryPolicy {
+    static let maximumAcquisitionAttempts = 3
+    private static let delaysSeconds = [30, 120]
+
+    static func continuation(
+        after payload: PressureArtifactWarmJobPayload
+    ) -> PressureArtifactWarmRetryContinuation? {
+        guard payload.acquisitionAttempt < delaysSeconds.count else {
+            return nil
+        }
+
+        return PressureArtifactWarmRetryContinuation(
+            payload: PressureArtifactWarmJobPayload(
+                runTime: payload.runTime,
+                forecastHour: payload.forecastHour,
+                validTime: payload.validTime,
+                product: payload.product,
+                fieldSetVersion: payload.fieldSetVersion,
+                acquisitionAttempt: payload.acquisitionAttempt + 1
+            ),
+            delaySeconds: delaysSeconds[payload.acquisitionAttempt]
+        )
+    }
+
+    static func isTransientAcquisitionFailure(_ error: any Error) -> Bool {
+        guard !(error is CancellationError) else {
+            return false
+        }
+
+        if let acquisitionError = error as? PressureArtifactAcquisitionError {
+            if case .transient = acquisitionError {
+                return true
+            }
+            return false
+        }
+
+        if let warmingError = error as? PressureArtifactWarmingError {
+            if case .warmAttemptTimedOut = warmingError {
+                return true
+            }
+            return false
+        }
+
+        if error is HrrrPressureByteRangeDownloaderError
+            || error is HrrrPressureSubsetGribCacheError
+            || error is HrrrPressureSubsetGribCacheKeyError
+            || error is PressureArtifactValidationError
+            || error is Abort {
+            return false
+        }
+
+        return false
+    }
+}
+
+protocol PressureArtifactWarmRetryDispatching: Sendable {
+    func dispatch(
+        _ continuation: PressureArtifactWarmRetryContinuation,
+        on application: Application
+    ) async throws
+}
+
+struct DefaultPressureArtifactWarmRetryDispatcher: PressureArtifactWarmRetryDispatching {
+    func dispatch(
+        _ continuation: PressureArtifactWarmRetryContinuation,
+        on application: Application
+    ) async throws {
+        try await application.queues
+            .queue(ArcusQueueLane.modelArtifacts.queueName)
+            .dispatch(
+                PressureArtifactWarmJob.self,
+                continuation.payload,
+                maxRetryCount: 0,
+                delayUntil: Date(timeIntervalSinceNow: TimeInterval(continuation.delaySeconds))
+            )
+    }
+}
+
+enum PressureArtifactAcquisitionError: Error, Sendable, CustomStringConvertible {
+    case transient(String)
+    case terminal(String)
+
+    static func classify(_ error: any Error) -> Self {
+        let description = String(describing: error)
+        if HTTPTransportFailureClassifier.isTransient(error)
+            || recognizedPressureRequestErrorTokens.contains(where: description.lowercased().contains) {
+            return .transient(description)
+        }
+        return .terminal(description)
+    }
+
+    var description: String {
+        switch self {
+        case .transient(let reason):
+            return "Transient pressure artifact acquisition failure: \(reason)"
+        case .terminal(let reason):
+            return "Terminal pressure artifact acquisition failure: \(reason)"
+        }
+    }
+
+    private static let recognizedPressureRequestErrorTokens = [
+        "httpclienterror.readtimeout",
+        "httpclienterror.writetimeout",
+        "httpclienterror.connecttimeout",
+        "httpclienterror.sockshandshaketimeout",
+        "httpclienterror.httpproxyhandshaketimeout",
+        "httpclienterror.tlshandshaketimeout",
+        "httpclienterror.getconnectionfrompooltimeout",
+        "httpclienterror.deadlineexceeded",
+        "httpclienterror.remoteconnectionclosed",
+        "channelerror.connecttimeout"
+    ]
+}
+
 struct PressureArtifactWarmJob: AsyncJob {
     typealias Payload = PressureArtifactWarmJobPayload
 
     private let makeWarmingService: @Sendable (Application) -> any PressureArtifactWarming
+    private let retryDispatcher: any PressureArtifactWarmRetryDispatching
 
     init(
+        retryDispatcher: any PressureArtifactWarmRetryDispatching = DefaultPressureArtifactWarmRetryDispatcher(),
         makeWarmingService: @escaping @Sendable (Application) -> any PressureArtifactWarming = { application in
             PressureArtifactWarmingService.makeDefault(application: application)
         }
     ) {
+        self.retryDispatcher = retryDispatcher
         self.makeWarmingService = makeWarmingService
     }
 
-    init(warmingService: any PressureArtifactWarming) {
-        self.init { _ in warmingService }
+    init(
+        warmingService: any PressureArtifactWarming,
+        retryDispatcher: any PressureArtifactWarmRetryDispatching = DefaultPressureArtifactWarmRetryDispatcher()
+    ) {
+        self.init(retryDispatcher: retryDispatcher) { _ in warmingService }
     }
 
     func dequeue(_ context: QueueContext, _ payload: Payload) async throws {
@@ -77,23 +226,40 @@ struct PressureArtifactWarmJob: AsyncJob {
             )
         } catch {
             try rethrowCancellationIfNeeded(error)
-            if case PressureArtifactWarmingError.warmAttemptTimedOut(let seconds) = error {
-                throw PressureArtifactWarmJobError.warmAttemptTimedOut(seconds: seconds)
+            if PressureArtifactWarmRetryPolicy.isTransientAcquisitionFailure(error) {
+                try await scheduleRetryIfAvailable(
+                    after: error,
+                    payload: payload,
+                    context: context
+                )
+                return
             }
-            throw PressureArtifactWarmJobError.warmingFailed(
-                errorType: String(describing: type(of: error))
+            if let disposition = error as? PressureArtifactFailureDispositionError {
+                context.logger.error(
+                    "\(disposition.logMessage)",
+                    metadata: artifactMetadata(payload).merging([
+                        "acquisitionAttempt": .stringConvertible(payload.acquisitionAttempt),
+                        "errorType": .string(disposition.errorType)
+                    ]) { _, new in new }
+                )
+                return
+            }
+            if error is PressureArtifactFailureCompletionError {
+                throw PressureArtifactWarmJobError.warmingFailed(
+                    errorType: String(describing: type(of: error))
+                )
+            }
+
+            context.logger.error(
+                "PressureArtifactWarmJob completed with a terminal failure.",
+                metadata: artifactMetadata(payload)
             )
+            return
         }
 
         context.logger.info(
             "PressureArtifactWarmJob finished.",
-            metadata: [
-                "runTime": .string(payload.runTime.ISO8601Format()),
-                "forecastHour": .stringConvertible(payload.forecastHour),
-                "validTime": .string(payload.validTime.ISO8601Format()),
-                "product": .string(payload.product.rawValue),
-                "fieldSetVersion": .string(payload.fieldSetVersion.rawValue)
-            ]
+            metadata: artifactMetadata(payload)
         )
     }
 
@@ -109,5 +275,53 @@ struct PressureArtifactWarmJob: AsyncJob {
                 "errorType": .string(String(describing: type(of: error)))
             ]
         )
+    }
+
+    private func scheduleRetryIfAvailable(
+        after error: any Error,
+        payload: Payload,
+        context: QueueContext
+    ) async throws {
+        guard let continuation = PressureArtifactWarmRetryPolicy.continuation(after: payload) else {
+            context.logger.error(
+                "PressureArtifactWarmJob exhausted transient acquisition attempts.",
+                metadata: artifactMetadata(payload).merging([
+                    "acquisitionAttempt": .stringConvertible(payload.acquisitionAttempt),
+                    "errorType": .string(String(describing: type(of: error)))
+                ]) { _, new in new }
+            )
+            return
+        }
+
+        do {
+            try await retryDispatcher.dispatch(
+                continuation,
+                on: context.application
+            )
+        } catch {
+            try rethrowCancellationIfNeeded(error)
+            throw PressureArtifactWarmJobError.retryDispatchFailed(
+                errorType: String(describing: type(of: error))
+            )
+        }
+
+        context.logger.info(
+            "PressureArtifactWarmJob scheduled a transient acquisition retry.",
+            metadata: artifactMetadata(payload).merging([
+                "acquisitionAttempt": .stringConvertible(payload.acquisitionAttempt),
+                "nextAcquisitionAttempt": .stringConvertible(continuation.payload.acquisitionAttempt),
+                "retryDelaySeconds": .stringConvertible(continuation.delaySeconds)
+            ]) { _, new in new }
+        )
+    }
+
+    private func artifactMetadata(_ payload: Payload) -> Logger.Metadata {
+        [
+            "runTime": .string(payload.runTime.ISO8601Format()),
+            "forecastHour": .stringConvertible(payload.forecastHour),
+            "validTime": .string(payload.validTime.ISO8601Format()),
+            "product": .string(payload.product.rawValue),
+            "fieldSetVersion": .string(payload.fieldSetVersion.rawValue)
+        ]
     }
 }

--- a/Sources/App/StormSetup/HRRRPressureArtifactProbeService.swift
+++ b/Sources/App/StormSetup/HRRRPressureArtifactProbeService.swift
@@ -25,7 +25,11 @@ struct DefaultPressureArtifactWarmJobDispatcher: PressureArtifactWarmJobDispatch
     ) async throws {
         try await application.queues
             .queue(queueName)
-            .dispatch(PressureArtifactWarmJob.self, payload)
+            .dispatch(
+                PressureArtifactWarmJob.self,
+                payload,
+                maxRetryCount: 0
+            )
     }
 }
 

--- a/Sources/App/StormSetup/HrrrPressureByteRangeDownloader.swift
+++ b/Sources/App/StormSetup/HrrrPressureByteRangeDownloader.swift
@@ -83,11 +83,17 @@ struct HrrrPressureByteRangeDownloader: Sendable {
 
         for range in byteRangePlan.ranges {
             try Task.checkCancellation()
-            let response = try await httpClient.get(
-                sourceURL,
-                headers: requestHeaders(for: range),
-                timeoutSeconds: requestTimeoutSeconds
-            )
+            let response: HTTPResponse
+            do {
+                response = try await httpClient.get(
+                    sourceURL,
+                    headers: requestHeaders(for: range),
+                    timeoutSeconds: requestTimeoutSeconds
+                )
+            } catch {
+                try rethrowCancellationIfNeeded(error)
+                throw PressureArtifactAcquisitionError.classify(error)
+            }
             try Task.checkCancellation()
 
             switch response.status {

--- a/Sources/App/StormSetup/PressureArtifactWarmingService.swift
+++ b/Sources/App/StormSetup/PressureArtifactWarmingService.swift
@@ -62,6 +62,36 @@ enum PressureArtifactWarmingError: Error, Sendable, CustomStringConvertible {
     }
 }
 
+enum PressureArtifactFailureDispositionError: Error, Sendable, CustomStringConvertible {
+    case completionDeferred(errorType: String)
+    case completionObsolete(errorType: String)
+
+    var errorType: String {
+        switch self {
+        case .completionDeferred(let errorType), .completionObsolete(let errorType):
+            return errorType
+        }
+    }
+
+    var logMessage: String {
+        switch self {
+        case .completionDeferred:
+            return "PressureArtifactWarmJob left failure completion to durable queue work."
+        case .completionObsolete:
+            return "PressureArtifactWarmJob completed after losing its failure-completion claim."
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .completionDeferred(let errorType):
+            return "Pressure artifact failure completion was deferred (\(errorType))."
+        case .completionObsolete(let errorType):
+            return "Pressure artifact failure completion was already obsolete (\(errorType))."
+        }
+    }
+}
+
 struct PressureArtifactWarmingService: PressureArtifactWarming {
     private let httpClient: any HTTPClient
     private let validator: any PressureArtifactValidating
@@ -407,7 +437,9 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
                         state: "failure completion deferred"
                     )
                 )
-                throw acquisitionError
+                throw PressureArtifactFailureDispositionError.completionDeferred(
+                    errorType: String(describing: type(of: acquisitionError))
+                )
             }
 
             guard completedFailure else {
@@ -418,10 +450,9 @@ struct PressureArtifactWarmingService: PressureArtifactWarming {
                         state: "failed"
                     )
                 )
-                if timeoutSeconds != nil {
-                    throw acquisitionError
-                }
-                return
+                throw PressureArtifactFailureDispositionError.completionObsolete(
+                    errorType: String(describing: type(of: acquisitionError))
+                )
             }
 
             if let timeoutSeconds {
@@ -513,14 +544,20 @@ extension PressureArtifactWarmingService {
             throw PressureArtifactWarmingError.missingIdxURL
         }
 
-        let response = try await httpClient.get(
-            idxURL,
-            headers: [
-                "User-Agent": HTTPRequestHeaders.userAgent(),
-                "Accept": "text/plain, application/octet-stream, */*"
-            ],
-            timeoutSeconds: httpRequestTimeoutSeconds
-        )
+        let response: HTTPResponse
+        do {
+            response = try await httpClient.get(
+                idxURL,
+                headers: [
+                    "User-Agent": HTTPRequestHeaders.userAgent(),
+                    "Accept": "text/plain, application/octet-stream, */*"
+                ],
+                timeoutSeconds: httpRequestTimeoutSeconds
+            )
+        } catch {
+            try rethrowCancellationIfNeeded(error)
+            throw PressureArtifactAcquisitionError.classify(error)
+        }
         try Task.checkCancellation()
 
         guard (200...299).contains(response.status) else {

--- a/Tests/AppTests/HRRRPressureArtifactProbeServiceTests.swift
+++ b/Tests/AppTests/HRRRPressureArtifactProbeServiceTests.swift
@@ -5,9 +5,30 @@ import Foundation
 import Queues
 import Testing
 import Vapor
+import XCTQueues
 
 @Suite("HRRR pressure artifact probe service", .serialized)
 struct HRRRPressureArtifactProbeServiceTests {
+    @Test("default pressure warm dispatcher disables automatic retries")
+    func defaultWarmDispatcherDisablesAutomaticRetries() async throws {
+        try await withApp { app, _ in
+            app.queues.use(.test)
+            let payload = makePayload(from: makePressureCandidate(from: makeSurfaceCandidate()))
+
+            try await DefaultPressureArtifactWarmJobDispatcher().dispatch(
+                payload,
+                to: ArcusQueueLane.modelArtifacts.queueName,
+                on: app
+            )
+
+            let jobID = try #require(app.queues.test.queue.first)
+            let jobData = try #require(app.queues.test.jobs[jobID])
+            #expect(jobData.jobName == PressureArtifactWarmJob.name)
+            #expect(jobData.maxRetryCount == 0)
+            #expect(try PressureArtifactWarmJob.parsePayload(jobData.payload).acquisitionAttempt == 0)
+        }
+    }
+
     @Test("unavailable idx conflicts update only lastCheckedAt")
     func unavailableIdxConflictsUpdateOnlyLastCheckedAt() async throws {
         try await withApp { app, _ in

--- a/Tests/AppTests/PressureArtifactFailureCompletionJobTests.swift
+++ b/Tests/AppTests/PressureArtifactFailureCompletionJobTests.swift
@@ -28,7 +28,7 @@ struct PressureArtifactFailureCompletionJobTests {
                 failureCompleter: completer
             )
 
-            await #expect(throws: PressureArtifactWarmingError.self) {
+            await #expect(throws: PressureArtifactFailureDispositionError.self) {
                 try await service.warm(payload: artifact, on: app, logger: app.logger)
             }
 

--- a/Tests/AppTests/PressureArtifactWarmJobTests.swift
+++ b/Tests/AppTests/PressureArtifactWarmJobTests.swift
@@ -9,6 +9,372 @@ import ArcusCore
 
 @Suite("Pressure artifact warm job", .serialized)
 struct PressureArtifactWarmJobTests {
+    @Test("pressure warm retry delays are deterministic and positive")
+    func retryDelaysAreDeterministicAndPositive() {
+        let initialPayload = makePayload()
+        let firstRetry = PressureArtifactWarmRetryPolicy.continuation(after: initialPayload)
+        let secondRetry = firstRetry.flatMap {
+            PressureArtifactWarmRetryPolicy.continuation(after: $0.payload)
+        }
+
+        #expect(PressureArtifactWarmRetryPolicy.maximumAcquisitionAttempts == 3)
+        #expect(firstRetry?.payload.acquisitionAttempt == 1)
+        #expect(firstRetry?.delaySeconds == 30)
+        #expect(secondRetry?.payload.acquisitionAttempt == 2)
+        #expect(secondRetry?.delaySeconds == 120)
+        #expect(firstRetry?.delaySeconds ?? 0 > 0)
+        #expect(secondRetry?.delaySeconds ?? 0 > 0)
+        #expect(secondRetry.flatMap {
+            PressureArtifactWarmRetryPolicy.continuation(after: $0.payload)
+        } == nil)
+    }
+
+    @Test("legacy pressure warm payloads decode as initial acquisition attempts")
+    func legacyPayloadsDecodeAsInitialAttempts() throws {
+        let payload = makePayload()
+        let encoded = try JSONEncoder().encode(payload)
+        var object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        object.removeValue(forKey: "acquisitionAttempt")
+
+        let legacyData = try JSONSerialization.data(withJSONObject: object)
+        let decoded = try JSONDecoder().decode(PressureArtifactWarmJobPayload.self, from: legacyData)
+
+        #expect(decoded.acquisitionAttempt == 0)
+    }
+
+    @Test("pressure warm retry classification is narrow")
+    func retryClassificationIsNarrow() {
+        let source = makeSourceMetadata(for: makePayload())
+
+        #expect(PressureArtifactWarmRetryPolicy.isTransientAcquisitionFailure(
+            PressureArtifactAcquisitionError.classify(URLError(.timedOut))
+        ))
+        #expect(PressureArtifactWarmRetryPolicy.isTransientAcquisitionFailure(
+            PressureArtifactAcquisitionError.classify(URLError(.networkConnectionLost))
+        ))
+        #expect(PressureArtifactWarmRetryPolicy.isTransientAcquisitionFailure(
+            PressureArtifactAcquisitionError.classify(URLError(.dnsLookupFailed))
+        ))
+        #expect(PressureArtifactWarmRetryPolicy.isTransientAcquisitionFailure(
+            PressureArtifactWarmingError.warmAttemptTimedOut(seconds: 900)
+        ))
+        #expect(PressureArtifactWarmRetryPolicy.isTransientAcquisitionFailure(
+            PressureArtifactAcquisitionError.classify(
+                DescribedPressureArtifactWarmError(description: "HTTPClientError.readTimeout")
+            )
+        ))
+        #expect(PressureArtifactWarmRetryPolicy.isTransientAcquisitionFailure(
+            PressureArtifactAcquisitionError.classify(
+                DescribedPressureArtifactWarmError(description: "HTTPClientError.remoteConnectionClosed")
+            )
+        ))
+        #expect(PressureArtifactWarmRetryPolicy.isTransientAcquisitionFailure(CancellationError()) == false)
+        #expect(PressureArtifactWarmRetryPolicy.isTransientAcquisitionFailure(
+            PressureArtifactWarmingError.noSelectableMessages
+        ) == false)
+        #expect(PressureArtifactWarmRetryPolicy.isTransientAcquisitionFailure(
+            HrrrPressureByteRangeDownloaderError.emptyResponseBody(source: source, range: "bytes=0-3")
+        ) == false)
+        #expect(PressureArtifactWarmRetryPolicy.isTransientAcquisitionFailure(
+            HrrrPressureSubsetGribCacheError.responseTooLarge(
+                source: source,
+                byteCount: 2,
+                maximumByteCount: 1
+            )
+        ) == false)
+        #expect(PressureArtifactWarmRetryPolicy.isTransientAcquisitionFailure(
+            HrrrPressureSubsetGribCacheError.checksumMismatch(
+                source: source,
+                expected: "expected",
+                actual: "actual"
+            )
+        ) == false)
+        #expect(PressureArtifactWarmRetryPolicy.isTransientAcquisitionFailure(
+            PressureArtifactWarmValidatorStubError.failedValidation
+        ) == false)
+        #expect(PressureArtifactWarmRetryPolicy.isTransientAcquisitionFailure(
+            DescribedPressureArtifactWarmError(
+                description: "unknown work timed out after a DNS connection reset failed"
+            )
+        ) == false)
+    }
+
+    @Test("transient queue failure is delayed and a later attempt succeeds")
+    func transientQueueFailureIsDelayedAndLaterAttemptSucceeds() async throws {
+        try await withApp { app, blockingWorkExecutor in
+            let payload = makePayload()
+            let sourceURLs = makeSourceURLs(for: payload)
+            try await seedCatalogRow(status: .pending, payload: payload, on: app.db)
+            let client = PressureArtifactWarmStubHTTPClient(
+                idxResponses: [sourceURLs.idx.absoluteString: Data(makeCompleteInventoryText().utf8)],
+                rangeResponses: makeRangeResponses(for: payload),
+                idxFailureDescriptions: [sourceURLs.idx.absoluteString: ["HTTPClientError.remoteConnectionClosed"]]
+            )
+            let service = makeWarmingService(
+                blockingWorkExecutor: blockingWorkExecutor,
+                client: client
+            )
+            app.queues.use(.test)
+            app.queues.add(PressureArtifactWarmJob(warmingService: service))
+            try await DefaultPressureArtifactWarmJobDispatcher().dispatch(
+                payload,
+                to: ArcusQueueLane.modelArtifacts.queueName,
+                on: app
+            )
+
+            let firstAttemptStartedAt = Date()
+            try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
+
+            let delayed = try queuedJobData(on: app)
+            let retryPayload = try PressureArtifactWarmJob.parsePayload(delayed.data.payload)
+            #expect(delayed.data.maxRetryCount == 0)
+            #expect(retryPayload.acquisitionAttempt == 1)
+            let delayUntil = try #require(delayed.data.delayUntil)
+            #expect((29...31).contains(delayUntil.timeIntervalSince(firstAttemptStartedAt)))
+            let failedRow = try #require(try await findCatalogRow(for: payload, on: app.db))
+            #expect(failedRow.status == .failed)
+            #expect(failedRow.claimToken == nil)
+            #expect(failedRow.leaseExpiresAt == nil)
+
+            try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
+            let stillDelayed = try queuedJobData(on: app)
+            #expect(try PressureArtifactWarmJob.parsePayload(stillDelayed.data.payload).acquisitionAttempt == 1)
+            #expect(client.idxRequestCount == 1)
+
+            makeQueuedJobEligible(stillDelayed, on: app)
+            try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
+
+            let readyRow = try #require(try await findCatalogRow(for: payload, on: app.db))
+            #expect(app.queues.test.queue.isEmpty)
+            #expect(app.queues.test.jobs.isEmpty)
+            #expect(client.idxRequestCount == 2)
+            #expect(readyRow.status == .ready)
+            #expect(readyRow.claimToken == nil)
+            #expect(readyRow.leaseExpiresAt == nil)
+        }
+    }
+
+    @Test("transient range failure schedules a delayed continuation that later succeeds")
+    func transientRangeFailureSchedulesDelayedContinuationThatLaterSucceeds() async throws {
+        try await withApp { app, blockingWorkExecutor in
+            let payload = makePayload()
+            let sourceURLs = makeSourceURLs(for: payload)
+            try await seedCatalogRow(status: .pending, payload: payload, on: app.db)
+            let client = PressureArtifactWarmStubHTTPClient(
+                idxResponses: [sourceURLs.idx.absoluteString: Data(makeCompleteInventoryText().utf8)],
+                rangeResponses: makeRangeResponses(for: payload),
+                rangeFailureCodes: [sourceURLs.grib.absoluteString: [.networkConnectionLost]]
+            )
+            let service = makeWarmingService(
+                blockingWorkExecutor: blockingWorkExecutor,
+                client: client
+            )
+            app.queues.use(.test)
+            app.queues.add(PressureArtifactWarmJob(warmingService: service))
+            try await DefaultPressureArtifactWarmJobDispatcher().dispatch(
+                payload,
+                to: ArcusQueueLane.modelArtifacts.queueName,
+                on: app
+            )
+
+            try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
+
+            let delayed = try queuedJobData(on: app)
+            #expect(delayed.data.maxRetryCount == 0)
+            #expect(try PressureArtifactWarmJob.parsePayload(delayed.data.payload).acquisitionAttempt == 1)
+            #expect(client.rangeRequestCount == 1)
+
+            makeQueuedJobEligible(delayed, on: app)
+            try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
+
+            let row = try #require(try await findCatalogRow(for: payload, on: app.db))
+            #expect(app.queues.test.queue.isEmpty)
+            #expect(app.queues.test.jobs.isEmpty)
+            #expect(client.idxRequestCount == 2)
+            #expect(client.rangeRequestCount > 1)
+            #expect(row.status == .ready)
+            #expect(row.claimToken == nil)
+            #expect(row.leaseExpiresAt == nil)
+        }
+    }
+
+    @Test("three transient failures exhaust the queue job and leave a claim-free failed row")
+    func transientFailureExhaustionLeavesClaimFreeFailedRow() async throws {
+        try await withApp { app, blockingWorkExecutor in
+            let payload = makePayload()
+            let sourceURLs = makeSourceURLs(for: payload)
+            try await seedCatalogRow(status: .pending, payload: payload, on: app.db)
+            let client = PressureArtifactWarmStubHTTPClient(
+                idxFailureCodes: [sourceURLs.idx.absoluteString: [.timedOut, .timedOut, .timedOut]]
+            )
+            let service = makeWarmingService(
+                blockingWorkExecutor: blockingWorkExecutor,
+                client: client
+            )
+            app.queues.use(.test)
+            app.queues.add(PressureArtifactWarmJob(warmingService: service))
+            try await DefaultPressureArtifactWarmJobDispatcher().dispatch(
+                payload,
+                to: ArcusQueueLane.modelArtifacts.queueName,
+                on: app
+            )
+
+            for expectedFailureCount in 1...2 {
+                let attemptStartedAt = Date()
+                try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
+                let delayed = try queuedJobData(on: app)
+                let retryPayload = try PressureArtifactWarmJob.parsePayload(delayed.data.payload)
+                #expect(delayed.data.maxRetryCount == 0)
+                #expect(retryPayload.acquisitionAttempt == expectedFailureCount)
+                let expectedDelay = expectedFailureCount == 1 ? 30.0 : 120.0
+                let delayUntil = try #require(delayed.data.delayUntil)
+                #expect(((expectedDelay - 1)...(expectedDelay + 1)).contains(
+                    delayUntil.timeIntervalSince(attemptStartedAt)
+                ))
+
+                try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
+                let stillDelayed = try queuedJobData(on: app)
+                #expect(
+                    try PressureArtifactWarmJob.parsePayload(stillDelayed.data.payload).acquisitionAttempt
+                        == expectedFailureCount
+                )
+                #expect(client.idxRequestCount == expectedFailureCount)
+                makeQueuedJobEligible(stillDelayed, on: app)
+            }
+            try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
+
+            let row = try #require(try await findCatalogRow(for: payload, on: app.db))
+            #expect(client.idxRequestCount == 3)
+            #expect(app.queues.test.queue.isEmpty)
+            #expect(app.queues.test.jobs.isEmpty)
+            #expect(row.status == .failed)
+            #expect(row.claimToken == nil)
+            #expect(row.leaseExpiresAt == nil)
+        }
+    }
+
+    @Test("deferred failure completion does not schedule an acquisition continuation")
+    func deferredFailureCompletionDoesNotScheduleAcquisitionContinuation() async throws {
+        try await withApp { app, blockingWorkExecutor in
+            let payload = makePayload()
+            let sourceURLs = makeSourceURLs(for: payload)
+            try await seedCatalogRow(status: .pending, payload: payload, on: app.db)
+            let completionDispatcher = RecordingPressureArtifactFailureCompletionDispatcher()
+            let retryDispatcher = RecordingPressureArtifactWarmRetryDispatcher()
+            let service = PressureArtifactWarmingService(
+                httpClient: PressureArtifactWarmStubHTTPClient(
+                    idxFailureCodes: [sourceURLs.idx.absoluteString: [.timedOut]]
+                ),
+                blockingWorkExecutor: blockingWorkExecutor,
+                validator: PressureArtifactWarmValidatorStub(lineCount: makeExpectedValidationLineCount()),
+                cacheRootURL: testRootURL(),
+                dateProvider: FixedStormSetupDateProvider(nowDate: makeDate()),
+                retentionDuration: serviceRetentionSeconds,
+                maximumByteCount: serviceMaximumByteCount,
+                failureCompleter: AlwaysFailingPressureArtifactFailureCompleter(),
+                failureCompletionDispatcher: completionDispatcher
+            )
+            app.queues.use(.test)
+            app.queues.add(PressureArtifactWarmJob(
+                warmingService: service,
+                retryDispatcher: retryDispatcher
+            ))
+            try await DefaultPressureArtifactWarmJobDispatcher().dispatch(
+                payload,
+                to: ArcusQueueLane.modelArtifacts.queueName,
+                on: app
+            )
+
+            try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
+
+            let row = try #require(try await findCatalogRow(for: payload, on: app.db))
+            #expect(completionDispatcher.payloads.count == 1)
+            #expect(retryDispatcher.continuations.isEmpty)
+            #expect(app.queues.test.queue.isEmpty)
+            #expect(app.queues.test.jobs.isEmpty)
+            #expect(row.status == .warming)
+            #expect(row.claimToken != nil)
+            #expect(row.leaseExpiresAt != nil)
+        }
+    }
+
+    @Test("failed durable completion dispatch remains a zero-retry warm failure")
+    func failedCompletionDispatchRemainsZeroRetryWarmFailure() async throws {
+        try await withApp { app, blockingWorkExecutor in
+            let payload = makePayload()
+            let sourceURLs = makeSourceURLs(for: payload)
+            try await seedCatalogRow(status: .pending, payload: payload, on: app.db)
+            let retryDispatcher = RecordingPressureArtifactWarmRetryDispatcher()
+            let service = PressureArtifactWarmingService(
+                httpClient: PressureArtifactWarmStubHTTPClient(
+                    idxFailureCodes: [sourceURLs.idx.absoluteString: [.timedOut]]
+                ),
+                blockingWorkExecutor: blockingWorkExecutor,
+                validator: PressureArtifactWarmValidatorStub(lineCount: makeExpectedValidationLineCount()),
+                cacheRootURL: testRootURL(),
+                dateProvider: FixedStormSetupDateProvider(nowDate: makeDate()),
+                retentionDuration: serviceRetentionSeconds,
+                maximumByteCount: serviceMaximumByteCount,
+                failureCompleter: AlwaysFailingPressureArtifactFailureCompleter(),
+                failureCompletionDispatcher: ThrowingPressureArtifactFailureCompletionDispatcher()
+            )
+            app.queues.use(.test)
+            app.queues.add(PressureArtifactWarmJob(
+                warmingService: service,
+                retryDispatcher: retryDispatcher
+            ))
+            try await DefaultPressureArtifactWarmJobDispatcher().dispatch(
+                payload,
+                to: ArcusQueueLane.modelArtifacts.queueName,
+                on: app
+            )
+
+            try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
+
+            let row = try #require(try await findCatalogRow(for: payload, on: app.db))
+            #expect(retryDispatcher.continuations.isEmpty)
+            #expect(app.queues.test.queue.isEmpty)
+            #expect(app.queues.test.jobs.isEmpty)
+            #expect(row.status == .warming)
+            #expect(row.claimToken != nil)
+            #expect(row.leaseExpiresAt != nil)
+        }
+    }
+
+    @Test("failed acquisition continuation dispatch leaves a claim-free failed row")
+    func failedAcquisitionContinuationDispatchLeavesClaimFreeFailedRow() async throws {
+        try await withApp { app, blockingWorkExecutor in
+            let payload = makePayload()
+            let sourceURLs = makeSourceURLs(for: payload)
+            try await seedCatalogRow(status: .pending, payload: payload, on: app.db)
+            let service = makeWarmingService(
+                blockingWorkExecutor: blockingWorkExecutor,
+                client: PressureArtifactWarmStubHTTPClient(
+                    idxFailureCodes: [sourceURLs.idx.absoluteString: [.timedOut]]
+                )
+            )
+            app.queues.use(.test)
+            app.queues.add(PressureArtifactWarmJob(
+                warmingService: service,
+                retryDispatcher: ThrowingPressureArtifactWarmRetryDispatcher()
+            ))
+            try await DefaultPressureArtifactWarmJobDispatcher().dispatch(
+                payload,
+                to: ArcusQueueLane.modelArtifacts.queueName,
+                on: app
+            )
+
+            try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
+
+            let row = try #require(try await findCatalogRow(for: payload, on: app.db))
+            #expect(app.queues.test.queue.isEmpty)
+            #expect(app.queues.test.jobs.isEmpty)
+            #expect(row.status == .failed)
+            #expect(row.claimToken == nil)
+            #expect(row.leaseExpiresAt == nil)
+        }
+    }
+
     @Test("default pressure warmer propagates configured fractional HTTP timeout")
     func defaultPressureWarmerPropagatesConfiguredFractionalHTTPTimeout() async throws {
         try await withApp { app, _ in
@@ -63,7 +429,11 @@ struct PressureArtifactWarmJobTests {
                 retentionDuration: serviceRetentionSeconds,
                 maximumByteCount: serviceMaximumByteCount
             )
-            let job = PressureArtifactWarmJob(warmingService: service)
+            let retryDispatcher = RecordingPressureArtifactWarmRetryDispatcher()
+            let job = PressureArtifactWarmJob(
+                warmingService: service,
+                retryDispatcher: retryDispatcher
+            )
             let context = makeQueueContext(app: app)
 
             async let first = job.dequeue(context, payload)
@@ -160,10 +530,10 @@ struct PressureArtifactWarmJobTests {
                 maximumByteCount: serviceMaximumByteCount
             )
             let job = PressureArtifactWarmJob(warmingService: service)
+            let logHandler = CapturingLogHandler()
+            let logger = Logger(label: "pressure-warm-terminal", factory: { _ in logHandler })
 
-            await #expect(throws: PressureArtifactWarmJobError.self) {
-                try await job.dequeue(makeQueueContext(app: app), payload)
-            }
+            try await job.dequeue(makeQueueContext(app: app, logger: logger), payload)
 
             let row = try #require(try await PressureArtifactCatalogModel.find(
                 runTime: payload.runTime,
@@ -177,6 +547,10 @@ struct PressureArtifactWarmJobTests {
             #expect(row.errorSummary?.contains("failedValidation") == true)
             #expect(row.localPath == nil)
             #expect(row.byteSize == nil)
+            #expect(logHandler.events.contains { $0.message == "PressureArtifactWarmJob finished." } == false)
+            #expect(logHandler.events.contains {
+                $0.message == "PressureArtifactWarmJob completed with a terminal failure."
+            })
         }
     }
 
@@ -223,7 +597,9 @@ struct PressureArtifactWarmJobTests {
             #expect(renderedLogs.contains(sentinelURL.path) == false)
             #expect(renderedLogs.contains(sentinelURL.absoluteString) == false)
             #expect(renderedLogs.contains("Pressure artifact validation failed."))
-            #expect(renderedLogs.contains("Job failed"))
+            #expect(renderedLogs.contains("Pressure artifact failure completion deferred to durable queue work."))
+            #expect(renderedLogs.contains("PressureArtifactWarmJob left failure completion to durable queue work."))
+            #expect(renderedLogs.contains("PressureArtifactWarmJob scheduled a transient acquisition retry.") == false)
         }
     }
 
@@ -250,7 +626,11 @@ struct PressureArtifactWarmJobTests {
                 maximumByteCount: serviceMaximumByteCount,
                 recoveryTimeoutSeconds: 1_800
             )
-            let job = PressureArtifactWarmJob(warmingService: service)
+            let retryDispatcher = RecordingPressureArtifactWarmRetryDispatcher()
+            let job = PressureArtifactWarmJob(
+                warmingService: service,
+                retryDispatcher: retryDispatcher
+            )
 
             await #expect(throws: CancellationError.self) {
                 try await job.dequeue(makeQueueContext(app: app), payload)
@@ -278,12 +658,36 @@ struct PressureArtifactWarmJobTests {
             #expect(client.idxRequestCount == 1)
             #expect(client.rangeRequestCount == makeExpectedValidationLineCount())
             #expect(validator.validationCount == 1)
+            #expect(retryDispatcher.continuations.isEmpty)
             #expect(FileManager.default.fileExists(atPath: cachedKey.subsetFileURL(rootURL: cacheRoot).path))
             #expect(FileManager.default.fileExists(atPath: cachedKey.metadataFileURL(rootURL: cacheRoot).path))
         }
     }
 
-    @Test("whole-warm timeout releases dequeue and completes the owned claim as failed")
+    @Test("queue-worker cancellation does not dispatch an acquisition continuation")
+    func queueWorkerCancellationDoesNotDispatchAcquisitionContinuation() async throws {
+        try await withApp { app, _ in
+            let retryDispatcher = RecordingPressureArtifactWarmRetryDispatcher()
+            app.queues.use(.test)
+            app.queues.add(PressureArtifactWarmJob(
+                warmingService: CancellingPressureArtifactWarming(),
+                retryDispatcher: retryDispatcher
+            ))
+            try await DefaultPressureArtifactWarmJobDispatcher().dispatch(
+                makePayload(),
+                to: ArcusQueueLane.modelArtifacts.queueName,
+                on: app
+            )
+
+            try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
+
+            #expect(retryDispatcher.continuations.isEmpty)
+            #expect(app.queues.test.queue.isEmpty)
+            #expect(app.queues.test.jobs.isEmpty)
+        }
+    }
+
+    @Test("whole-warm timeout completes the owned claim and schedules a logical retry")
     func wholeWarmTimeoutReleasesDequeueAndCompletesOwnedClaimAsFailed() async throws {
         try await withApp { app, blockingWorkExecutor in
             let payload = makePayload()
@@ -302,23 +706,23 @@ struct PressureArtifactWarmJobTests {
                 warmTimeoutSeconds: 12,
                 timeoutSleeper: timeoutSleeper
             )
-            let job = PressureArtifactWarmJob(warmingService: service)
-            let dequeueTask = Task {
-                try await job.dequeue(makeQueueContext(app: app), payload)
+            app.queues.use(.test)
+            app.queues.add(PressureArtifactWarmJob(warmingService: service))
+            try await DefaultPressureArtifactWarmJobDispatcher().dispatch(
+                payload,
+                to: ArcusQueueLane.modelArtifacts.queueName,
+                on: app
+            )
+            let attemptStartedAt = Date()
+            let workerTask = Task {
+                try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
             }
 
             await client.waitUntilRequestStarts()
             await timeoutSleeper.waitUntilSleepStarts()
             await timeoutSleeper.fire()
 
-            do {
-                try await dequeueTask.value
-                Issue.record("Expected the queue-facing dequeue call to throw a warm timeout.")
-            } catch PressureArtifactWarmJobError.warmAttemptTimedOut(let seconds) {
-                #expect(seconds == 12)
-            } catch {
-                Issue.record("Expected a distinct warm timeout, got \(String(reflecting: error)).")
-            }
+            try await workerTask.value
 
             let row = try #require(
                 try await PressureArtifactCatalogModel.find(
@@ -336,6 +740,12 @@ struct PressureArtifactWarmJobTests {
             #expect(row.byteSize == nil)
             #expect(row.errorSummary == "Pressure artifact warm attempt timed out after 12 seconds.")
             #expect((row.errorSummary?.count ?? .max) < 100)
+            let delayed = try queuedJobData(on: app)
+            let retryPayload = try PressureArtifactWarmJob.parsePayload(delayed.data.payload)
+            let delayUntil = try #require(delayed.data.delayUntil)
+            #expect(delayed.data.maxRetryCount == 0)
+            #expect(retryPayload.acquisitionAttempt == 1)
+            #expect((29...31).contains(delayUntil.timeIntervalSince(attemptStartedAt)))
         }
     }
 
@@ -358,7 +768,11 @@ struct PressureArtifactWarmJobTests {
                 warmTimeoutSeconds: 12,
                 timeoutSleeper: timeoutSleeper
             )
-            let job = PressureArtifactWarmJob(warmingService: service)
+            let retryDispatcher = RecordingPressureArtifactWarmRetryDispatcher()
+            let job = PressureArtifactWarmJob(
+                warmingService: service,
+                retryDispatcher: retryDispatcher
+            )
             let dequeueTask = Task {
                 try await job.dequeue(makeQueueContext(app: app), payload)
             }
@@ -381,14 +795,7 @@ struct PressureArtifactWarmJobTests {
             await timeoutSleeper.waitUntilSleepStarts()
             await timeoutSleeper.fire()
 
-            do {
-                try await dequeueTask.value
-                Issue.record("Expected the stale owner to surface its warm timeout.")
-            } catch PressureArtifactWarmJobError.warmAttemptTimedOut(let seconds) {
-                #expect(seconds == 12)
-            } catch {
-                Issue.record("Expected a distinct warm timeout, got \(String(reflecting: error)).")
-            }
+            try await dequeueTask.value
 
             let refetched = try #require(
                 try await PressureArtifactCatalogModel.find(
@@ -402,6 +809,7 @@ struct PressureArtifactWarmJobTests {
             #expect(refetched.claimToken == newerClaimToken)
             #expect(refetched.leaseExpiresAt == newerLeaseExpiresAt)
             #expect(refetched.errorSummary == nil)
+            #expect(retryDispatcher.continuations.isEmpty)
         }
     }
 
@@ -869,8 +1277,8 @@ struct PressureArtifactWarmJobTests {
         #expect(requested.contains(50) == false)
     }
 
-    @Test("validation line-count mismatch marks the catalog row failed")
-    func validationLineCountMismatchMarksTheCatalogRowFailed() async throws {
+    @Test("validation failures containing transport words remain terminal")
+    func validationFailuresContainingTransportWordsRemainTerminal() async throws {
         try await withApp { app, blockingWorkExecutor in
             let payload = makePayload()
             let sourceURLs = makeSourceURLs(for: payload)
@@ -881,7 +1289,12 @@ struct PressureArtifactWarmJobTests {
                 idxResponses: [sourceURLs.idx.absoluteString: Data(makeCompleteInventoryText().utf8)],
                 rangeResponses: makeRangeResponses(for: payload)
             )
-            let validator = PressureArtifactWarmValidatorStub(lineCount: expectedLineCount - 1)
+            let validator = PressureArtifactWarmValidatorStub(
+                error: DescribedPressureArtifactWarmError(
+                    description: "validation timed out after DNS connection reset failed"
+                ),
+                lineCount: expectedLineCount
+            )
             let service = PressureArtifactWarmingService(
                 httpClient: client,
                 blockingWorkExecutor: blockingWorkExecutor,
@@ -893,9 +1306,14 @@ struct PressureArtifactWarmJobTests {
             )
             let job = PressureArtifactWarmJob(warmingService: service)
 
-            await #expect(throws: PressureArtifactWarmJobError.self) {
-                try await job.dequeue(makeQueueContext(app: app), payload)
-            }
+            app.queues.use(.test)
+            app.queues.add(job)
+            try await DefaultPressureArtifactWarmJobDispatcher().dispatch(
+                payload,
+                to: ArcusQueueLane.modelArtifacts.queueName,
+                on: app
+            )
+            try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
 
             let row = try #require(try await PressureArtifactCatalogModel.find(
                 runTime: payload.runTime,
@@ -906,9 +1324,12 @@ struct PressureArtifactWarmJobTests {
             ))
 
             #expect(row.status == .failed)
-            #expect(row.errorSummary?.contains("expected \(expectedLineCount)") == true)
-            #expect(row.errorSummary?.contains("returned \(expectedLineCount - 1) messages") == true)
+            #expect(row.errorSummary?.contains("validation timed out") == true)
+            #expect(row.errorSummary?.contains("DNS connection reset") == true)
             #expect(row.status != .ready)
+            #expect(validator.validationCount == 1)
+            #expect(app.queues.test.queue.isEmpty)
+            #expect(app.queues.test.jobs.isEmpty)
         }
     }
 
@@ -934,9 +1355,14 @@ struct PressureArtifactWarmJobTests {
             )
             let job = PressureArtifactWarmJob(warmingService: service)
 
-            await #expect(throws: PressureArtifactWarmJobError.self) {
-                try await job.dequeue(makeQueueContext(app: app), payload)
-            }
+            app.queues.use(.test)
+            app.queues.add(job)
+            try await DefaultPressureArtifactWarmJobDispatcher().dispatch(
+                payload,
+                to: ArcusQueueLane.modelArtifacts.queueName,
+                on: app
+            )
+            try await app.queues.queue(ArcusQueueLane.modelArtifacts.queueName).worker.run()
 
             let row = try #require(try await PressureArtifactCatalogModel.find(
                 runTime: payload.runTime,
@@ -951,6 +1377,8 @@ struct PressureArtifactWarmJobTests {
             #expect(row.status == .failed)
             #expect(row.status != .ready)
             #expect(row.errorSummary?.contains("selection is incomplete") == true)
+            #expect(app.queues.test.queue.isEmpty)
+            #expect(app.queues.test.jobs.isEmpty)
         }
     }
 
@@ -1007,6 +1435,55 @@ struct PressureArtifactWarmJobTests {
 }
 
 private extension PressureArtifactWarmJobTests {
+    func makeWarmingService(
+        blockingWorkExecutor: any PressureArtifactBlockingWorkExecuting,
+        client: any App.HTTPClient
+    ) -> PressureArtifactWarmingService {
+        PressureArtifactWarmingService(
+            httpClient: client,
+            blockingWorkExecutor: blockingWorkExecutor,
+            validator: PressureArtifactWarmValidatorStub(lineCount: makeExpectedValidationLineCount()),
+            cacheRootURL: testRootURL(),
+            dateProvider: FixedStormSetupDateProvider(nowDate: makeDate()),
+            retentionDuration: serviceRetentionSeconds,
+            maximumByteCount: serviceMaximumByteCount
+        )
+    }
+
+    func findCatalogRow(
+        for payload: PressureArtifactWarmJobPayload,
+        on db: any Database
+    ) async throws -> PressureArtifactCatalogModel? {
+        try await PressureArtifactCatalogModel.find(
+            runTime: payload.runTime,
+            forecastHour: payload.forecastHour,
+            product: payload.product,
+            fieldSetVersion: payload.fieldSetVersion,
+            on: db
+        )
+    }
+
+    func queuedJobData(on app: Application) throws -> (id: JobIdentifier, data: JobData) {
+        let id = try #require(app.queues.test.queue.first)
+        let data = try #require(app.queues.test.jobs[id])
+        return (id, data)
+    }
+
+    func makeQueuedJobEligible(
+        _ queuedJob: (id: JobIdentifier, data: JobData),
+        on app: Application
+    ) {
+        let data = queuedJob.data
+        app.queues.test.jobs[queuedJob.id] = JobData(
+            payload: data.payload,
+            maxRetryCount: data.maxRetryCount,
+            jobName: data.jobName,
+            delayUntil: .distantPast,
+            queuedAt: data.queuedAt,
+            attempts: data.attempts ?? 0
+        )
+    }
+
     func withApp(
         test: (Application, NIOThreadPoolPressureArtifactBlockingWorkExecutor) async throws -> Void
     ) async throws {
@@ -1214,6 +1691,64 @@ private struct AlwaysFailingPressureArtifactFailureCompleter: PressureArtifactFa
     }
 }
 
+private struct CancellingPressureArtifactWarming: PressureArtifactWarming {
+    func warm(
+        payload: PressureArtifactWarmJobPayload,
+        on application: Application,
+        logger: Logger
+    ) async throws {
+        _ = payload
+        _ = application
+        _ = logger
+        throw CancellationError()
+    }
+}
+
+private final class RecordingPressureArtifactFailureCompletionDispatcher: PressureArtifactFailureCompletionJobDispatching, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _payloads: [PressureArtifactFailureCompletionJobPayload] = []
+
+    var payloads: [PressureArtifactFailureCompletionJobPayload] {
+        lock.withLock { _payloads }
+    }
+
+    func dispatch(
+        _ payload: PressureArtifactFailureCompletionJobPayload,
+        on application: Application
+    ) async throws {
+        _ = application
+        lock.withLock {
+            _payloads.append(payload)
+        }
+    }
+}
+
+private struct ThrowingPressureArtifactFailureCompletionDispatcher: PressureArtifactFailureCompletionJobDispatching {
+    func dispatch(
+        _ payload: PressureArtifactFailureCompletionJobPayload,
+        on application: Application
+    ) async throws {
+        _ = payload
+        _ = application
+        throw PressureArtifactWarmTestDispatchError.failed
+    }
+}
+
+private struct ThrowingPressureArtifactWarmRetryDispatcher: PressureArtifactWarmRetryDispatching {
+    func dispatch(
+        _ continuation: PressureArtifactWarmRetryContinuation,
+        on application: Application
+    ) async throws {
+        _ = continuation
+        _ = application
+        throw PressureArtifactWarmTestDispatchError.failed
+    }
+}
+
+private enum PressureArtifactWarmTestDispatchError: Error {
+    case failed
+}
+
 private actor ControllablePressureArtifactWarmTimeoutSleeper: PressureArtifactWarmTimeoutSleeping {
     private var sleepStarted = false
     private var sleepStartedWaiters: [CheckedContinuation<Void, Never>] = []
@@ -1302,6 +1837,9 @@ private final class PressureArtifactWarmStubHTTPClient: App.HTTPClient, @uncheck
     private let idxResponses: [String: Data]
     private let rangeResponses: [String: HTTPResponse]
     private let lock = NSLock()
+    private var idxFailureCodes: [String: [URLError.Code]]
+    private var idxFailureDescriptions: [String: [String]]
+    private var rangeFailureCodes: [String: [URLError.Code]]
     private var _idxRequestCount = 0
     private var _rangeRequestCount = 0
     private var _requestedURLs: [String] = []
@@ -1310,10 +1848,16 @@ private final class PressureArtifactWarmStubHTTPClient: App.HTTPClient, @uncheck
 
     init(
         idxResponses: [String: Data] = [:],
-        rangeResponses: [String: HTTPResponse] = [:]
+        rangeResponses: [String: HTTPResponse] = [:],
+        idxFailureCodes: [String: [URLError.Code]] = [:],
+        idxFailureDescriptions: [String: [String]] = [:],
+        rangeFailureCodes: [String: [URLError.Code]] = [:]
     ) {
         self.idxResponses = idxResponses
         self.rangeResponses = rangeResponses
+        self.idxFailureCodes = idxFailureCodes
+        self.idxFailureDescriptions = idxFailureDescriptions
+        self.rangeFailureCodes = rangeFailureCodes
     }
 
     var idxRequestCount: Int {
@@ -1342,6 +1886,28 @@ private final class PressureArtifactWarmStubHTTPClient: App.HTTPClient, @uncheck
         if headers["Range"] == nil {
             lock.withLock { _idxRequestCount += 1 }
             lock.withLock { _idxRequestTimeouts.append(timeoutSeconds) }
+            let failureDescription = lock.withLock { () -> String? in
+                guard var descriptions = idxFailureDescriptions[url.absoluteString], !descriptions.isEmpty else {
+                    return nil
+                }
+                let description = descriptions.removeFirst()
+                idxFailureDescriptions[url.absoluteString] = descriptions
+                return description
+            }
+            if let failureDescription {
+                throw DescribedPressureArtifactWarmError(description: failureDescription)
+            }
+            let failureCode = lock.withLock { () -> URLError.Code? in
+                guard var codes = idxFailureCodes[url.absoluteString], !codes.isEmpty else {
+                    return nil
+                }
+                let code = codes.removeFirst()
+                idxFailureCodes[url.absoluteString] = codes
+                return code
+            }
+            if let failureCode {
+                throw URLError(failureCode)
+            }
             guard let data = idxResponses[url.absoluteString] else {
                 throw URLError(.badServerResponse)
             }
@@ -1355,6 +1921,17 @@ private final class PressureArtifactWarmStubHTTPClient: App.HTTPClient, @uncheck
 
         lock.withLock { _rangeRequestCount += 1 }
         lock.withLock { _rangeRequestTimeouts.append(timeoutSeconds) }
+        let failureCode = lock.withLock { () -> URLError.Code? in
+            guard var codes = rangeFailureCodes[url.absoluteString], !codes.isEmpty else {
+                return nil
+            }
+            let code = codes.removeFirst()
+            rangeFailureCodes[url.absoluteString] = codes
+            return code
+        }
+        if let failureCode {
+            throw URLError(failureCode)
+        }
         let key = url.absoluteString + "|" + (headers["Range"] ?? "")
         guard let response = rangeResponses[key] else {
             throw URLError(.badServerResponse)
@@ -1386,6 +1963,29 @@ private final class PressureArtifactWarmStubHTTPClient: App.HTTPClient, @uncheck
     }
 
     func clearCache() {}
+}
+
+private final class RecordingPressureArtifactWarmRetryDispatcher: PressureArtifactWarmRetryDispatching, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _continuations: [PressureArtifactWarmRetryContinuation] = []
+
+    var continuations: [PressureArtifactWarmRetryContinuation] {
+        lock.withLock { _continuations }
+    }
+
+    func dispatch(
+        _ continuation: PressureArtifactWarmRetryContinuation,
+        on application: Application
+    ) async throws {
+        _ = application
+        lock.withLock {
+            _continuations.append(continuation)
+        }
+    }
+}
+
+private struct DescribedPressureArtifactWarmError: Error, CustomStringConvertible {
+    let description: String
 }
 
 private enum PressureArtifactWarmValidatorStubError: Error, CustomStringConvertible {

--- a/docs/audits/weekly-bug-scan.md
+++ b/docs/audits/weekly-bug-scan.md
@@ -351,3 +351,188 @@
 - Validation: `swift test --filter NotificationSendJobFreshnessDecisionTests` passed (7 tests).
 - Follow-up fixed on `2026-07-26`: NWS lifecycle classification and cleanup now expire alerts with an elapsed `expires` timestamp when `ends` is absent. Regression coverage verifies both canonical state derivation and persisted-series cleanup.
 - Roadmap: APNs failure retry/backoff remains unresolved and is tracked in [GitHub issue #13](https://github.com/justinrooks/arcus-signal/issues/13). The planned slice adds bounded queue retries, exponential backoff, retryable ledger reclaim, and terminal handling for permanent token failures.
+
+## 2026-07-30
+
+### 1. Repository scanned
+- `arcus-signal`
+
+### 2. Commit window inspected
+- Last automation run marker: `2026-07-23T16:07:02.928Z`
+- Window used: commits after `2026-07-23T16:07:02Z` through `2026-07-30`
+- Commits inspected:
+  - `c539de30e3f22fdab9e1d6a8d5c2dbba580003b8` (`Harden NWS alert lifecycle and notification delivery (#151)`)
+  - `254728f4c54816e59a06bd4422418f75a57c7267` (`Filter notification candidates by 24-hour presence freshness (#152)`)
+  - `45b636218ab262ed9bbf8a7022e7cb16f3d30024` (`Document architecture recovery plan and execution guardrails (#172)`)
+  - `a12d34e26c757b691bb97412b43f0bdb6ed9f9ba` (`Centralize HRRR surface-to-pressure identity (#173)`)
+  - `9fbb0f2260dd215dedee8c5de4af37b7d8d3a95f` (`Extract pure H3 coverage result (#174)`)
+  - `7feb0ada715baf7e3b26d7641c194963d145dc17` (`Move H3 computation before the transaction (#175)`)
+  - `a4b9f436bdc8ed87380f45bdf64f6f5796c8595d` (`Isolate notification candidate selection #158`)
+
+### 3. Highest-risk changed areas
+- NWS alert lifecycle and final delivery eligibility (`Sources/App/Jobs/IngestNWSAlertsJob.swift`, `Sources/App/Jobs/NotificationSendJob.swift`, `Sources/App/Models/NWS/ArcusEvent.swift`)
+- Candidate freshness and H3/UGC selection (`Sources/App/Infrastructure/Notifications/LocationFreshnessPolicy.swift`, `Sources/App/Models/Notification/NotificationCandidateStore.swift`)
+- H3 coverage computation, persistence transaction, and notification outbox dispatch (`Sources/App/Jobs/H3CoverageBuilder.swift`, `Sources/App/Jobs/TargetEventRevisionJob.swift`)
+- HRRR surface-to-pressure artifact identity (`Sources/App/StormSetup/HrrrSourceModels.swift`, `Sources/App/StormSetup/AnvilProfilePreviewProvider.swift`, `Sources/App/StormSetup/HrrrPressureDirectObjectResolver.swift`)
+
+### 4. Findings table
+
+| Bug | Repo | Evidence | Impact | Confidence | Minimal fix | Validation |
+|---|---|---|---|---|---|---|
+| No credible bug found | `arcus-signal` | Reviewed all seven commits and the changed lifecycle, candidate-query, H3 targeting, and HRRR identity paths. Focused suites passed: `NotificationSendJobCandidateQueryTests` (3), `H3CoverageBuilderTests` (6), `TargetEventRevisionJobFallbackTests` (5), `StormSetupHrrrSourceTests` (16), and `NotificationSendJobFreshnessDecisionTests` (7). | No confirmed defect to fix. | High | None. | No implementation required; continue with the next weekly scan. |
+
+### 5. Top recommended fix
+- No fix recommended.
+- Why it matters: the prior lifecycle finding is fixed, candidate freshness remains enforced after extraction, and H3 computation moved outside the transaction without breaking persistence, fallback, or notification dispatch behavior.
+- Expected files touched: none.
+- Estimated churn: none.
+- Regression risk: none.
+
+### 6. Watchlist
+- No low-confidence concern met the evidence threshold. Future-dated presence was considered, but `Sources/App/Controllers/DeviceController.swift` rejects timestamps more than five minutes ahead, so the local evidence does not support a bug finding.
+
+### 7. Out-of-scope notes
+- All sibling repositories and external client implementations were intentionally not scanned. No cross-repository findings were included.
+
+### 8. No fix recommended
+- Evidence inspected: seven commits in the bounded window; direct inspection of NWS lifecycle cleanup and delivery gates, H3/UGC candidate queries, H3 coverage construction and transaction boundaries, HRRR surface-to-pressure identity, and the five focused test suites listed above.
+- Implementation recommended: `no`
+
+### Audit entry (short)
+- Date: `2026-07-30`
+- Repository reviewed: `arcus-signal`
+- Workflow reviewed: weekly bug scan (audit-only, commits since last automation run)
+- Commit window inspected: after `2026-07-23T16:07:02Z` through `2026-07-30`; seven commits
+- Files inspected:
+  - `Sources/App/Clients/NwsClient.swift`
+  - `Sources/App/Infrastructure/Notifications/LocationFreshnessPolicy.swift`
+  - `Sources/App/Jobs/H3CoverageBuilder.swift`
+  - `Sources/App/Jobs/IngestNWSAlertsJob.swift`
+  - `Sources/App/Jobs/NotificationSendJob.swift`
+  - `Sources/App/Jobs/TargetEventRevisionJob.swift`
+  - `Sources/App/Models/NWS/ArcusEvent.swift`
+  - `Sources/App/Models/Notification/NotificationCandidateStore.swift`
+  - `Sources/App/StormSetup/AnvilProfilePreviewProvider.swift`
+  - `Sources/App/StormSetup/HRRRPressureArtifactProbeService.swift`
+  - `Sources/App/StormSetup/HrrrPressureDirectObjectResolver.swift`
+  - `Sources/App/StormSetup/HrrrSourceModels.swift`
+  - `Tests/AppTests/H3CoverageBuilderTests.swift`
+  - `Tests/AppTests/NotificationSendJobCandidateQueryTests.swift`
+  - `Tests/AppTests/NotificationSendJobFreshnessDecisionTests.swift`
+  - `Tests/AppTests/StormSetupHrrrSourceTests.swift`
+  - `Tests/AppTests/TargetEventRevisionJobFallbackTests.swift`
+- Top finding: no credible bug found
+- Best next fix: no fix recommended; retain the current focused regression coverage
+- Implementation recommended: `no`
+- Out-of-scope repositories intentionally not scanned: all sibling repositories
+## 2026-08-06
+
+### 1. Repository scanned
+- `arcus-signal`
+
+### 2. Commit window inspected
+- Reliable previous end marker: `7d0f7bc51423f0f0df64663ffb02be1d872c302b` from the 2026-07-30 audit entry
+- Window used: commits after `7d0f7bc51423f0f0df64663ffb02be1d872c302b` through `51f4259b06f1e851f97ee37742e3384fe005f21a`
+- Dates: `2026-07-30T11:36:38-06:00` through `2026-08-02T13:05:34-06:00`
+- Commit count: 13
+- Start commit: `ed27578baabd48f63cb74c4dfb0f51ba1a154e0e`
+- End commit: `51f4259b06f1e851f97ee37742e3384fe005f21a`
+- Fallback strategy: none; the bounded window contained commits
+
+### 3. Highest-risk changed areas
+- Pressure-artifact catalog claims, probe transitions, cleanup, and warming completion (`Sources/App/Models/Data/PressureArtifactCatalogStore.swift`, `Sources/App/StormSetup/HRRRPressureArtifactProbeService.swift`, `Sources/App/StormSetup/PressureArtifactWarmingService.swift`)
+- Storm Setup cache I/O and Anvil evidence orchestration (`Sources/App/StormSetup/GribSubsetCache.swift`, `Sources/App/StormSetup/StormSetupSnapshotCache.swift`, `Sources/App/StormSetup/StormSetupProvider.swift`, `Sources/App/StormSetup/StormSetupAnvilEvidencePolicy.swift`)
+- Child-process cancellation and output draining (`Sources/App/StormSetup/GribAdapter.swift`)
+- NWS persistence and notification ledger ownership (`Sources/App/Services/NWSIngestPersistence.swift`, `Sources/App/Models/Notification/NotificationDeliveryStore.swift`)
+- Device-presence migration repair (`Sources/App/Migrations/RepairDevicePresenceSourceConstraintForExpandedLocationUploadSources.swift`)
+
+### 4. Findings
+
+#### BUG-SIGNAL-PRESSURE-PROBE-ENQUEUE-OVERWRITE
+
+- Finding ID: `BUG-SIGNAL-PRESSURE-PROBE-ENQUEUE-OVERWRITE`
+- Fingerprint: `weekly-bug-scan|arcus-signal|HRRRPressureArtifactProbeService.markProbeFailure|unconditional-post-dispatch-state-overwrite`
+- Repository: `arcus-signal`
+- Audit type: Weekly Bug Scan
+- Title: Probe enqueue failure can overwrite active or completed pressure-artifact work
+- Status: `NEW`
+- Severity: `MEDIUM`
+- Confidence: `MEDIUM`
+- First observed: `2026-08-06`
+- Last verified: `2026-08-06`
+- Affected files and symbols: `Sources/App/StormSetup/HRRRPressureArtifactProbeService.swift` (`probe`), `Sources/App/Models/Data/PressureArtifactCatalogStore.swift` (`markProbeFailure`), `Sources/App/StormSetup/PressureArtifactWarmingService.swift` (`warm`, `claimCatalogRow`, `markReady`)
+- Failure mode: The probe changes a row to `pending`, dispatches `PressureArtifactWarmJob`, and treats any dispatch error as proof that the job was not accepted. If queue acceptance succeeds but the dispatcher throws afterward, the worker may advance the row to `warming` or `ready` before the probe catch path executes. `markProbeFailure` updates by artifact identity without a status or ownership predicate, so it can erase an active claim or replace a valid ready artifact with `failed`, clearing `local_path` and `byte_size`.
+- Evidence: Commit `1f5cda034628b4ae806cfca541e522353307c9e5` centralized the transition while preserving its behavior. `HRRRPressureArtifactProbeService.probe` claims at lines 204-223, dispatches at 225-230, and calls `markProbeFailure` for a non-cancellation error at 244-251. `PressureArtifactCatalogStore.markProbeFailure` at lines 474-499 has no current-state or ownership predicate. `PressureArtifactWarmingService` can legitimately claim the pending row at lines 112-117 and complete it ready at 288-304. The existing dispatch-failure test covers only a dispatcher that throws without advancing the row.
+- Blast radius: Affected cycles can lose current pressure-profile evidence until a later probe and warm cycle recovers the artifact, degrading Storm Setup analysis. Reachability is limited to ambiguous queue-dispatch failures, but the state mutation can discard completed work.
+- Minimal fix strategy: Make probe-failure persistence compare-and-set against the probe-owned pending transition so it cannot mutate `warming` or `ready`. Preserve the ordinary pre-enqueue failure behavior. Avoid broader queue or retry redesign.
+- Required validation: Deterministic integration tests that advance the row to `warming` and `ready` before the dispatcher throws, proving lease/claim and artifact metadata remain intact; retain the ordinary dispatch-failure test; run `HRRRPressureArtifactProbeServiceTests` and `PressureArtifactWarmJobTests`.
+- Related GitHub issue: [#198](https://github.com/justinrooks/arcus-signal/issues/198)
+- Triage: `ACTIONABLE`
+
+### 5. Watchlist
+- None. No lower-confidence candidate in the bounded window had enough concrete local evidence to retain.
+
+### 6. Resolved findings
+- None re-verified in this bounded window.
+
+### 7. Top finding
+- `BUG-SIGNAL-PRESSURE-PROBE-ENQUEUE-OVERWRITE`
+
+### 8. Best next fix
+- Add an ownership/current-state predicate to probe failure persistence and regression-test ambiguous dispatch outcomes where the worker has already reached `warming` or `ready`.
+- Expected files: `Sources/App/Models/Data/PressureArtifactCatalogStore.swift`, optionally `Sources/App/StormSetup/HRRRPressureArtifactProbeService.swift`, and `Tests/AppTests/HRRRPressureArtifactProbeServiceTests.swift`.
+- Estimated churn: small, approximately 30-70 LOC.
+- Regression risk: low to medium; the ordinary pre-enqueue error path must continue to become `failed`.
+- Implementation recommended: `yes`
+
+### 9. Validation
+- `swift test --filter HRRRPressureArtifactProbeServiceTests` passed (11 tests).
+- `swift test --filter PressureArtifactWarmJobTests` passed (18 tests).
+- `swift test --filter ProcessRunnerTests` passed (9 tests).
+- `swift test --filter StormSetupAnvilEvidencePolicyTests` passed (6 tests).
+- `swift test --filter StormSetupGribSubsetCacheTests` passed (13 tests).
+- `swift test --filter StormSetupSnapshotCacheTests` passed (14 tests).
+- Total focused validation: 71 tests passed.
+
+### 10. GitHub triage
+- GitHub issues created: [#198](https://github.com/justinrooks/arcus-signal/issues/198)
+- GitHub issues updated: none
+- Existing issues referenced: none; searches by finding mechanism and affected subsystem found no equivalent open issue
+
+### 11. Files inspected
+- `Sources/App/Models/Data/PressureArtifactCatalogStore.swift`
+- `Sources/App/Models/Notification/NotificationDeliveryStore.swift`
+- `Sources/App/Services/NWSIngestPersistence.swift`
+- `Sources/App/StormSetup/APIDependencyComposition.swift`
+- `Sources/App/StormSetup/AnvilProfilePreviewProvider.swift`
+- `Sources/App/StormSetup/GribAdapter.swift`
+- `Sources/App/StormSetup/GribSubsetCache.swift`
+- `Sources/App/StormSetup/HRRRPressureArtifactProbeService.swift`
+- `Sources/App/StormSetup/PressureArtifactCleanupService.swift`
+- `Sources/App/StormSetup/PressureArtifactWarmingService.swift`
+- `Sources/App/StormSetup/StormSetupAnvilEvidencePolicy.swift`
+- `Sources/App/StormSetup/StormSetupProvider.swift`
+- `Sources/App/StormSetup/StormSetupSnapshotCache.swift`
+- `Sources/App/Migrations/RepairDevicePresenceSourceConstraintForExpandedLocationUploadSources.swift`
+- `Tests/AppTests/HRRRPressureArtifactProbeServiceTests.swift`
+- `Tests/AppTests/PressureArtifactWarmJobTests.swift`
+- `Tests/AppTests/ProcessRunnerTests.swift`
+- `Tests/AppTests/StormSetupAnvilEvidencePolicyTests.swift`
+- `Tests/AppTests/StormSetupGribSubsetCacheTests.swift`
+- `Tests/AppTests/StormSetupSnapshotCacheTests.swift`
+
+### 12. Scope notes
+- Repository scanned: `arcus-signal` only.
+- Out-of-scope repositories: all sibling repositories and external clients were intentionally not scanned.
+- Skipped evidence: no cross-repository claims were evaluated or included.
+
+### Audit entry (short)
+- Date: `2026-08-06`
+- Repository reviewed: `arcus-signal`
+- Workflow reviewed: weekly bug scan (audit-only, commits since the reliable previous end marker)
+- Commit window inspected: `ed27578baabd48f63cb74c4dfb0f51ba1a154e0e` through `51f4259b06f1e851f97ee37742e3384fe005f21a`; 13 commits
+- Files inspected: pressure-artifact catalog/probe/warm/cleanup paths, Storm Setup cache and evidence orchestration, child-process cancellation, NWS persistence, notification ledger ownership, migration repair, and focused tests listed above
+- Top finding: probe enqueue failure can overwrite pressure-artifact work that a worker has already advanced to `warming` or `ready`
+- Best next fix: constrain `markProbeFailure` to the probe-owned pending state and add deterministic ambiguous-dispatch regression tests
+- Implementation recommended: `yes`
+- Out-of-scope repositories intentionally not scanned: all sibling repositories

--- a/docs/audits/weekly-test-gap-audit.md
+++ b/docs/audits/weekly-test-gap-audit.md
@@ -156,3 +156,86 @@
 - Implementation recommended: no - implemented on 2026-07-26
 - Implementation status: implemented on 2026-07-26 by [`/Users/justin/Code/arcus-signal/Tests/AppTests/AirQualityTests.swift`](/Users/justin/Code/arcus-signal/Tests/AppTests/AirQualityTests.swift)
 - Out-of-scope repositories intentionally not scanned: all sibling repositories and external AirNow implementation details
+
+## 2026-07-28
+- Repository reviewed: `arcus-signal`
+- Commit window inspected: since the last automation run (`2026-07-21T15:01:58.004Z` through `2026-07-28`); commits `c539de30e3f22fdab9e1d6a8d5c2dbba580003b8` and `254728f4c54816e59a06bd4422418f75a57c7267`
+- High-risk areas inspected:
+  - NWS lifecycle derivation and cleanup when `expires` or `ends` reaches its terminal timestamp
+  - send-boundary suppression for inactive or expired series while preserving explicit cancellation and all-clear delivery
+  - H3 and UGC candidate filtering at the shared 24-hour presence cutoff
+  - operator-dashboard reporting and stored-snapshot compatibility for candidate-query eligibility
+- Files inspected:
+  - `Sources/App/Clients/NwsClient.swift`
+  - `Sources/App/Infrastructure/Notifications/LocationFreshnessPolicy.swift`
+  - `Sources/App/Jobs/IngestNWSAlertsJob.swift`
+  - `Sources/App/Jobs/NotificationSendJob.swift`
+  - `Sources/App/Models/API/OperatorDashboardSnapshotResponse.swift`
+  - `Sources/App/Models/NWS/ArcusEvent.swift`
+  - `Sources/App/Models/Notification/NotificationSendAttemptModel.swift`
+  - `Sources/App/lib/OperatorDashboardSnapshotRefresher.swift`
+  - `Tests/AppTests/LocationFreshnessPolicyTests.swift`
+  - `Tests/AppTests/NWSAlertLifecycleTests.swift`
+  - `Tests/AppTests/NotificationSendJobCandidateQueryTests.swift`
+  - `Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift`
+  - `Tests/AppTests/NotificationSendJobFreshnessDecisionTests.swift`
+  - `Tests/AppTests/OperatorDashboardTargetableCoverageTests.swift`
+  - `Tests/AppTests/OperatorDashboardTests.swift`
+- Existing relevant tests found:
+  - `NWSAlertLifecycleTests` covers earliest-terminal lifecycle derivation and cleanup of active series whose `expires` has elapsed while `ends` is absent
+  - `NotificationSendJobFreshnessDecisionTests` covers inactive/expired new and update suppression plus explicit terminal-notification eligibility at the pure decision boundary
+  - `NotificationSendJobCandidateQueryTests` covers H3 and UGC inclusion at the exact 24-hour cutoff and exclusion immediately beyond it, while preserving active/subscribed/token filters
+  - `LocationFreshnessPolicyTests`, `OperatorDashboardTargetableCoverageTests`, and `OperatorDashboardTests` cover the shared threshold, aggregate semantics, legacy snapshot defaults, API projection, and rendered metrics
+- Recommended test gap:
+  - Behavior: `NotificationSendJob.dequeue` must stop an inactive or expired normal notification before candidate resolution and APNs delivery, then persist one send-attempt summary with `noOpReason == inactiveOrExpiredSeries`
+  - Repository: `arcus-signal`
+  - Evidence: commit `c539de30e3f22fdab9e1d6a8d5c2dbba580003b8`; production wiring in `Sources/App/Jobs/NotificationSendJob.swift`; only the extracted `deliveryNoOpReason` helper is exercised by `Tests/AppTests/NotificationSendJobFreshnessDecisionTests.swift`, while adjacent delivery-boundary tests do not execute this early-return path
+  - Risk reduced: prevents a regression that could send stale severe-weather alerts or silently lose the operator-visible no-op accounting used to diagnose suppressed delivery
+  - Test type: integration
+  - Suggested test name: `dequeuePersistsInactiveSeriesNoOpWithoutResolvingCandidatesOrSending`
+  - Minimal setup: seed an inactive series and send-attempt table, execute `dequeue` with a recording sender, then query the persisted attempt
+  - Expected assertion: sender call count is zero, candidate resolution is false, counts remain zero, and exactly one attempt records `inactiveOrExpiredSeries`
+  - Size: S
+  - Confidence: Medium
+- Top recommended test: add the inactive-series `dequeue` integration test to the existing notification delivery-boundary suite; expected files touched: `Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift`; estimated churn: roughly 30-60 lines; regression risk: low
+- GitHub issue: [#154 — Characterize notification dequeue lifecycle](https://github.com/justinrooks/arcus-signal/issues/154) captured this exact finding, is labeled `test`, is attached to Project Arcus, and is closed after implementation
+- Watchlist items:
+  - The newly enabled `Flood Advisory`, `Flood Statement`, and `Heat Advisory` request-filter values rely on the existing NWS HTTP request-contract test. Promote only if that test does not assert the complete event whitelist after these commits.
+- Implementation recommended: yes, as one focused integration test
+- Out-of-scope repositories intentionally not scanned: all sibling repositories and external NWS/APNs implementations
+
+## 2026-08-04
+- Repository reviewed: `arcus-signal`
+- Commit window inspected: since the last automation run (`2026-07-28T15:01:54.935Z` through `2026-08-04`); 18 commits from `45b636218ab262ed9bbf8a7022e7cb16f3d30024` through `51f4259b06f1e851f97ee37742e3384fe005f21a`
+- High-risk areas inspected:
+  - notification candidate selection, atomic ledger claims/completions, duplicate suppression, and inactive-series send suppression
+  - NWS event/revision transactional persistence, lineage reconciliation, dispatch-intent creation, and rollback behavior
+  - Storm Setup cache I/O serialization, candidate fallback, pressure-artifact catalog transitions, and child-process cancellation/timeout cleanup
+- Files inspected:
+  - `Sources/App/Models/Notification/NotificationCandidateStore.swift`
+  - `Sources/App/Models/Notification/NotificationDeliveryStore.swift`
+  - `Sources/App/Jobs/NotificationSendJob.swift`
+  - `Sources/App/Services/NWSIngestPersistence.swift`
+  - `Sources/App/Jobs/IngestNWSAlertsJob.swift`
+  - `Sources/App/StormSetup/GribSubsetCache.swift`
+  - `Sources/App/StormSetup/StormSetupSnapshotCache.swift`
+  - `Sources/App/StormSetup/GribAdapter.swift`
+  - `Sources/App/Models/Data/PressureArtifactCatalogStore.swift`
+  - `Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift`
+  - `Tests/AppTests/NotificationLedgerFreshnessPersistenceTests.swift`
+  - `Tests/AppTests/NWSIngestPersistenceFlowTests.swift`
+  - `Tests/AppTests/StormSetupGribSubsetCacheTests.swift`
+  - `Tests/AppTests/StormSetupProviderTests.swift`
+  - `Tests/AppTests/ProcessRunnerTests.swift`
+- Existing relevant tests found:
+  - notification delivery-boundary coverage now includes the prior audit's recommended inactive-series dequeue test, plus stale/degraded/fresh handling, duplicate claims, and sender failure persistence
+  - notification persistence coverage exercises exact claim fields, duplicate claims, sent/failed completion, and missing-claim failures
+  - NWS persistence flow coverage exercises geometry-specific dispatch intents, duplicate revisions, deterministic lineage reconciliation, and full rollback after a late transaction failure
+  - Storm Setup coverage exercises cache corruption and partial-write handling, serialized critical sections with cancellation, ordered candidate fallback, and cooperative/forced child-process termination
+- Recommended test gaps: none (High: 0, Medium: 0, Low: 0)
+- Top recommended test: none. No test gap recommended; the behavior-bearing extraction commits added or strengthened focused contract tests alongside the ownership changes.
+- Validation: `swift test --filter NotificationSendJobDeliveryBoundaryTests` (6 passed), `swift test --filter NWSIngestPersistenceFlowTests` (5 passed), `swift test --filter ProcessRunnerTests` (9 passed), and `swift test --filter StormSetupGribSubsetCacheTests` (13 passed)
+- Watchlist items:
+  - APNs retry/backoff, queue replay, abandoned-claim recovery, and unknown-outcome handling remain explicit unimplemented reliability gaps in `docs/architecture.md`; tests should accompany those behaviors when implementation is scoped, but current evidence does not justify tests for behavior that does not yet exist.
+- Implementation recommended: no
+- Out-of-scope repositories intentionally not scanned: all sibling repositories and external NWS, APNs, Redis, and PostgreSQL implementations


### PR DESCRIPTION
# Summary
This branch tightens pressure warm retry behavior so transient acquisition and transport failures can be retried with bounded backoff, while deterministic validation and inventory failures still fail fast. It also preserves claim fencing across retries and adds supporting probe/service and docs updates.

# What Changed
- Added bounded retry handling to `PressureArtifactWarmJob` for classified transient failures, including request timeouts, whole-attempt timeouts, and transport interruptions.
- Added deterministic retry scheduling so retry attempts back off in a fixed, small sequence instead of retrying unboundedly.
- Kept validation, inventory, size, cache-integrity, and other deterministic pressure warm failures terminal.
- Updated pressure artifact warming and probe services to preserve claim fencing and recover rows only when the current owner is still valid.
- Expanded queue-level tests for transient success-after-retry, retry exhaustion, and non-retryable failure cases.
- Updated audit docs for the pressure warm reliability work.

# User Impact
Pressure artifact warming becomes more resilient to temporary network or timeout problems, which should reduce false terminal failures. Non-transient warm failures still stop immediately, so the branch does not add noisy retries to deterministic failure modes.

# Testing
- `swift test --filter PressureArtifactWarmJobTests`
- `swift test --filter HRRRPressureArtifactProbeServiceTests`
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency`

# Notes
- The branch keeps retries narrow; it does not introduce a general retry framework.