### PR TITLE
Characterize abandoned model-artifact processing jobs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/queues.git", from: "1.18.0"),
         // 🧠 Redis queue backend.
         .package(url: "https://github.com/vapor/queues-redis-driver.git", from: "1.1.2"),
+        .package(url: "https://github.com/vapor/redis.git", from: "4.8.0"),
         // ⬡ H3 Geospacial Encoding
         .package(url: "https://github.com/pawelmajcher/SwiftyH3.git", from: "0.5.0"),
         // 📩 APNs push notifications
@@ -37,6 +38,7 @@ let package = Package(
                 .product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
                 .product(name: "Queues", package: "queues"),
                 .product(name: "QueuesRedisDriver", package: "queues-redis-driver"),
+                .product(name: "Redis", package: "redis"),
                 .product(name: "SwiftyH3", package: "SwiftyH3"),
                 .product(name: "VaporAPNS", package: "apns"),
                 .product(name: "ArcusCore", package: "ArcusCore"),
@@ -84,6 +86,7 @@ let package = Package(
                 .target(name: "App"),
                 .product(name: "VaporTesting", package: "vapor"),
                 .product(name: "XCTQueues", package: "queues"),
+                .product(name: "Redis", package: "redis"),
             ],
             path: "Tests/AppTests",
             exclude: [

--- a/Sources/App/Worker/ModelArtifactQueueRecovery.swift
+++ b/Sources/App/Worker/ModelArtifactQueueRecovery.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Queues
+import Redis
+
+/// Reads the Redis-backed model-artifact queue without changing it.
+///
+/// Issue #195 will apply the plan atomically before workers start. Keeping this
+/// reader mutation-free lets the Redis driver contract be characterized safely.
+struct ModelArtifactQueueRecoveryStore {
+    private let queue: any Queue
+    private let redis: any RedisClient
+
+    init(queue: any Queue, redis: any RedisClient) {
+        self.queue = queue
+        self.redis = redis
+    }
+
+    func snapshot() async throws -> ModelArtifactQueueRecoverySnapshot {
+        let waitingJobIdentifiers = try await jobIdentifiers(in: RedisKey(queue.key))
+        let processingEntries = try await processingEntries()
+
+        return ModelArtifactQueueRecoverySnapshot(
+            waitingJobIdentifiers: waitingJobIdentifiers,
+            processingEntries: processingEntries
+        )
+    }
+
+    private var processingKey: String {
+        "\(queue.key)-processing"
+    }
+
+    private func jobIdentifiers(in key: RedisKey) async throws -> [JobIdentifier] {
+        let values = try await redis
+            .lrange(from: key, firstIndex: 0, lastIndex: -1, as: Data.self)
+            .get()
+
+        return values.compactMap { value in
+            value.flatMap { String(data: $0, encoding: .utf8) }
+        }.map(JobIdentifier.init(string:))
+    }
+
+    private func processingEntries() async throws -> [ModelArtifactQueueProcessingEntry] {
+        let values = try await redis
+            .lrange(from: RedisKey(processingKey), firstIndex: 0, lastIndex: -1, as: Data.self)
+            .get()
+
+        return try await values.asyncMap { value in
+            guard let value,
+                  let identifier = String(data: value, encoding: .utf8) else {
+                return .malformedIdentifier
+            }
+
+            let jobIdentifier = JobIdentifier(string: identifier)
+            return .job(
+                jobIdentifier: jobIdentifier,
+                jobDataState: try await jobDataState(for: jobIdentifier)
+            )
+        }
+    }
+
+    private func jobDataState(for jobIdentifier: JobIdentifier) async throws -> ModelArtifactQueueJobDataState {
+        guard let data = try await redis
+            .get(RedisKey("job:\(jobIdentifier.string)"), as: Data.self)
+            .get() else {
+            return .missing
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        do {
+            return .named(try decoder.decode(JobData.self, from: data).jobName)
+        } catch {
+            return .malformed
+        }
+    }
+}
+
+enum ModelArtifactQueueProcessingEntry: Sendable, Equatable {
+    case job(jobIdentifier: JobIdentifier, jobDataState: ModelArtifactQueueJobDataState)
+    case malformedIdentifier
+}
+
+enum ModelArtifactQueueJobDataState: Sendable, Equatable {
+    case named(String)
+    case missing
+    case malformed
+}
+
+struct ModelArtifactQueueRecoverySnapshot: Sendable, Equatable {
+    let waitingJobIdentifiers: [JobIdentifier]
+    let processingEntries: [ModelArtifactQueueProcessingEntry]
+
+    func plan(knownJobNames: Set<String>) -> ModelArtifactQueueRecoveryPlan {
+        let waitingJobIdentifiers = Set(waitingJobIdentifiers)
+        var handledJobIdentifiers = Set<JobIdentifier>()
+        var actions = [ModelArtifactQueueRecoveryAction]()
+
+        for entry in processingEntries {
+            guard case let .job(jobIdentifier, jobDataState) = entry else {
+                actions.append(.preserveMalformedIdentifier)
+                continue
+            }
+
+            guard handledJobIdentifiers.insert(jobIdentifier).inserted else {
+                continue
+            }
+
+            switch jobDataState {
+            case .missing:
+                actions.append(.preserveMissingJobData(jobIdentifier))
+            case .malformed:
+                actions.append(.preserveMalformedJobData(jobIdentifier))
+            case let .named(jobName):
+                guard knownJobNames.contains(jobName) else {
+                    actions.append(.preserveUnknownJob(jobIdentifier, jobName: jobName))
+                    continue
+                }
+
+                if waitingJobIdentifiers.contains(jobIdentifier) {
+                    actions.append(.removeProcessingDuplicate(jobIdentifier))
+                } else {
+                    actions.append(.returnToWaiting(jobIdentifier))
+                }
+            }
+        }
+
+        return ModelArtifactQueueRecoveryPlan(actions: actions)
+    }
+}
+
+struct ModelArtifactQueueRecoveryPlan: Sendable, Equatable {
+    let actions: [ModelArtifactQueueRecoveryAction]
+}
+
+enum ModelArtifactQueueRecoveryAction: Sendable, Equatable {
+    case returnToWaiting(JobIdentifier)
+    case removeProcessingDuplicate(JobIdentifier)
+    case preserveMissingJobData(JobIdentifier)
+    case preserveMalformedJobData(JobIdentifier)
+    case preserveMalformedIdentifier
+    case preserveUnknownJob(JobIdentifier, jobName: String)
+}
+
+enum ModelArtifactQueueRecoveryContract {
+    static let knownJobNames: Set<String> = [
+        PressureArtifactWarmJob.name,
+        PressureArtifactFailureCompletionJob.name,
+        CleanupPressureArtifactsJob.name
+    ]
+}
+
+private extension Array {
+    func asyncMap<T: Sendable>(
+        _ transform: (Element) async throws -> T
+    ) async throws -> [T] {
+        var values = [T]()
+        values.reserveCapacity(count)
+        for element in self {
+            values.append(try await transform(element))
+        }
+        return values
+    }
+}

--- a/Tests/AppTests/ModelArtifactQueueRecoveryTests.swift
+++ b/Tests/AppTests/ModelArtifactQueueRecoveryTests.swift
@@ -1,0 +1,248 @@
+@testable import App
+import Queues
+import Redis
+import Testing
+import Vapor
+
+@Suite("Model-artifact queue recovery", .serialized)
+struct ModelArtifactQueueRecoveryTests {
+    @Test("known abandoned jobs are planned back to waiting")
+    func knownAbandonedJobIsPlannedBackToWaiting() async throws {
+        let jobIdentifier = JobIdentifier()
+
+        try await withUniqueQueue(jobIdentifiers: [jobIdentifier]) { recoveryStore, queue, redis in
+            try await storeJob(
+                named: PressureArtifactWarmJob.name,
+                with: jobIdentifier,
+                in: queue
+            )
+            try await addToProcessing(jobIdentifier, for: queue, using: redis)
+
+            let snapshot = try await recoveryStore.snapshot()
+
+            #expect(snapshot.waitingJobIdentifiers.isEmpty)
+            #expect(snapshot.processingEntries == [
+                .job(jobIdentifier: jobIdentifier, jobDataState: .named(PressureArtifactWarmJob.name))
+            ])
+            #expect(snapshot.plan(knownJobNames: ModelArtifactQueueRecoveryContract.knownJobNames).actions == [
+                .returnToWaiting(jobIdentifier)
+            ])
+        }
+    }
+
+    @Test("missing job data remains in processing for investigation")
+    func missingJobDataIsPreserved() async throws {
+        let jobIdentifier = JobIdentifier()
+
+        try await withUniqueQueue(jobIdentifiers: [jobIdentifier]) { recoveryStore, queue, redis in
+            try await addToProcessing(jobIdentifier, for: queue, using: redis)
+
+            let snapshot = try await recoveryStore.snapshot()
+
+            #expect(snapshot.processingEntries == [
+                .job(jobIdentifier: jobIdentifier, jobDataState: .missing)
+            ])
+            #expect(snapshot.plan(knownJobNames: ModelArtifactQueueRecoveryContract.knownJobNames).actions == [
+                .preserveMissingJobData(jobIdentifier)
+            ])
+        }
+    }
+
+    @Test("unknown jobs remain in processing for investigation")
+    func unknownJobIsPreserved() async throws {
+        let jobIdentifier = JobIdentifier()
+
+        try await withUniqueQueue(jobIdentifiers: [jobIdentifier]) { recoveryStore, queue, redis in
+            try await storeJob(named: "UnrecognizedModelArtifactJob", with: jobIdentifier, in: queue)
+            try await addToProcessing(jobIdentifier, for: queue, using: redis)
+
+            let snapshot = try await recoveryStore.snapshot()
+
+            #expect(snapshot.plan(knownJobNames: ModelArtifactQueueRecoveryContract.knownJobNames).actions == [
+                .preserveUnknownJob(jobIdentifier, jobName: "UnrecognizedModelArtifactJob")
+            ])
+        }
+    }
+
+    @Test("malformed job data is preserved while valid jobs remain recoverable")
+    func malformedJobDataDoesNotHideKnownAbandonedJob() async throws {
+        let knownJobIdentifier = JobIdentifier()
+        let malformedJobIdentifier = JobIdentifier()
+
+        try await withUniqueQueue(jobIdentifiers: [knownJobIdentifier, malformedJobIdentifier]) { recoveryStore, queue, redis in
+            try await storeJob(
+                named: CleanupPressureArtifactsJob.name,
+                with: knownJobIdentifier,
+                in: queue
+            )
+            try await storeMalformedJobData(for: malformedJobIdentifier, using: redis)
+            try await addToProcessing(knownJobIdentifier, for: queue, using: redis)
+            try await addToProcessing(malformedJobIdentifier, for: queue, using: redis)
+
+            let snapshot = try await recoveryStore.snapshot()
+
+            #expect(snapshot.plan(knownJobNames: ModelArtifactQueueRecoveryContract.knownJobNames).actions == [
+                .preserveMalformedJobData(malformedJobIdentifier),
+                .returnToWaiting(knownJobIdentifier)
+            ])
+        }
+    }
+
+    @Test("malformed processing identifiers are preserved while valid jobs remain recoverable")
+    func malformedIdentifierDoesNotHideKnownAbandonedJob() async throws {
+        let knownJobIdentifier = JobIdentifier()
+
+        try await withUniqueQueue(jobIdentifiers: [knownJobIdentifier]) { recoveryStore, queue, redis in
+            try await storeJob(
+                named: CleanupPressureArtifactsJob.name,
+                with: knownJobIdentifier,
+                in: queue
+            )
+            try await addToProcessing(knownJobIdentifier, for: queue, using: redis)
+            try await addMalformedIdentifierToProcessing(for: queue, using: redis)
+
+            let snapshot = try await recoveryStore.snapshot()
+
+            #expect(snapshot.plan(knownJobNames: ModelArtifactQueueRecoveryContract.knownJobNames).actions == [
+                .preserveMalformedIdentifier,
+                .returnToWaiting(knownJobIdentifier)
+            ])
+        }
+    }
+
+    @Test("duplicate processing membership yields one waiting transition")
+    func duplicateProcessingMembershipIsDeduplicated() async throws {
+        let jobIdentifier = JobIdentifier()
+
+        try await withUniqueQueue(jobIdentifiers: [jobIdentifier]) { recoveryStore, queue, redis in
+            try await storeJob(
+                named: PressureArtifactFailureCompletionJob.name,
+                with: jobIdentifier,
+                in: queue
+            )
+            try await addToProcessing(jobIdentifier, for: queue, using: redis)
+            try await addToProcessing(jobIdentifier, for: queue, using: redis)
+
+            let snapshot = try await recoveryStore.snapshot()
+
+            #expect(snapshot.processingEntries.count == 2)
+            #expect(snapshot.plan(knownJobNames: ModelArtifactQueueRecoveryContract.knownJobNames).actions == [
+                .returnToWaiting(jobIdentifier)
+            ])
+        }
+    }
+
+    @Test("already-waiting known jobs are not added to waiting again")
+    func alreadyWaitingKnownJobOnlyRemovesProcessingMembership() async throws {
+        let jobIdentifier = JobIdentifier()
+
+        try await withUniqueQueue(jobIdentifiers: [jobIdentifier]) { recoveryStore, queue, redis in
+            try await storeJob(
+                named: PressureArtifactWarmJob.name,
+                with: jobIdentifier,
+                in: queue
+            )
+            _ = try await redis.lpush(jobIdentifier.string, into: RedisKey(queue.key)).get()
+            try await addToProcessing(jobIdentifier, for: queue, using: redis)
+
+            let snapshot = try await recoveryStore.snapshot()
+
+            #expect(snapshot.waitingJobIdentifiers == [jobIdentifier])
+            #expect(snapshot.plan(knownJobNames: ModelArtifactQueueRecoveryContract.knownJobNames).actions == [
+                .removeProcessingDuplicate(jobIdentifier)
+            ])
+        }
+    }
+}
+
+private extension ModelArtifactQueueRecoveryTests {
+    func withUniqueQueue(
+        jobIdentifiers: [JobIdentifier],
+        test: (ModelArtifactQueueRecoveryStore, any Queue, any RedisClient) async throws -> Void
+    ) async throws {
+        let app = try await Application.make(.testing)
+        let queueName = QueueName(string: "issue-194-\(UUID().uuidString)")
+
+        do {
+            try await configure(app, mode: .api)
+
+            let queue = app.queues.queue(queueName)
+            guard let redis = queue as? any RedisClient else {
+                throw ModelArtifactQueueRecoveryTestError.redisQueueDriverUnavailable
+            }
+
+            let recoveryStore = ModelArtifactQueueRecoveryStore(queue: queue, redis: redis)
+            try await test(recoveryStore, queue, redis)
+            try await deleteTestKeys(for: queue, jobIdentifiers: jobIdentifiers, using: redis)
+            try await app.asyncShutdown()
+        } catch {
+            let queue = app.queues.queue(queueName)
+            if let redis = queue as? any RedisClient {
+                try? await deleteTestKeys(
+                    for: queue,
+                    jobIdentifiers: jobIdentifiers,
+                    using: redis
+                )
+            }
+            try? await app.asyncShutdown()
+            throw error
+        }
+    }
+
+    func storeJob(named jobName: String, with jobIdentifier: JobIdentifier, in queue: any Queue) async throws {
+        try await queue.set(
+            jobIdentifier,
+            to: JobData(
+                payload: [],
+                maxRetryCount: 0,
+                jobName: jobName,
+                delayUntil: nil,
+                queuedAt: .now
+            )
+        ).get()
+    }
+
+    func addToProcessing(
+        _ jobIdentifier: JobIdentifier,
+        for queue: any Queue,
+        using redis: any RedisClient
+    ) async throws {
+        _ = try await redis
+            .lpush(jobIdentifier.string, into: RedisKey("\(queue.key)-processing"))
+            .get()
+    }
+
+    func storeMalformedJobData(
+        for jobIdentifier: JobIdentifier,
+        using redis: any RedisClient
+    ) async throws {
+        try await redis
+            .set(RedisKey("job:\(jobIdentifier.string)"), to: Data("not JSON".utf8))
+            .get()
+    }
+
+    func addMalformedIdentifierToProcessing(
+        for queue: any Queue,
+        using redis: any RedisClient
+    ) async throws {
+        _ = try await redis
+            .lpush(Data([0xFF]), into: RedisKey("\(queue.key)-processing"))
+            .get()
+    }
+
+    func deleteTestKeys(
+        for queue: any Queue,
+        jobIdentifiers: [JobIdentifier],
+        using redis: any RedisClient
+    ) async throws {
+        let keys = [
+            RedisKey(queue.key),
+            RedisKey("\(queue.key)-processing")
+        ] + jobIdentifiers.map { RedisKey("job:\($0.string)") }
+        _ = try await redis.delete(keys).get()
+    }
+}
+
+private enum ModelArtifactQueueRecoveryTestError: Error {
+    case redisQueueDriverUnavailable
+}

