### PR TITLE
Surface pressure artifact backlog health

### DIFF
--- a/Sources/App/Models/API/OperatorDashboardSnapshotResponse.swift
+++ b/Sources/App/Models/API/OperatorDashboardSnapshotResponse.swift
@@ -442,6 +442,10 @@ public struct StoredPressureArtifactDashboardCatalogMetric: Codable, Sendable {
     public var readyCount: Int
     public var failedCount: Int
     public var expiredCount: Int
+    public var stuckWarmingCount: Int
+    public var oldestExpiredWarmingLeaseAgeSeconds: Int?
+    public var oldestPendingAgeSeconds: Int?
+    public var stuckReason: String?
     public var mostRecentFailureAt: Date?
     public var mostRecentFailureSummary: String?
 
@@ -453,6 +457,10 @@ public struct StoredPressureArtifactDashboardCatalogMetric: Codable, Sendable {
         readyCount: Int = 0,
         failedCount: Int = 0,
         expiredCount: Int = 0,
+        stuckWarmingCount: Int = 0,
+        oldestExpiredWarmingLeaseAgeSeconds: Int? = nil,
+        oldestPendingAgeSeconds: Int? = nil,
+        stuckReason: String? = nil,
         mostRecentFailureAt: Date? = nil,
         mostRecentFailureSummary: String? = nil
     ) {
@@ -463,8 +471,35 @@ public struct StoredPressureArtifactDashboardCatalogMetric: Codable, Sendable {
         self.readyCount = readyCount
         self.failedCount = failedCount
         self.expiredCount = expiredCount
+        self.stuckWarmingCount = stuckWarmingCount
+        self.oldestExpiredWarmingLeaseAgeSeconds = oldestExpiredWarmingLeaseAgeSeconds
+        self.oldestPendingAgeSeconds = oldestPendingAgeSeconds
+        self.stuckReason = stuckReason
         self.mostRecentFailureAt = mostRecentFailureAt
         self.mostRecentFailureSummary = mostRecentFailureSummary
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case refreshedAt, totalRowCount, pendingCount, warmingCount, readyCount, failedCount, expiredCount
+        case stuckWarmingCount, oldestExpiredWarmingLeaseAgeSeconds, oldestPendingAgeSeconds, stuckReason
+        case mostRecentFailureAt, mostRecentFailureSummary
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.refreshedAt = try container.decodeIfPresent(Date.self, forKey: .refreshedAt)
+        self.totalRowCount = try container.decodeIfPresent(Int.self, forKey: .totalRowCount) ?? 0
+        self.pendingCount = try container.decodeIfPresent(Int.self, forKey: .pendingCount) ?? 0
+        self.warmingCount = try container.decodeIfPresent(Int.self, forKey: .warmingCount) ?? 0
+        self.readyCount = try container.decodeIfPresent(Int.self, forKey: .readyCount) ?? 0
+        self.failedCount = try container.decodeIfPresent(Int.self, forKey: .failedCount) ?? 0
+        self.expiredCount = try container.decodeIfPresent(Int.self, forKey: .expiredCount) ?? 0
+        self.stuckWarmingCount = try container.decodeIfPresent(Int.self, forKey: .stuckWarmingCount) ?? 0
+        self.oldestExpiredWarmingLeaseAgeSeconds = try container.decodeIfPresent(Int.self, forKey: .oldestExpiredWarmingLeaseAgeSeconds)
+        self.oldestPendingAgeSeconds = try container.decodeIfPresent(Int.self, forKey: .oldestPendingAgeSeconds)
+        self.stuckReason = try container.decodeIfPresent(String.self, forKey: .stuckReason)
+        self.mostRecentFailureAt = try container.decodeIfPresent(Date.self, forKey: .mostRecentFailureAt)
+        self.mostRecentFailureSummary = try container.decodeIfPresent(String.self, forKey: .mostRecentFailureSummary)
     }
 }
 
@@ -804,6 +839,10 @@ public struct PressureArtifactCatalogMetricResponse: Content, Sendable {
     public var readyCount: Int
     public var failedCount: Int
     public var expiredCount: Int
+    public var stuckWarmingCount: Int
+    public var oldestExpiredWarmingLeaseAgeSeconds: Int?
+    public var oldestPendingAgeSeconds: Int?
+    public var stuckReason: String?
     public var mostRecentFailureAt: Date?
     public var mostRecentFailureSummary: String?
 
@@ -815,6 +854,10 @@ public struct PressureArtifactCatalogMetricResponse: Content, Sendable {
         self.readyCount = metric.readyCount
         self.failedCount = metric.failedCount
         self.expiredCount = metric.expiredCount
+        self.stuckWarmingCount = metric.stuckWarmingCount
+        self.oldestExpiredWarmingLeaseAgeSeconds = metric.oldestExpiredWarmingLeaseAgeSeconds
+        self.oldestPendingAgeSeconds = metric.oldestPendingAgeSeconds
+        self.stuckReason = metric.stuckReason
         self.mostRecentFailureAt = metric.mostRecentFailureAt
         self.mostRecentFailureSummary = metric.mostRecentFailureSummary
     }

--- a/Sources/App/lib/OperatorDashboardPageRenderer.swift
+++ b/Sources/App/lib/OperatorDashboardPageRenderer.swift
@@ -845,7 +845,11 @@ enum OperatorDashboardPageRenderer {
             return renderCard('Pressure artifact catalog', `${metric?.readyCount ?? 0} ready`, metric?.refreshedAt, [
               { label: 'Total', value: String(metric?.totalCount ?? 0) },
               { label: 'Pending', value: String(metric?.pendingCount ?? 0) },
+              { label: 'Oldest pending', value: formatDuration(metric?.oldestPendingAgeSeconds) },
               { label: 'Warming', value: String(metric?.warmingCount ?? 0) },
+              { label: 'Stuck warming', value: String(metric?.stuckWarmingCount ?? 0) },
+              { label: 'Oldest expired lease', value: formatDuration(metric?.oldestExpiredWarmingLeaseAgeSeconds) },
+              { label: 'Pipeline status', value: metric?.stuckReason ?? 'Healthy' },
               { label: 'Failed', value: String(metric?.failedCount ?? 0) },
               { label: 'Expired', value: String(metric?.expiredCount ?? 0) },
               { label: 'Most recent failure', value: formatDate(metric?.mostRecentFailureAt) },
@@ -1345,7 +1349,11 @@ enum OperatorDashboardPageRenderer {
             lines: [
                 ("Total", "\(metric.totalCount)"),
                 ("Pending", "\(metric.pendingCount)"),
+                ("Oldest pending", maybeDuration(metric.oldestPendingAgeSeconds)),
                 ("Warming", "\(metric.warmingCount)"),
+                ("Stuck warming", "\(metric.stuckWarmingCount)"),
+                ("Oldest expired lease", maybeDuration(metric.oldestExpiredWarmingLeaseAgeSeconds)),
+                ("Pipeline status", metric.stuckReason ?? "Healthy"),
                 ("Failed", "\(metric.failedCount)"),
                 ("Expired", "\(metric.expiredCount)"),
                 ("Most recent failure", maybeDate(metric.mostRecentFailureAt)),

--- a/Sources/App/lib/OperatorDashboardSnapshotRefresher.swift
+++ b/Sources/App/lib/OperatorDashboardSnapshotRefresher.swift
@@ -394,7 +394,26 @@ struct OperatorDashboardSnapshotRefresher {
                 COUNT(*) FILTER (WHERE status = 'warming') AS "warmingCount",
                 COUNT(*) FILTER (WHERE status = 'ready') AS "readyCount",
                 COUNT(*) FILTER (WHERE status = 'failed') AS "failedCount",
-                COUNT(*) FILTER (WHERE status = 'expired') AS "expiredCount"
+                COUNT(*) FILTER (WHERE status = 'expired') AS "expiredCount",
+                COUNT(*) FILTER (
+                    WHERE status = 'warming'
+                      AND lease_expires_at <= \(bind: now)
+                ) AS "stuckWarmingCount",
+                CASE
+                    WHEN MIN(lease_expires_at) FILTER (
+                        WHERE status = 'warming'
+                          AND lease_expires_at <= \(bind: now)
+                    ) IS NULL THEN NULL
+                    ELSE GREATEST(0, EXTRACT(EPOCH FROM (
+                        \(bind: now) - MIN(lease_expires_at) FILTER (
+                            WHERE status = 'warming'
+                              AND lease_expires_at <= \(bind: now)
+                        )
+                    )))::BIGINT
+                END AS "oldestExpiredWarmingLeaseAgeSeconds",
+                GREATEST(0, EXTRACT(EPOCH FROM (
+                    \(bind: now) - MIN(COALESCE(last_checked_at, created_at)) FILTER (WHERE status = 'pending')
+                )))::BIGINT AS "oldestPendingAgeSeconds"
             FROM pressure_artifact_catalog
             WHERE product = 'wrfprsf'
               AND field_set_version = \(bind: fieldSetVersion)
@@ -451,6 +470,7 @@ struct OperatorDashboardSnapshotRefresher {
         """).first(decoding: PressureArtifactRow.self)
 
         let latestFailure = latestFailedRow ?? recentRows.first(where: { $0.status == PressureArtifactCatalogStatus.failed.rawValue })
+        let stuckWarmingCount = aggregate.map { Int($0.stuckWarmingCount) } ?? 0
 
         return .init(
             pressureArtifactReadiness: readiness,
@@ -462,6 +482,10 @@ struct OperatorDashboardSnapshotRefresher {
                 readyCount: aggregate.map { Int($0.readyCount) } ?? 0,
                 failedCount: aggregate.map { Int($0.failedCount) } ?? 0,
                 expiredCount: aggregate.map { Int($0.expiredCount) } ?? 0,
+                stuckWarmingCount: stuckWarmingCount,
+                oldestExpiredWarmingLeaseAgeSeconds: aggregate?.oldestExpiredWarmingLeaseAgeSeconds.map(Int.init),
+                oldestPendingAgeSeconds: aggregate?.oldestPendingAgeSeconds.map(Int.init),
+                stuckReason: makeStuckWarmingReason(count: stuckWarmingCount),
                 mostRecentFailureAt: latestFailure?.updatedAt,
                 mostRecentFailureSummary: latestFailure?.errorSummary
             ),
@@ -485,6 +509,12 @@ struct OperatorDashboardSnapshotRefresher {
                 }
             )
         )
+    }
+
+    private func makeStuckWarmingReason(count: Int) -> String? {
+        guard count > 0 else { return nil }
+        let artifactLabel = count == 1 ? "artifact has" : "artifacts have"
+        return "\(count) warming \(artifactLabel) an expired lease; the warming pipeline is stuck."
     }
 
     private func loadPressureArtifactReadiness(
@@ -772,6 +802,9 @@ private struct PressureArtifactCatalogAggregateRow: Decodable {
     let readyCount: Int64
     let failedCount: Int64
     let expiredCount: Int64
+    let stuckWarmingCount: Int64
+    let oldestExpiredWarmingLeaseAgeSeconds: Int64?
+    let oldestPendingAgeSeconds: Int64?
 }
 
 private struct PressureArtifactRow: Decodable {

--- a/Tests/AppTests/OperatorDashboardPressureArtifactTests.swift
+++ b/Tests/AppTests/OperatorDashboardPressureArtifactTests.swift
@@ -92,8 +92,9 @@ struct OperatorDashboardPressureArtifactTests {
                 status: .warming,
                 localPath: nil,
                 byteSize: nil,
+                leaseExpiresAt: now.addingTimeInterval(300),
                 source: .unknown,
-                lastCheckedAt: makeUTCDate(year: 2026, month: 6, day: 3, hour: 20, minute: 30)
+                lastCheckedAt: nil
             )
             try await warmingRow.create(on: app.db)
 
@@ -107,7 +108,7 @@ struct OperatorDashboardPressureArtifactTests {
                 localPath: nil,
                 byteSize: nil,
                 source: .unknown,
-                lastCheckedAt: nil
+                lastCheckedAt: now.addingTimeInterval(-60)
             )
             try await pendingRow.create(on: app.db)
 
@@ -154,6 +155,10 @@ struct OperatorDashboardPressureArtifactTests {
             #expect(artifacts.pressureArtifactCatalog.readyCount == 2)
             #expect(artifacts.pressureArtifactCatalog.failedCount == 2)
             #expect(artifacts.pressureArtifactCatalog.expiredCount == 1)
+            #expect(artifacts.pressureArtifactCatalog.stuckWarmingCount == 0)
+            #expect(artifacts.pressureArtifactCatalog.oldestExpiredWarmingLeaseAgeSeconds == nil)
+            #expect(artifacts.pressureArtifactCatalog.oldestPendingAgeSeconds == 60)
+            #expect(artifacts.pressureArtifactCatalog.stuckReason == nil)
             #expect(artifacts.pressureArtifactReadiness.selectionOutcome == .exact)
             #expect(artifacts.pressureArtifactReadiness.status == PressureArtifactCatalogStatus.ready.rawValue)
             #expect(artifacts.pressureArtifactReadiness.runTime == exactPressureRow.runTime)
@@ -187,6 +192,8 @@ struct OperatorDashboardPressureArtifactTests {
             #expect(html.contains("EXACT"))
             #expect(html.contains("accent"))
             #expect(html.contains("Catalog status"))
+            #expect(html.contains("Pipeline status"))
+            #expect(html.contains("Healthy"))
             #expect(html.contains("localPath") == false)
         }
     }
@@ -367,6 +374,75 @@ struct OperatorDashboardPressureArtifactTests {
             #expect(readiness.byteSize == 7)
             #expect(html.contains("UNAVAILABLE"))
             #expect(html.contains("danger"))
+        }
+    }
+
+    @Test("expired warming leases surface a stuck backlog without exposing lease details")
+    func expiredWarmingLeasesSurfaceAStuckBacklogWithoutExposingLeaseDetails() async throws {
+        try await withApp { app in
+            let now = makeUTCDate(year: 2026, month: 6, day: 3, hour: 23)
+            let currentVersion = HrrrProduct.wrfprsf.defaultFieldSetVersion
+            let stuckRow = PressureArtifactCatalogModel(
+                runTime: now,
+                forecastHour: 0,
+                validTime: now,
+                product: .wrfprsf,
+                fieldSetVersion: currentVersion,
+                status: .warming,
+                claimToken: UUID(),
+                leaseExpiresAt: now.addingTimeInterval(-300)
+            )
+            let pendingRow = PressureArtifactCatalogModel(
+                runTime: now.addingTimeInterval(-3_600),
+                forecastHour: 0,
+                validTime: now.addingTimeInterval(-3_600),
+                product: .wrfprsf,
+                fieldSetVersion: currentVersion,
+                status: .pending,
+                lastCheckedAt: now.addingTimeInterval(-600)
+            )
+            let expiredAtBoundaryRow = PressureArtifactCatalogModel(
+                runTime: now.addingTimeInterval(-7_200),
+                forecastHour: 1,
+                validTime: now.addingTimeInterval(-7_200),
+                product: .wrfprsf,
+                fieldSetVersion: currentVersion,
+                status: .warming,
+                claimToken: UUID(),
+                leaseExpiresAt: now
+            )
+            let olderPendingRow = PressureArtifactCatalogModel(
+                runTime: now.addingTimeInterval(-10_800),
+                forecastHour: 2,
+                validTime: now.addingTimeInterval(-10_800),
+                product: .wrfprsf,
+                fieldSetVersion: currentVersion,
+                status: .pending,
+                lastCheckedAt: now.addingTimeInterval(-1_200)
+            )
+            try await stuckRow.create(on: app.db)
+            try await pendingRow.create(on: app.db)
+            try await expiredAtBoundaryRow.create(on: app.db)
+            try await olderPendingRow.create(on: app.db)
+
+            try await OperatorDashboardSnapshotRefresher().refreshIfDue(on: app, forceAll: true, now: now)
+
+            let snapshot = try #require(try await app.operatorDashboardSnapshotStore.load(on: app.db))
+            let response = OperatorDashboardSnapshotResponse(snapshot: snapshot, renderedAt: now)
+            let html = OperatorDashboardPageRenderer.render(snapshot: response)
+            let body = try JSONEncoder().encode(response)
+
+            #expect(response.modelArtifacts.pressureArtifactReadiness.selectionOutcome == .unavailable)
+            #expect(response.modelArtifacts.pressureArtifactCatalog.pendingCount == 2)
+            #expect(response.modelArtifacts.pressureArtifactCatalog.oldestPendingAgeSeconds == 1_200)
+            #expect(response.modelArtifacts.pressureArtifactCatalog.stuckWarmingCount == 2)
+            #expect(response.modelArtifacts.pressureArtifactCatalog.oldestExpiredWarmingLeaseAgeSeconds == 300)
+            #expect(response.modelArtifacts.pressureArtifactCatalog.stuckReason == "2 warming artifacts have an expired lease; the warming pipeline is stuck.")
+            #expect(String(decoding: body, as: UTF8.self).contains("stuckReason"))
+            #expect(html.contains("Stuck warming"))
+            #expect(html.contains("warming pipeline is stuck"))
+            #expect(html.contains("claimToken") == false)
+            #expect(html.contains("leaseExpiresAt") == false)
         }
     }
 
@@ -569,6 +645,32 @@ struct OperatorDashboardPressureArtifactTests {
                 #expect(html.contains(expectedReason))
             }
         }
+    }
+
+    @Test("legacy pressure artifact catalog metrics decode with safe backlog defaults")
+    func legacyPressureArtifactCatalogMetricsDecodeWithSafeBacklogDefaults() throws {
+        let json = #"""
+        {
+          "refreshedAt": "2026-06-03T18:00:00Z",
+          "totalRowCount": 2,
+          "pendingCount": 1,
+          "warmingCount": 1,
+          "readyCount": 0,
+          "failedCount": 0,
+          "expiredCount": 0,
+          "mostRecentFailureAt": null,
+          "mostRecentFailureSummary": null
+        }
+        """#
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let metric = try decoder.decode(StoredPressureArtifactDashboardCatalogMetric.self, from: Data(json.utf8))
+
+        #expect(metric.stuckWarmingCount == 0)
+        #expect(metric.oldestExpiredWarmingLeaseAgeSeconds == nil)
+        #expect(metric.oldestPendingAgeSeconds == nil)
+        #expect(metric.stuckReason == nil)
     }
 }
 

--- a/docs/plans/pressure-artifact-warm-reliability-progress.md
+++ b/docs/plans/pressure-artifact-warm-reliability-progress.md
@@ -52,7 +52,7 @@ This ledger tracks the bounded-execution and queue-recovery campaign defined by 
 | 03 | [#193](https://github.com/justinrooks/arcus-signal/issues/193) | Retry transient warm failures with bounded backoff | 01, 02 | Pending |
 | 04 | [#194](https://github.com/justinrooks/arcus-signal/issues/194) | Characterize abandoned model-artifact processing jobs | None | Pending |
 | 05 | [#195](https://github.com/justinrooks/arcus-signal/issues/195) | Recover abandoned model-artifact jobs at worker startup | 04 | Implemented — ready for commit |
-| 06 | [#196](https://github.com/justinrooks/arcus-signal/issues/196) | Surface stuck pressure-artifact backlog health | 02 | Pending |
+| 06 | [#196](https://github.com/justinrooks/arcus-signal/issues/196) | Surface stuck pressure-artifact backlog health | 02 | Implemented — ready for commit |
 | 07 | [#201](https://github.com/justinrooks/arcus-signal/issues/201) | Add durable fenced failure-completion retries | 01, 02 | Implemented — ready for publication |
 
 ## Investigation notes
@@ -104,10 +104,11 @@ This ledger tracks the bounded-execution and queue-recovery campaign defined by 
 
 ### Issue #196 - 06: Surface stuck pressure-artifact backlog health
 
-- **Status:** Pending
-- **Goal:** Show expired warming leases, pending count, and oldest actionable age in dashboard JSON and HTML.
-- **Likely files:** dashboard snapshot metric/refresher, response DTO/renderer, dashboard pressure-artifact tests.
-- **Stop condition:** Operators can distinguish unavailable source data from a stuck warm pipeline without seeing claim tokens, Redis payloads, or local paths.
+- **Status:** Implemented — ready for commit
+- **Behavior:** Catalog-derived dashboard metrics now report stuck `warming` rows with expired leases, the oldest expired-lease age, pending count, and oldest pending age. A concise pipeline-stuck reason appears in JSON and HTML only when an expired warming lease exists.
+- **Compatibility:** Legacy stored catalog metrics decode the new fields to safe zero/nil defaults.
+- **Privacy:** Claim tokens, lease timestamps, Redis payloads, source URLs, and local paths remain absent from dashboard responses and HTML.
+- **Focused verification:** Passed — `swift test --filter OperatorDashboardPressureArtifactTests`; `swift test --filter OperatorDashboardTests`.
 
 ### Issue #201 - 07: Add durable fenced failure-completion retries
 


### PR DESCRIPTION
# Summary
Expose pressure-artifact backlog health in the operator dashboard so expired warming leases and aging pending work can be distinguished from unavailable source data.

# What Changed
- Add catalog-derived stuck warming count, oldest expired lease age, and oldest pending age to dashboard snapshot metrics.
- Render a concise pipeline-stuck reason and backlog values in JSON and HTML.
- Preserve backward decoding of legacy stored dashboard metrics with safe defaults.
- Add focused fixtures for healthy, stuck, boundary, legacy, and sensitive-field behavior.
- Update the pressure-artifact reliability progress ledger for issue #196.

# User Impact
Operators can identify a warming pipeline stuck behind expired leases and assess pending backlog age from the dashboard. No claim tokens, lease timestamps, Redis payloads, source URLs, or local paths are exposed.

# Testing
- No GitHub Actions workflow run is associated with commit `65c8b3c`.
- The progress ledger records `swift test --filter OperatorDashboardPressureArtifactTests` and `swift test --filter OperatorDashboardTests` as focused verification, but no execution log is included in the committed evidence.

# Notes
- Closes #196.
- The working tree was clean at publication time; an unrelated local `docs/Sql/Device.sql` edit was stashed outside this branch diff.