### PR TITLE
Recover abandoned model-artifact jobs before worker startup

### DIFF
--- a/Sources/App/Worker/ModelArtifactQueueRecovery.swift
+++ b/Sources/App/Worker/ModelArtifactQueueRecovery.swift
@@ -1,11 +1,8 @@
 import Foundation
 import Queues
-import Redis
+@preconcurrency import Redis
 
-/// Reads the Redis-backed model-artifact queue without changing it.
-///
-/// Issue #195 will apply the plan atomically before workers start. Keeping this
-/// reader mutation-free lets the Redis driver contract be characterized safely.
+/// Inspects and atomically reconciles the Redis-backed model-artifact queue.
 struct ModelArtifactQueueRecoveryStore {
     private let queue: any Queue
     private let redis: any RedisClient
@@ -23,6 +20,19 @@ struct ModelArtifactQueueRecoveryStore {
             waitingJobIdentifiers: waitingJobIdentifiers,
             processingEntries: processingEntries
         )
+    }
+
+    func recoverKnownJobs(
+        knownJobNames: Set<String> = ModelArtifactQueueRecoveryContract.knownJobNames
+    ) async throws -> ModelArtifactQueueRecoverySummary {
+        let arguments = [
+            RESPValue(from: Self.recoveryScript),
+            RESPValue(from: 2),
+            RESPValue(from: queue.key),
+            RESPValue(from: processingKey)
+        ] + knownJobNames.sorted().map { RESPValue(from: $0) }
+        let response = try await redis.send(command: "EVAL", with: arguments).get()
+        return try Self.decodeSummary(response)
     }
 
     private var processingKey: String {
@@ -73,6 +83,277 @@ struct ModelArtifactQueueRecoveryStore {
             return .malformed
         }
     }