--- a/docs/plans/pressure-artifact-warm-reliability-progress.md
+++ b/docs/plans/pressure-artifact-warm-reliability-progress.md
@@ -88,10 +88,11 @@ This ledger tracks the bounded-execution and queue-recovery campaign defined by 
 
 ### Issue #194 - 04: Characterize abandoned model-artifact processing jobs
 
-- **Status:** Pending
+- **Status:** In progress — awaiting human review
 - **Goal:** Add tests and a narrow recovery seam that describe current Redis waiting/processing/job-data behavior without mutating production startup.
 - **Likely files:** new model-artifact queue recovery type/protocol and focused tests; no production lifecycle wiring.
 - **Stop condition:** Tests pin valid, missing-data, unknown-job, duplicate, and already-waiting cases using isolated Redis keys.
+- **Recovery transition for Issue #195:** In one Redis script, inspect each `vapor_queues[model-artifacts]-processing` entry. Preserve and report entries with malformed identifiers, missing or malformed job data, or unknown job names. For known warm, failure-completion, and cleanup jobs, add the identifier to `vapor_queues[model-artifacts]` only when absent, then remove all matching processing entries. The script must keep that check/add/remove sequence atomic so recovery cannot create a second waiting membership.
 
 ### Issue #195 - 05: Recover abandoned model-artifact jobs at worker startup
 


### PR DESCRIPTION
# Summary
This branch adds a narrow Redis-backed recovery seam for model-artifact queue state and characterizes the abandoned-job cases that startup recovery must handle later. It does not wire recovery into worker startup; instead it captures the waiting and processing contract, including malformed, missing, unknown, duplicate, and already-waiting states.

# What Changed
- Added `ModelArtifactQueueRecoveryStore` to snapshot the Redis waiting and processing lists without mutating them.
- Defined recovery planning types that classify known jobs, unknown jobs, missing job data, malformed job data, malformed processing identifiers, and duplicate waiting membership.
- Added a contract set for the currently recognized model-artifact jobs so the recovery seam can distinguish known from unknown work.
- Added focused Redis-backed tests that characterize each abandoned-job case with isolated queue/job keys.
- Updated the pressure warm reliability progress ledger with the atomic transition required by the next implementation issue.
- Added the Redis package dependency needed by the recovery seam and tests.

# User Impact
No direct user-facing behavior change. This branch only characterizes the recovery state machine and documents the transition needed for the next implementation step.

# Testing
- `swift test --filter ModelArtifactQueueRecoveryTests`
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency`

# Notes
- The branch intentionally does not modify worker startup behavior.
- The recovery plan is descriptive only; the atomic transition is deferred to the follow-up implementation issue.