+
+    private static func decodeSummary(_ response: RESPValue) throws -> ModelArtifactQueueRecoverySummary {
+        guard let values = response.array,
+              values.count == 10,
+              let inspectedEntryCount = values[0].int,
+              let returnedToWaitingCount = values[1].int,
+              let alreadyWaitingCount = values[2].int,
+              let removedProcessingEntryCount = values[3].int,
+              let preservedMissingJobDataCount = values[4].int,
+              let preservedMalformedJobDataCount = values[5].int,
+              let preservedMalformedIdentifierCount = values[6].int,
+              let preservedUnknownJobCount = values[7].int,
+              let returnedValues = values[8].array,
+              let alreadyWaitingValues = values[9].array else {
+            throw ModelArtifactQueueRecoveryError.invalidScriptResponse
+        }
+
+        let returnedJobIdentifiers = try jobIdentifiers(from: returnedValues)
+        let alreadyWaitingJobIdentifiers = try jobIdentifiers(from: alreadyWaitingValues)
+        guard returnedToWaitingCount == returnedJobIdentifiers.count,
+              alreadyWaitingCount == alreadyWaitingJobIdentifiers.count else {
+            throw ModelArtifactQueueRecoveryError.invalidScriptResponse
+        }
+
+        return ModelArtifactQueueRecoverySummary(
+            inspectedEntryCount: inspectedEntryCount,
+            returnedJobIdentifiers: returnedJobIdentifiers,
+            alreadyWaitingJobIdentifiers: alreadyWaitingJobIdentifiers,
+            removedProcessingEntryCount: removedProcessingEntryCount,
+            preservedMissingJobDataCount: preservedMissingJobDataCount,
+            preservedMalformedJobDataCount: preservedMalformedJobDataCount,
+            preservedMalformedIdentifierCount: preservedMalformedIdentifierCount,
+            preservedUnknownJobCount: preservedUnknownJobCount
+        )
+    }
+
+    private static func jobIdentifiers(from values: [RESPValue]) throws -> [String] {
+        try values.map { value in
+            guard let identifier = value.string else {
+                throw ModelArtifactQueueRecoveryError.invalidScriptResponse
+            }
+            return identifier
+        }
+    }
+
+    /// Redis executes this script atomically. It classifies every entry before
+    /// applying any mutation so malformed queue state cannot produce a partial
+    /// recovery merely because a later entry cannot be inspected.
+    private static let recoveryScript = #"""
+    local waiting_key = KEYS[1]
+    local processing_key = KEYS[2]
+
+    local known_job_names = {}
+    for index = 1, #ARGV do
+        known_job_names[ARGV[index]] = true
+    end
+
+    local function is_valid_utf8(value)
+        local continuation_count = 0
+        local continuation_minimum = 128
+        local continuation_maximum = 191
+        for index = 1, #value do
+            local first = string.byte(value, index)
+            if continuation_count > 0 then
+                if first < continuation_minimum or first > continuation_maximum then return false end
+                continuation_count = continuation_count - 1
+                continuation_minimum = 128
+                continuation_maximum = 191
+            elseif first <= 127 then
+                continuation_count = 0
+            elseif first >= 194 and first <= 223 then
+                continuation_count = 1
+            elseif first >= 224 and first <= 239 then
+                continuation_count = 2
+                if first == 224 then continuation_minimum = 160 end
+                if first == 237 then continuation_maximum = 159 end
+            elseif first >= 240 and first <= 244 then
+                continuation_count = 3
+                if first == 240 then continuation_minimum = 144 end
+                if first == 244 then continuation_maximum = 143 end
+            else
+                return false
+            end
+        end
+        return continuation_count == 0
+    end
+
+    local function is_nonnegative_integer(value)
+        return type(value) == 'number' and value >= 0 and value == math.floor(value)
+    end
+
+    local function skip_whitespace(value, index)
+        while index <= #value do
+            local byte = string.byte(value, index)
+            if byte ~= 9 and byte ~= 10 and byte ~= 13 and byte ~= 32 then break end
+            index = index + 1
+        end
+        return index
+    end
+
+    local function string_end(value, index)
+        index = index + 1
+        while index <= #value do
+            local byte = string.byte(value, index)
+            if byte == 34 then return index + 1 end
+            if byte == 92 then index = index + 1 end
+            index = index + 1
+        end
+        return nil
+    end
+
+    -- Redis cjson represents both [] and {} as an empty Lua table. Inspect the
+    -- validated raw JSON so an empty object cannot masquerade as a byte array.
+    local function has_single_array_payload(value)
+        local depth = 0
+        local payload_count = 0
+        local index = 1
+        while index <= #value do
+            local byte = string.byte(value, index)
+            if byte == 34 then
+                local token_start = index
+                local token_end = string_end(value, index)
+                if not token_end then return false end
+                if depth == 1 then
+                    local colon_index = skip_whitespace(value, token_end)
+                    if string.byte(value, colon_index) == 58 then
+                        local decoded_ok, key = pcall(
+                            cjson.decode,
+                            string.sub(value, token_start, token_end - 1)
+                        )
+                        if not decoded_ok then return false end
+                        if key == 'payload' then
+                            payload_count = payload_count + 1
+                            local payload_index = skip_whitespace(value, colon_index + 1)
+                            if string.byte(value, payload_index) ~= 91 then return false end
+                        end
+                    end
+                end
+                index = token_end
+            elseif byte == 123 or byte == 91 then
+                depth = depth + 1
+                index = index + 1
+            elseif byte == 125 or byte == 93 then
+                depth = depth - 1
+                index = index + 1
+            else
+                index = index + 1
+            end
+        end
+        return payload_count == 1
+    end
+
+    local function is_valid_payload(payload)
+        if type(payload) ~= 'table' then return false end
+        local count = 0
+        for index, byte in pairs(payload) do
+            if type(index) ~= 'number' or index < 1 or index ~= math.floor(index) or
+               not is_nonnegative_integer(byte) or byte > 255 then return false end
+            count = count + 1
+        end
+        for index = 1, count do
+            if payload[index] == nil then return false end
+        end
+        return true
+    end
+
+    local function is_valid_job_data(decoded, encoded)
+        if type(decoded) ~= 'table' or
+           not has_single_array_payload(encoded) or
+           not is_valid_payload(decoded.payload) or
+           not is_nonnegative_integer(decoded.maxRetryCount) or
+           type(decoded.queuedAt) ~= 'number' or
+           type(decoded.jobName) ~= 'string' then return false end
+
+        if decoded.attempts ~= nil and decoded.attempts ~= cjson.null and
+           not is_nonnegative_integer(decoded.attempts) then return false end
+        if decoded.delayUntil ~= nil and decoded.delayUntil ~= cjson.null and
+           type(decoded.delayUntil) ~= 'number' then return false end
+        return true
+    end
+
+    local waiting_entries = redis.call('LRANGE', waiting_key, 0, -1)
+    local processing_entries = redis.call('LRANGE', processing_key, 0, -1)
+    local waiting_membership = {}
+    for _, identifier in ipairs(waiting_entries) do
+        waiting_membership[identifier] = true
+    end
+
+    local handled_identifiers = {}
+    local actions = {}
+    local returned_identifiers = {}
+    local already_waiting_identifiers = {}
+    local missing_count = 0
+    local malformed_data_count = 0
+    local malformed_identifier_count = 0
+    local unknown_count = 0
+
+    for _, identifier in ipairs(processing_entries) do
+        if not is_valid_utf8(identifier) then
+            malformed_identifier_count = malformed_identifier_count + 1
+        elseif not handled_identifiers[identifier] then
+            handled_identifiers[identifier] = true
+            local job_data = redis.call('GET', 'job:' .. identifier)
+            if not job_data then
+                missing_count = missing_count + 1
+            else
+                local decoded_ok, decoded = pcall(cjson.decode, job_data)
+                if not decoded_ok or not is_valid_job_data(decoded, job_data) then
+                    malformed_data_count = malformed_data_count + 1
+                elseif not known_job_names[decoded.jobName] then
+                    unknown_count = unknown_count + 1
+                elseif waiting_membership[identifier] then
+                    table.insert(actions, { kind = 'already-waiting', identifier = identifier })
+                    table.insert(already_waiting_identifiers, identifier)
+                else
+                    table.insert(actions, { kind = 'return', identifier = identifier })
+                    table.insert(returned_identifiers, identifier)
+                end
+            end
+        end
+    end
+
+    local removed_processing_entry_count = 0
+    for _, action in ipairs(actions) do
+        if action.kind == 'return' then
+            redis.call('LPUSH', waiting_key, action.identifier)
+        end
+        removed_processing_entry_count = removed_processing_entry_count +
+            redis.call('LREM', processing_key, 0, action.identifier)
+    end
+
+    return {
+        #processing_entries,
+        #returned_identifiers,
+        #already_waiting_identifiers,
+        removed_processing_entry_count,
+        missing_count,
+        malformed_data_count,
+        malformed_identifier_count,
+        unknown_count,
+        returned_identifiers,
+        already_waiting_identifiers
+    }
+    """#
+}
+
+struct ModelArtifactQueueRecoverySummary: Sendable, Equatable {
+    let inspectedEntryCount: Int
+    let returnedJobIdentifiers: [String]
+    let alreadyWaitingJobIdentifiers: [String]
+    let removedProcessingEntryCount: Int
+    let preservedMissingJobDataCount: Int
+    let preservedMalformedJobDataCount: Int
+    let preservedMalformedIdentifierCount: Int
+    let preservedUnknownJobCount: Int
+
+    static let empty = ModelArtifactQueueRecoverySummary(
+        inspectedEntryCount: 0,
+        returnedJobIdentifiers: [],
+        alreadyWaitingJobIdentifiers: [],
+        removedProcessingEntryCount: 0,
+        preservedMissingJobDataCount: 0,
+        preservedMalformedJobDataCount: 0,
+        preservedMalformedIdentifierCount: 0,
+        preservedUnknownJobCount: 0
+    )
+}
+
+enum ModelArtifactQueueRecoveryError: Error {
+    case invalidScriptResponse
+    case redisQueueDriverUnavailable
 }
 
 enum ModelArtifactQueueProcessingEntry: Sendable, Equatable {

--- a/Sources/App/Worker/WorkerRuntime.swift
+++ b/Sources/App/Worker/WorkerRuntime.swift
@@ -1,27 +1,85 @@
 import Queues
+import Redis
 import Vapor
 
 public final class WorkerRuntime: LifecycleHandler, @unchecked Sendable {
+    typealias RecoveryOperation = @Sendable (Application) async throws -> ModelArtifactQueueRecoverySummary
+    typealias QueueConsumerStarter = @Sendable (Application, ArcusQueueLane) throws -> Void
+    typealias ScheduledJobStarter = @Sendable (Application) throws -> Void
+
     private let startupGracePeriodSeconds: Int64
+    private let recoveryOperation: RecoveryOperation
+    private let queueConsumerStarter: QueueConsumerStarter
+    private let scheduledJobStarter: ScheduledJobStarter
     private var startupTask: Task<Void, Never>?
 
     public init(startupGracePeriodSeconds: Int64 = 5) {
         self.startupGracePeriodSeconds = max(0, startupGracePeriodSeconds)
+        self.recoveryOperation = { app in
+            let queue = app.queues.queue(ArcusQueueLane.modelArtifacts.queueName)
+            guard let redis = queue as? any RedisClient else {
+                throw ModelArtifactQueueRecoveryError.redisQueueDriverUnavailable
+            }
+            return try await ModelArtifactQueueRecoveryStore(queue: queue, redis: redis)
+                .recoverKnownJobs()
+        }
+        self.queueConsumerStarter = { app, lane in
+            try app.queues.startInProcessJobs(on: lane.queueName)
+        }
+        self.scheduledJobStarter = { app in
+            try app.queues.startScheduledJobs()
+        }
+    }
+
+    init(
+        startupGracePeriodSeconds: Int64 = 0,
+        recoveryOperation: @escaping RecoveryOperation,
+        queueConsumerStarter: @escaping QueueConsumerStarter,
+        scheduledJobStarter: @escaping ScheduledJobStarter
+    ) {
+        self.startupGracePeriodSeconds = max(0, startupGracePeriodSeconds)
+        self.recoveryOperation = recoveryOperation
+        self.queueConsumerStarter = queueConsumerStarter
+        self.scheduledJobStarter = scheduledJobStarter
     }
 
     public func didBoot(_ app: Application) throws {
+        logQueueBackend(on: app)
+        guard startupGracePeriodSeconds == 0 else {
+            scheduleDelayedStart(on: app)
+            return
+        }
+
+        try app.eventLoopGroup.any().makeFutureWithTask {
+            try await self.startWorkerRuntime(on: app)
+        }.wait()
+    }
+
+    public func didBootAsync(_ app: Application) async throws {
+        logQueueBackend(on: app)
+        guard startupGracePeriodSeconds == 0 else {
+            scheduleDelayedStart(on: app)
+            return
+        }
+
+        try await startWorkerRuntime(on: app)
+    }
+
+    public func shutdown(_ app: Application) {
+        startupTask?.cancel()
+        app.logger.info("Worker runtime stopped.")
+    }
+
+    private func logQueueBackend(on app: Application) {
         if let redisURL = Environment.get("REDIS_URL"), let parsed = URL(string: redisURL) {
             let port = parsed.port ?? 6379
             app.logger.info("Worker queue backend: redis://\(parsed.host ?? "unknown"):\(port)")
         } else {
             app.logger.info("Worker queue backend: redis://127.0.0.1:6379 (default)")
         }
+    }
 
-        if startupGracePeriodSeconds == 0 {
-            try startWorkerRuntime(on: app)
-            return
-        }
-
+    private func scheduleDelayedStart(on app: Application) {
         startupTask = Task { [startupGracePeriodSeconds] in
             do {
                 try await Task.sleep(for: .seconds(startupGracePeriodSeconds))
@@ -30,7 +88,7 @@ public final class WorkerRuntime: LifecycleHandler, @unchecked Sendable {
             }
 
             do {
-                try startWorkerRuntime(on: app)
+                try await startWorkerRuntime(on: app)
             } catch {
                 app.logger.error(
                     "Failed to start worker runtime.",
@@ -45,21 +103,37 @@ public final class WorkerRuntime: LifecycleHandler, @unchecked Sendable {
         }
     }
 
-    public func shutdown(_ app: Application) {
-        startupTask?.cancel()
-        app.logger.info("Worker runtime stopped.")
-    }
+    func reconcileAndStartQueueRuntime(on app: Application) async throws {
+        let recoverySummary = try await recoveryOperation(app)
+        app.logger.info(
+            "Model-artifact queue recovery completed.",
+            metadata: [
+                "inspectedEntries": .stringConvertible(recoverySummary.inspectedEntryCount),
+                "returnedToWaiting": .stringConvertible(recoverySummary.returnedJobIdentifiers.count),
+                "alreadyWaiting": .stringConvertible(recoverySummary.alreadyWaitingJobIdentifiers.count),
+                "removedProcessingEntries": .stringConvertible(recoverySummary.removedProcessingEntryCount),
+                "preservedMissingJobData": .stringConvertible(recoverySummary.preservedMissingJobDataCount),
+                "preservedMalformedJobData": .stringConvertible(recoverySummary.preservedMalformedJobDataCount),
+                "preservedMalformedIdentifiers": .stringConvertible(recoverySummary.preservedMalformedIdentifierCount),
+                "preservedUnknownJobs": .stringConvertible(recoverySummary.preservedUnknownJobCount),
+                "returnedJobIdentifiers": .string(recoverySummary.returnedJobIdentifiers.joined(separator: ",")),
+                "alreadyWaitingJobIdentifiers": .string(recoverySummary.alreadyWaitingJobIdentifiers.joined(separator: ","))
+            ]
+        )
 
-    private func startWorkerRuntime(on app: Application) throws {
         for lane in ArcusQueueLane.allCases {
-            try app.queues.startInProcessJobs(on: lane.queueName)
+            try queueConsumerStarter(app, lane)
             app.logger.info(
                 "Worker queue consumers started.",
                 metadata: ["lane": .string(lane.rawValue)]
             )
         }
-        try app.queues.startScheduledJobs()
+        try scheduledJobStarter(app)
         app.logger.info("Worker scheduled jobs started.")
+    }
+
+    private func startWorkerRuntime(on app: Application) async throws {
+        try await reconcileAndStartQueueRuntime(on: app)
 
         Task {
             do {

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -969,6 +969,83 @@ struct AppTests {
         }
     }
 
+    @Test("Worker recovers model-artifact jobs before starting any consumers or schedules")
+    func workerRuntimeReconcilesBeforeStartingQueues() async throws {
+        let app = try await Application.make(.testing)
+        let recorder = WorkerRuntimeStartRecorder()
+        let runtime = WorkerRuntime(
+            recoveryOperation: { _ in
+                recorder.record("recovery")
+                return .empty
+            },
+            queueConsumerStarter: { _, lane in
+                recorder.record("consumer:\(lane.rawValue)")
+            },
+            scheduledJobStarter: { _ in
+                recorder.record("scheduled")
+            }
+        )
+
+        do {
+            try await runtime.reconcileAndStartQueueRuntime(on: app)
+            try await app.asyncShutdown()
+        } catch {
+            try? await app.asyncShutdown()
+            throw error
+        }
+
+        #expect(recorder.events == ["recovery"] + ArcusQueueLane.allCases.map { "consumer:\($0.rawValue)" } + ["scheduled"])
+    }
+
+    @Test("Worker boot fails before consumers when zero-grace model-artifact recovery fails")
+    func workerRuntimeBootStopsBeforeConsumersWhenRecoveryFails() async throws {
+        let app = try await Application.make(.testing)
+        let recorder = WorkerRuntimeStartRecorder()
+        let runtime = WorkerRuntime(
+            recoveryOperation: { _ in
+                recorder.record("recovery")
+                throw WorkerRuntimeStartTestError.recoveryFailed
+            },
+            queueConsumerStarter: { _, lane in
+                recorder.record("consumer:\(lane.rawValue)")
+            },
+            scheduledJobStarter: { _ in
+                recorder.record("scheduled")
+            }
+        )
+        app.lifecycle.use(runtime)
+
+        await #expect(throws: WorkerRuntimeStartTestError.self) {
+            try await app.asyncBoot()
+        }
+        #expect(app.didShutdown == false)
+        #expect(recorder.events == ["recovery"])
+
+        try await app.asyncShutdown()
+        #expect(app.didShutdown)
+    }
+
+}
+
+private final class WorkerRuntimeStartRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedEvents: [String] = []
+
+    var events: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedEvents
+    }
+
+    func record(_ event: String) {
+        lock.lock()
+        recordedEvents.append(event)
+        lock.unlock()
+    }
+}
+
+private enum WorkerRuntimeStartTestError: Error {
+    case recoveryFailed
 }
 
 private final class SentinelStormSetupProvider: StormSetupProviding, @unchecked Sendable {

--- a/Tests/AppTests/ModelArtifactQueueRecoveryTests.swift
+++ b/Tests/AppTests/ModelArtifactQueueRecoveryTests.swift
@@ -153,6 +153,214 @@ struct ModelArtifactQueueRecoveryTests {
             ])
         }
     }
+
+    @Test("startup recovery returns every registered job exactly once without changing job data or other lanes")
+    func recoveryReturnsKnownJobsAtomicallyAndIdempotently() async throws {
+        let jobs = [
+            (JobIdentifier(), PressureArtifactWarmJob.name, [UInt8]("warm".utf8)),
+            (JobIdentifier(), PressureArtifactFailureCompletionJob.name, [UInt8]("completion".utf8)),
+            (JobIdentifier(), CleanupPressureArtifactsJob.name, [UInt8]("cleanup".utf8))
+        ]
+
+        try await withUniqueQueue(jobIdentifiers: jobs.map(\.0)) { recoveryStore, queue, redis in
+            for (identifier, jobName, payload) in jobs {
+                try await storeJob(named: jobName, payload: payload, with: identifier, in: queue)
+                try await addToProcessing(identifier, for: queue, using: redis)
+            }
+
+            let unrelatedWaitingKey = RedisKey("\(queue.key)-unrelated-waiting")
+            let unrelatedProcessingKey = RedisKey("\(queue.key)-unrelated-processing")
+            _ = try await redis.lpush("unrelated-waiting", into: unrelatedWaitingKey).get()
+            _ = try await redis.lpush("unrelated-processing", into: unrelatedProcessingKey).get()
+
+            let firstSummary = try await recoveryStore.recoverKnownJobs()
+            let firstSnapshot = try await recoveryStore.snapshot()
+
+            #expect(firstSummary.inspectedEntryCount == jobs.count)
+            #expect(Set(firstSummary.returnedJobIdentifiers) == Set(jobs.map(\.0.string)))
+            #expect(firstSummary.alreadyWaitingJobIdentifiers.isEmpty)
+            #expect(firstSummary.removedProcessingEntryCount == jobs.count)
+            #expect(Set(firstSnapshot.waitingJobIdentifiers) == Set(jobs.map(\.0)))
+            #expect(firstSnapshot.processingEntries.isEmpty)
+
+            for (identifier, jobName, payload) in jobs {
+                let stored = try await queue.get(identifier).get()
+                #expect(stored.jobName == jobName)
+                #expect(stored.payload == payload)
+            }
+
+            let unrelatedWaiting = try await redis
+                .lrange(from: unrelatedWaitingKey, firstIndex: 0, lastIndex: -1, as: String.self)
+                .get()
+            let unrelatedProcessing = try await redis
+                .lrange(from: unrelatedProcessingKey, firstIndex: 0, lastIndex: -1, as: String.self)
+                .get()
+            #expect(unrelatedWaiting == ["unrelated-waiting"])
+            #expect(unrelatedProcessing == ["unrelated-processing"])
+
+            let secondSummary = try await recoveryStore.recoverKnownJobs()
+            let secondSnapshot = try await recoveryStore.snapshot()
+            #expect(secondSummary == .empty)
+            #expect(secondSnapshot == firstSnapshot)
+        }
+    }
+
+    @Test("recovery preserves and reports unknown, missing, and malformed entries")
+    func recoveryPreservesUntrustworthyEntries() async throws {
+        let knownIdentifier = JobIdentifier()
+        let unknownIdentifier = JobIdentifier()
+        let missingIdentifier = JobIdentifier()
+        let malformedDataIdentifier = JobIdentifier()
+        let identifiers = [knownIdentifier, unknownIdentifier, missingIdentifier, malformedDataIdentifier]
+
+        try await withUniqueQueue(jobIdentifiers: identifiers) { recoveryStore, queue, redis in
+            try await storeJob(named: PressureArtifactWarmJob.name, with: knownIdentifier, in: queue)
+            try await storeJob(named: "UnrecognizedModelArtifactJob", with: unknownIdentifier, in: queue)
+            try await storeMalformedJobData(for: malformedDataIdentifier, using: redis)
+            for identifier in identifiers {
+                try await addToProcessing(identifier, for: queue, using: redis)
+            }
+            try await addMalformedIdentifierToProcessing(for: queue, using: redis)
+
+            let summary = try await recoveryStore.recoverKnownJobs()
+            let snapshot = try await recoveryStore.snapshot()
+
+            #expect(summary.inspectedEntryCount == 5)
+            #expect(summary.returnedJobIdentifiers == [knownIdentifier.string])
+            #expect(summary.removedProcessingEntryCount == 1)
+            #expect(summary.preservedUnknownJobCount == 1)
+            #expect(summary.preservedMissingJobDataCount == 1)
+            #expect(summary.preservedMalformedJobDataCount == 1)
+            #expect(summary.preservedMalformedIdentifierCount == 1)
+            #expect(snapshot.waitingJobIdentifiers == [knownIdentifier])
+            #expect(snapshot.processingEntries.count == 4)
+            #expect(snapshot.processingEntries.contains(.malformedIdentifier))
+            #expect(snapshot.processingEntries.contains(
+                .job(jobIdentifier: unknownIdentifier, jobDataState: .named("UnrecognizedModelArtifactJob"))
+            ))
+            #expect(snapshot.processingEntries.contains(
+                .job(jobIdentifier: missingIdentifier, jobDataState: .missing)
+            ))
+            #expect(snapshot.processingEntries.contains(
+                .job(jobIdentifier: malformedDataIdentifier, jobDataState: .malformed)
+            ))
+        }
+    }
+
+    @Test("structurally malformed registered job data remains in processing")
+    func recoveryPreservesStructurallyMalformedRegisteredJob() async throws {
+        let jobIdentifier = JobIdentifier()
+
+        try await withUniqueQueue(jobIdentifiers: [jobIdentifier]) { recoveryStore, queue, redis in
+            let malformedData = Data("{\"jobName\":\"\(PressureArtifactWarmJob.name)\"}".utf8)
+            try await redis
+                .set(RedisKey("job:\(jobIdentifier.string)"), to: malformedData)
+                .get()
+            try await addToProcessing(jobIdentifier, for: queue, using: redis)
+
+            let firstSummary = try await recoveryStore.recoverKnownJobs()
+            let firstSnapshot = try await recoveryStore.snapshot()
+
+            #expect(firstSummary.inspectedEntryCount == 1)
+            #expect(firstSummary.returnedJobIdentifiers.isEmpty)
+            #expect(firstSummary.preservedMalformedJobDataCount == 1)
+            #expect(firstSnapshot.waitingJobIdentifiers.isEmpty)
+            #expect(firstSnapshot.processingEntries == [
+                .job(jobIdentifier: jobIdentifier, jobDataState: .malformed)
+            ])
+
+            let secondSummary = try await recoveryStore.recoverKnownJobs()
+            #expect(secondSummary.preservedMalformedJobDataCount == 1)
+            #expect(try await recoveryStore.snapshot() == firstSnapshot)
+        }
+    }
+
+    @Test("object-valued payload remains in processing even when the job name is registered")
+    func recoveryPreservesRegisteredJobWithObjectPayload() async throws {
+        let jobIdentifier = JobIdentifier()
+
+        try await withUniqueQueue(jobIdentifiers: [jobIdentifier]) { recoveryStore, queue, redis in
+            let malformedData = Data(
+                "{\"payload\":{},\"maxRetryCount\":0,\"queuedAt\":0,\"jobName\":\"\(PressureArtifactWarmJob.name)\"}".utf8
+            )
+            try await redis
+                .set(RedisKey("job:\(jobIdentifier.string)"), to: malformedData)
+                .get()
+            try await addToProcessing(jobIdentifier, for: queue, using: redis)
+
+            let firstSummary = try await recoveryStore.recoverKnownJobs()
+            let firstSnapshot = try await recoveryStore.snapshot()
+
+            #expect(firstSummary.inspectedEntryCount == 1)
+            #expect(firstSummary.returnedJobIdentifiers.isEmpty)
+            #expect(firstSummary.preservedMalformedJobDataCount == 1)
+            #expect(firstSnapshot.waitingJobIdentifiers.isEmpty)
+            #expect(firstSnapshot.processingEntries == [
+                .job(jobIdentifier: jobIdentifier, jobDataState: .malformed)
+            ])
+
+            let secondSummary = try await recoveryStore.recoverKnownJobs()
+            #expect(secondSummary.preservedMalformedJobDataCount == 1)
+            #expect(try await recoveryStore.snapshot() == firstSnapshot)
+        }
+    }
+
+    @Test("recovery removes duplicate processing membership without duplicating waiting membership")
+    func recoveryDoesNotDuplicateAlreadyWaitingJob() async throws {
+        let jobIdentifier = JobIdentifier()
+
+        try await withUniqueQueue(jobIdentifiers: [jobIdentifier]) { recoveryStore, queue, redis in
+            try await storeJob(named: CleanupPressureArtifactsJob.name, with: jobIdentifier, in: queue)
+            _ = try await redis.lpush(jobIdentifier.string, into: RedisKey(queue.key)).get()
+            try await addToProcessing(jobIdentifier, for: queue, using: redis)
+            try await addToProcessing(jobIdentifier, for: queue, using: redis)
+
+            let summary = try await recoveryStore.recoverKnownJobs()
+            let snapshot = try await recoveryStore.snapshot()
+
+            #expect(summary.inspectedEntryCount == 2)
+            #expect(summary.returnedJobIdentifiers.isEmpty)
+            #expect(summary.alreadyWaitingJobIdentifiers == [jobIdentifier.string])
+            #expect(summary.removedProcessingEntryCount == 2)
+            #expect(snapshot.waitingJobIdentifiers == [jobIdentifier])
+            #expect(snapshot.processingEntries.isEmpty)
+            #expect(try await recoveryStore.recoverKnownJobs() == .empty)
+        }
+    }
+
+    @Test("recovery failure leaves every processing entry untouched")
+    func recoveryFailureDoesNotPartiallyMutateQueue() async throws {
+        let knownIdentifier = JobIdentifier()
+        let invalidStateIdentifier = JobIdentifier()
+
+        try await withUniqueQueue(
+            jobIdentifiers: [knownIdentifier, invalidStateIdentifier]
+        ) { recoveryStore, queue, redis in
+            try await storeJob(named: PressureArtifactWarmJob.name, with: knownIdentifier, in: queue)
+            _ = try await redis
+                .lpush("wrong Redis type", into: RedisKey("job:\(invalidStateIdentifier.string)"))
+                .get()
+            try await addToProcessing(invalidStateIdentifier, for: queue, using: redis)
+            try await addToProcessing(knownIdentifier, for: queue, using: redis)
+
+            var recoveryFailed = false
+            do {
+                _ = try await recoveryStore.recoverKnownJobs()
+            } catch {
+                recoveryFailed = true
+            }
+
+            let waiting = try await redis
+                .lrange(from: RedisKey(queue.key), firstIndex: 0, lastIndex: -1, as: String.self)
+                .get()
+            let processing = try await redis
+                .lrange(from: RedisKey("\(queue.key)-processing"), firstIndex: 0, lastIndex: -1, as: String.self)
+                .get()
+            #expect(recoveryFailed)
+            #expect(waiting.isEmpty)
+            #expect(Set(processing.compactMap { $0 }) == Set([knownIdentifier.string, invalidStateIdentifier.string]))
+        }
+    }
 }
 
 private extension ModelArtifactQueueRecoveryTests {
@@ -189,11 +397,16 @@ private extension ModelArtifactQueueRecoveryTests {
         }
     }
 
-    func storeJob(named jobName: String, with jobIdentifier: JobIdentifier, in queue: any Queue) async throws {
+    func storeJob(
+        named jobName: String,
+        payload: [UInt8] = [],
+        with jobIdentifier: JobIdentifier,
+        in queue: any Queue
+    ) async throws {
         try await queue.set(
             jobIdentifier,
             to: JobData(
-                payload: [],
+                payload: payload,
                 maxRetryCount: 0,
                 jobName: jobName,
                 delayUntil: nil,
@@ -237,7 +450,9 @@ private extension ModelArtifactQueueRecoveryTests {
     ) async throws {
         let keys = [
             RedisKey(queue.key),
-            RedisKey("\(queue.key)-processing")
+            RedisKey("\(queue.key)-processing"),
+            RedisKey("\(queue.key)-unrelated-waiting"),
+            RedisKey("\(queue.key)-unrelated-processing")
         ] + jobIdentifiers.map { RedisKey("job:\($0.string)") }
         _ = try await redis.delete(keys).get()
     }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@ Arcus Signal ingests NWS alert revisions, targets eligible installations by H3 o
 
 ### Queue topology
 
-[`ArcusQueueLane`](../Sources/App/Worker/ArcusQueueLane.swift) defines the `ingest`, `target`, `send`, and `model-artifacts` lanes. Worker configuration applies the same `QUEUE_WORKER_COUNT` to Vapor Queues, with a minimum and default of `1`, through [`configureWorkerQueueSettings(on:)`](../Sources/App/configure.swift); [`WorkerRuntime`](../Sources/App/Worker/WorkerRuntime.swift) starts consumers for every lane.
+[`ArcusQueueLane`](../Sources/App/Worker/ArcusQueueLane.swift) defines the `ingest`, `target`, `send`, and `model-artifacts` lanes. Worker configuration applies the same `QUEUE_WORKER_COUNT` to Vapor Queues, with a minimum and default of `1`, through [`configureWorkerQueueSettings(on:)`](../Sources/App/configure.swift). Before any consumer or schedule starts, [`WorkerRuntime`](../Sources/App/Worker/WorkerRuntime.swift) atomically returns abandoned registered model-artifact jobs to waiting while preserving and reporting unknown or malformed entries; failed reconciliation shuts the worker down. After successful reconciliation, `WorkerRuntime` starts consumers for every lane.
 
 ## Delivery pipeline
 

--- a/docs/plans/pressure-artifact-warm-reliability-progress.md
+++ b/docs/plans/pressure-artifact-warm-reliability-progress.md
@@ -51,7 +51,7 @@ This ledger tracks the bounded-execution and queue-recovery campaign defined by 
 | 02 | [#192](https://github.com/justinrooks/arcus-signal/issues/192) | Bound warm attempts and complete timed-out claims | 01 | Pending |
 | 03 | [#193](https://github.com/justinrooks/arcus-signal/issues/193) | Retry transient warm failures with bounded backoff | 01, 02 | Pending |
 | 04 | [#194](https://github.com/justinrooks/arcus-signal/issues/194) | Characterize abandoned model-artifact processing jobs | None | Pending |
-| 05 | [#195](https://github.com/justinrooks/arcus-signal/issues/195) | Recover abandoned model-artifact jobs at worker startup | 04 | Pending |
+| 05 | [#195](https://github.com/justinrooks/arcus-signal/issues/195) | Recover abandoned model-artifact jobs at worker startup | 04 | Implemented — ready for commit |
 | 06 | [#196](https://github.com/justinrooks/arcus-signal/issues/196) | Surface stuck pressure-artifact backlog health | 02 | Pending |
 | 07 | [#201](https://github.com/justinrooks/arcus-signal/issues/201) | Add durable fenced failure-completion retries | 01, 02 | Implemented — ready for publication |
 
@@ -96,10 +96,11 @@ This ledger tracks the bounded-execution and queue-recovery campaign defined by 
 
 ### Issue #195 - 05: Recover abandoned model-artifact jobs at worker startup
 
-- **Status:** Pending
-- **Goal:** Atomically return known abandoned model-artifact jobs to the waiting queue before consumers start.
-- **Likely files:** recovery implementation, worker lifecycle/configuration, characterization tests.
-- **Stop condition:** Restart recovery is idempotent, preserves unknown entries, avoids duplicate list membership, logs a summary, and starts consumers only after reconciliation.
+- **Status:** Implemented — ready for commit
+- **Behavior:** One Redis script classifies the complete `model-artifacts` processing list before mutation, returns registered warm, failure-completion, and cleanup jobs to waiting when absent, and removes all matching processing memberships atomically.
+- **Preservation:** Missing or malformed job data, malformed identifiers, and unknown job names remain in processing and are reported by count. Job data and other queue lanes are untouched.
+- **Startup:** `WorkerRuntime` awaits reconciliation before starting any queue consumer or schedule. A reconciliation failure starts neither and triggers the existing worker shutdown path.
+- **Focused verification:** `swift test --filter ModelArtifactQueueRecoveryTests`; `swift test --filter AppTests.AppTests`; strict-concurrency build; `git diff --check`.
 
 ### Issue #196 - 06: Surface stuck pressure-artifact backlog health
 
@@ -126,7 +127,7 @@ This ledger tracks the bounded-execution and queue-recovery campaign defined by 
 | 02 | `swift test --filter PressureArtifactWarmJobTests`; `swift test --filter PressureArtifactDiagnosticsTests` | Pending |
 | 03 | Focused warm-job retry tests; probe dispatch tests | Pending |
 | 04 | Focused model-artifact queue recovery characterization tests | Pending |
-| 05 | Recovery tests plus worker bootstrap tests and strict-concurrency build | Pending |
+| 05 | Recovery tests plus worker bootstrap tests and strict-concurrency build | Passed |
 | 06 | `swift test --filter OperatorDashboardPressureArtifactTests` | Pending |
 | 07 | Completion-job queue/PostgreSQL tests; warm and diagnostics regressions; strict-concurrency build | Passed |
 


### PR DESCRIPTION
# Summary

Closes #195. Recover abandoned model-artifact jobs atomically during worker startup, before queue consumers and scheduled jobs begin, while preserving queue entries that cannot be trusted for automatic recovery.

# What Changed

- Added Redis-backed atomic recovery for registered warm and cleanup jobs on the `model-artifacts` lane.
- Made recovery idempotent and duplicate-safe, returning known abandoned jobs to waiting exactly once.
- Preserved and counted missing, malformed, unknown, and malformed-identifier entries for investigation.
- Started worker consumers and schedules only after successful reconciliation, with safe zero-grace startup failure handling.
- Updated architecture and reliability progress documentation.

# User Impact

No direct user-facing UI change. Worker restarts can recover eligible abandoned model-artifact jobs before processing resumes, reducing stuck background work without discarding unrecognized queue state.

# Testing

- `swift test --filter ModelArtifactQueueRecoveryTests` — passed (13 tests).
- `swift test --filter AppTests.AppTests` — passed (30 tests).
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` — passed.