### PR TITLE
Define meaningful presence reconciliation transitions

### DIFF
--- a/Sources/App/Infrastructure/Notifications/PresenceReconciliationTrigger.swift
+++ b/Sources/App/Infrastructure/Notifications/PresenceReconciliationTrigger.swift
@@ -1,0 +1,109 @@
+//
+//  PresenceReconciliationTrigger.swift
+//  ArcusSignal
+//
+
+import Foundation
+
+public struct PresenceTargetingFingerprint: Equatable, Sendable {
+    public let h3Cell: Int64?
+    public let county: String?
+    public let forecastZone: String?
+    public let fireZone: String?
+
+    public init(
+        h3Cell: Int64?,
+        county: String?,
+        forecastZone: String?,
+        fireZone: String?
+    ) {
+        self.h3Cell = h3Cell
+        self.county = county
+        self.forecastZone = forecastZone
+        self.fireZone = fireZone
+    }
+}
+
+public struct PresenceReconciliationState: Sendable {
+    public let fingerprint: PresenceTargetingFingerprint
+    public let capturedAt: Date
+    public let locationAuth: LocationAuth
+    public let isActive: Bool
+    public let isSubscribed: Bool
+    public let hasAPNsToken: Bool
+
+    public init(
+        fingerprint: PresenceTargetingFingerprint,
+        capturedAt: Date,
+        locationAuth: LocationAuth,
+        isActive: Bool,
+        isSubscribed: Bool,
+        hasAPNsToken: Bool
+    ) {
+        self.fingerprint = fingerprint
+        self.capturedAt = capturedAt
+        self.locationAuth = locationAuth
+        self.isActive = isActive
+        self.isSubscribed = isSubscribed
+        self.hasAPNsToken = hasAPNsToken
+    }
+}
+
+public enum PresenceReconciliationTriggerCategory: String, Sendable, Equatable {
+    case firstUsablePresence
+    case movedWhileUsable
+    case becameUsable
+}
+
+public struct PresenceReconciliationTrigger: Sendable, Equatable {
+    public let category: PresenceReconciliationTriggerCategory
+
+    public init(category: PresenceReconciliationTriggerCategory) {
+        self.category = category
+    }
+
+    public static func decide(
+        previous: PresenceReconciliationState?,
+        current: PresenceReconciliationState,
+        now: Date,
+        freshnessPolicy: LocationFreshnessPolicy = .init()
+    ) -> Self? {
+        let currentUsable = isUsable(current, now: now, freshnessPolicy: freshnessPolicy)
+
+        guard currentUsable else {
+            return nil
+        }
+
+        guard let previous else {
+            return Self(category: .firstUsablePresence)
+        }
+
+        let previousUsable = isUsable(previous, now: now, freshnessPolicy: freshnessPolicy)
+        if !previousUsable {
+            return Self(category: .becameUsable)
+        }
+
+        guard previous.fingerprint != current.fingerprint else {
+            return nil
+        }
+
+        return Self(category: .movedWhileUsable)
+    }
+
+    private static func isUsable(
+        _ state: PresenceReconciliationState,
+        now: Date,
+        freshnessPolicy: LocationFreshnessPolicy
+    ) -> Bool {
+        guard state.isActive, state.isSubscribed, state.hasAPNsToken else {
+            return false
+        }
+
+        let freshness = freshnessPolicy.decide(
+            capturedAt: state.capturedAt,
+            locationAuth: state.locationAuth,
+            now: now
+        )
+        return freshness.state != .stale
+    }
+}

--- a/Tests/AppTests/PresenceReconciliationTriggerTests.swift
+++ b/Tests/AppTests/PresenceReconciliationTriggerTests.swift
@@ -1,0 +1,162 @@
+@testable import App
+import Foundation
+import Testing
+
+@Suite("Presence reconciliation trigger tests")
+struct PresenceReconciliationTriggerTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+    private let h3Cell: Int64 = 617_700_169_958_293_503
+
+    private var fingerprint: PresenceTargetingFingerprint {
+        .init(h3Cell: h3Cell, county: "COC013", forecastZone: "COZ039", fireZone: "COF241")
+    }
+
+    private func state(
+        fingerprint: PresenceTargetingFingerprint? = nil,
+        capturedAt: Date? = nil,
+        locationAuth: LocationAuth = .always,
+        isActive: Bool = true,
+        isSubscribed: Bool = true,
+        hasAPNsToken: Bool = true
+    ) -> PresenceReconciliationState {
+        .init(
+            fingerprint: fingerprint ?? self.fingerprint,
+            capturedAt: capturedAt ?? now,
+            locationAuth: locationAuth,
+            isActive: isActive,
+            isSubscribed: isSubscribed,
+            hasAPNsToken: hasAPNsToken
+        )
+    }
+
+    @Test("first usable presence triggers reconciliation")
+    func firstUsablePresence() {
+        let trigger = PresenceReconciliationTrigger.decide(
+            previous: nil,
+            current: state(),
+            now: now
+        )
+
+        #expect(trigger?.category == .firstUsablePresence)
+    }
+
+    @Test("changed targeting fingerprint while usable triggers movement")
+    func movedWhileUsable() {
+        let changed = PresenceTargetingFingerprint(
+            h3Cell: h3Cell + 1,
+            county: "COC013",
+            forecastZone: "COZ039",
+            fireZone: "COF241"
+        )
+
+        let trigger = PresenceReconciliationTrigger.decide(
+            previous: state(),
+            current: state(fingerprint: changed),
+            now: now
+        )
+
+        #expect(trigger?.category == .movedWhileUsable)
+    }
+
+    @Test("unusable presence becoming usable triggers reconciliation")
+    func becameUsable() {
+        let previous = state(capturedAt: now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold - 1))
+
+        let trigger = PresenceReconciliationTrigger.decide(
+            previous: previous,
+            current: state(),
+            now: now
+        )
+
+        #expect(trigger?.category == .becameUsable)
+    }
+
+    @Test("unchanged usable heartbeat does not trigger")
+    func unchangedUsableHeartbeat() {
+        let trigger = PresenceReconciliationTrigger.decide(
+            previous: state(capturedAt: now.addingTimeInterval(-60)),
+            current: state(),
+            now: now
+        )
+
+        #expect(trigger == nil)
+    }
+
+    @Test("source-independent fingerprint ignores non-targeting state")
+    func fingerprintOnlyContainsTargetingFields() {
+        let previous = state()
+        let current = state(capturedAt: now.addingTimeInterval(-60))
+
+        #expect(previous.fingerprint == current.fingerprint)
+    }
+
+    @Test("label-only or targeting-irrelevant changes do not trigger")
+    func irrelevantChangesDoNotTrigger() {
+        let unchanged = PresenceTargetingFingerprint(
+            h3Cell: h3Cell,
+            county: "COC013",
+            forecastZone: "COZ039",
+            fireZone: "COF241"
+        )
+
+        let trigger = PresenceReconciliationTrigger.decide(
+            previous: state(fingerprint: unchanged),
+            current: state(fingerprint: unchanged),
+            now: now
+        )
+
+        #expect(trigger == nil)
+    }
+
+    @Test("unusable to unusable changes do not trigger")
+    func unusableToUnusableDoesNotTrigger() {
+        let changed = PresenceTargetingFingerprint(
+            h3Cell: h3Cell + 1,
+            county: "COC013",
+            forecastZone: "COZ039",
+            fireZone: "COF241"
+        )
+        let previous = state(isSubscribed: false)
+
+        let trigger = PresenceReconciliationTrigger.decide(
+            previous: previous,
+            current: state(fingerprint: changed, isSubscribed: false),
+            now: now
+        )
+
+        #expect(trigger == nil)
+    }
+
+    @Test("stale to fresh transition triggers even without movement")
+    func staleToFresh() {
+        let previous = state(capturedAt: now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold - 1))
+        let current = state(capturedAt: now.addingTimeInterval(-60))
+
+        let trigger = PresenceReconciliationTrigger.decide(
+            previous: previous,
+            current: current,
+            now: now
+        )
+
+        #expect(trigger?.category == .becameUsable)
+    }
+
+    @Test("authorization, subscription, activity, and token state gate usability")
+    func deliveryStateGatesUsability() {
+        let unavailableStates: [PresenceReconciliationState] = [
+            state(locationAuth: .denied),
+            state(isActive: false),
+            state(isSubscribed: false),
+            state(hasAPNsToken: false)
+        ]
+
+        for unavailable in unavailableStates {
+            let trigger = PresenceReconciliationTrigger.decide(
+                previous: nil,
+                current: unavailable,
+                now: now
+            )
+            #expect(trigger == nil)
+        }
+    }
+}

--- a/docs/audits/weekly-bug-scan.md
+++ b/docs/audits/weekly-bug-scan.md
@@ -343,6 +343,87 @@
 - Implementation recommended: `yes`
 - Out-of-scope repositories intentionally not scanned: all sibling repositories
 
+## 2026-08-13
+
+### 1. Repository scanned
+- `arcus-signal`
+
+### 2. Commit window inspected
+- Reliable previous end marker: `51f4259b06f1e851f97ee37742e3384fe005f21a` from the 2026-08-06 audit entry
+- Window used: commits after `51f4259b06f1e851f97ee37742e3384fe005f21a` through `8985a4d89e22b31bc6951acfbe3ba2886a973991`
+- Dates: `2026-08-06T12:34:12-06:00` through `2026-08-10T08:11:36-06:00`
+- Commit count: 7
+- Start commit: `8ededc70f7fcef9f99cf251d34269dbed52fde8b`
+- End commit: `8985a4d89e22b31bc6951acfbe3ba2886a973991`
+- Fallback strategy: none; the bounded window contained commits
+
+### 3. High-risk areas inspected
+- Pressure-artifact HTTP request deadlines and transport failure classification (`Sources/App/Infrastructure/Networking/HTTPDataDownloader.swift`, pressure downloaders and caches)
+- Warm attempt timeout, claim fencing, failure completion, and bounded acquisition retry (`Sources/App/StormSetup/PressureArtifactWarmingService.swift`, `Sources/App/Jobs/PressureArtifactWarmJob.swift`, `Sources/App/Jobs/PressureArtifactFailureCompletionJob.swift`)
+- Abandoned Redis queue-job recovery before worker startup (`Sources/App/Worker/ModelArtifactQueueRecovery.swift`, `Sources/App/Worker/WorkerRuntime.swift`)
+- Pressure-artifact backlog health and dashboard compatibility (`Sources/App/lib/OperatorDashboardSnapshotRefresher.swift`, `Sources/App/Models/API/OperatorDashboardSnapshotResponse.swift`)
+- Prior probe dispatch-failure finding (`Sources/App/StormSetup/HRRRPressureArtifactProbeService.swift`, `Sources/App/Models/Data/PressureArtifactCatalogStore.swift`)
+
+### 4. Findings
+- New findings: none.
+- Changed findings: none.
+- Recurring finding: `BUG-SIGNAL-PRESSURE-PROBE-ENQUEUE-OVERWRITE` remains present at current `HEAD`. `PressureArtifactCatalogStore.markProbeFailure` still updates by artifact identity without a pending-state or ownership predicate. No materially new evidence, severity change, blast-radius change, or remediation improvement was found, so the normalized finding is not repeated. Existing GitHub issue: [#198](https://github.com/justinrooks/arcus-signal/issues/198) (open).
+- Resolved findings: none.
+
+### 5. Watchlist
+- None. The newly added timeout, retry, fenced failure-completion, startup recovery, and backlog-health paths had direct focused coverage and no concrete unsupported failure path was found.
+
+### 6. Top finding and best next fix
+- Top finding: recurring `BUG-SIGNAL-PRESSURE-PROBE-ENQUEUE-OVERWRITE`.
+- Best next fix: constrain probe failure persistence to the probe-owned pending transition and add ambiguous-dispatch regression coverage, as already scoped in issue #198.
+- Implementation recommended: `yes`, through the existing issue; no new issue is warranted.
+
+### 7. Validation
+- `swift test --filter PressureArtifactWarmJobTests` passed (32 tests).
+- `swift test --filter PressureArtifactFailureCompletionJobTests` passed (8 tests).
+- `swift test --filter ModelArtifactQueueRecoveryTests` passed (13 tests).
+- `swift test --filter OperatorDashboardPressureArtifactTests` passed (11 tests).
+- `swift test --filter HRRRPressureArtifactProbeServiceTests` passed (12 tests).
+- Total focused validation: 76 tests passed.
+
+### 8. GitHub triage
+- GitHub issues created: none.
+- GitHub issues updated: none; no materially new evidence justified a repetitive comment or edit.
+- Existing issues referenced: [#198](https://github.com/justinrooks/arcus-signal/issues/198).
+
+### 9. Files inspected
+- `Sources/App/Infrastructure/Networking/HTTPDataDownloader.swift`
+- `Sources/App/Jobs/PressureArtifactFailureCompletionJob.swift`
+- `Sources/App/Jobs/PressureArtifactWarmJob.swift`
+- `Sources/App/Models/API/OperatorDashboardSnapshotResponse.swift`
+- `Sources/App/Models/Data/PressureArtifactCatalogStore.swift`
+- `Sources/App/StormSetup/HRRRPressureArtifactProbeService.swift`
+- `Sources/App/StormSetup/PressureArtifactWarmingService.swift`
+- `Sources/App/Worker/ModelArtifactQueueRecovery.swift`
+- `Sources/App/Worker/WorkerRuntime.swift`
+- `Sources/App/lib/OperatorDashboardSnapshotRefresher.swift`
+- `Tests/AppTests/HRRRPressureArtifactProbeServiceTests.swift`
+- `Tests/AppTests/ModelArtifactQueueRecoveryTests.swift`
+- `Tests/AppTests/OperatorDashboardPressureArtifactTests.swift`
+- `Tests/AppTests/PressureArtifactFailureCompletionJobTests.swift`
+- `Tests/AppTests/PressureArtifactWarmJobTests.swift`
+
+### 10. Scope notes
+- Repository scanned: `arcus-signal` only.
+- Out-of-scope repositories: all sibling repositories and external clients were intentionally not scanned.
+- Skipped evidence: no cross-repository claims were evaluated or included.
+
+### Audit entry (short)
+- Date: `2026-08-13`
+- Repository reviewed: `arcus-signal`
+- Workflow reviewed: weekly bug scan (audit-only, commits since the reliable previous end marker)
+- Commit window inspected: `8ededc70f7fcef9f99cf251d34269dbed52fde8b` through `8985a4d89e22b31bc6951acfbe3ba2886a973991`; 7 commits
+- Files inspected: pressure-artifact HTTP deadlines, warm timeout/retry/failure completion, abandoned-job recovery, backlog health, prior probe failure transition, and focused tests listed above
+- Top finding: recurring probe enqueue failure can overwrite pressure-artifact work already advanced to `warming` or `ready`
+- Best next fix: implement existing issue #198; no duplicate issue or repetitive update
+- Implementation recommended: `yes`, through existing issue #198
+- Out-of-scope repositories intentionally not scanned: all sibling repositories
+
 ### 9. Implementation status
 - Fixed on `2026-07-26`.
 - `NotificationSendJob` now blocks `.new` and `.update` deliveries before candidate resolution, ledger claiming, and APNs when the series is inactive or its `expires` or `ends` timestamp has elapsed.

--- a/docs/audits/weekly-test-gap-audit.md
+++ b/docs/audits/weekly-test-gap-audit.md
@@ -239,3 +239,42 @@
   - APNs retry/backoff, queue replay, abandoned-claim recovery, and unknown-outcome handling remain explicit unimplemented reliability gaps in `docs/architecture.md`; tests should accompany those behaviors when implementation is scoped, but current evidence does not justify tests for behavior that does not yet exist.
 - Implementation recommended: no
 - Out-of-scope repositories intentionally not scanned: all sibling repositories and external NWS, APNs, Redis, and PostgreSQL implementations
+
+## 2026-08-11
+- Repository reviewed: `arcus-signal`
+- Commit window inspected: since the last automation run (`2026-08-04T15:01:09.569Z` through `2026-08-11`); seven commits from `8ededc70f7fcef9f99cf251d34269dbed52fde8b` through `8985a4d89e22b31bc6951acfbe3ba2886a973991`
+- High-risk areas inspected:
+  - pressure-artifact HTTP request deadlines, whole-warm timeout/cancellation ownership, transient failure classification, bounded logical retries, and terminal claim completion
+  - durable fenced failure-completion retries, stale-owner protection, retry exhaustion, and error-summary sanitization
+  - abandoned model-artifact Redis job recovery, atomic/idempotent queue transitions, malformed-state preservation, and worker startup ordering/failure
+  - pressure-artifact backlog metrics, expired-lease boundaries, stored-snapshot compatibility, and sensitive-field exclusion from operator output
+- Files inspected:
+  - `Sources/App/Infrastructure/Networking/HTTPDataDownloader.swift`
+  - `Sources/App/Jobs/PressureArtifactWarmJob.swift`
+  - `Sources/App/Jobs/PressureArtifactFailureCompletionJob.swift`
+  - `Sources/App/StormSetup/PressureArtifactWarmingService.swift`
+  - `Sources/App/StormSetup/HrrrPressureByteRangeDownloader.swift`
+  - `Sources/App/StormSetup/StormSetupConfiguration.swift`
+  - `Sources/App/Worker/ModelArtifactQueueRecovery.swift`
+  - `Sources/App/Worker/WorkerRuntime.swift`
+  - `Sources/App/lib/OperatorDashboardSnapshotRefresher.swift`
+  - `Sources/App/Models/API/OperatorDashboardSnapshotResponse.swift`
+  - `Tests/AppTests/PressureArtifactWarmJobTests.swift`
+  - `Tests/AppTests/PressureArtifactFailureCompletionJobTests.swift`
+  - `Tests/AppTests/HrrrPressureByteRangeDownloaderTests.swift`
+  - `Tests/AppTests/StormSetupConfigurationTests.swift`
+  - `Tests/AppTests/ModelArtifactQueueRecoveryTests.swift`
+  - `Tests/AppTests/AppTests.swift`
+  - `Tests/AppTests/OperatorDashboardPressureArtifactTests.swift`
+- Existing relevant tests found:
+  - warm-job coverage exercises deadline propagation, timeout/cancellation races, retry classification and exhaustion, continuation dispatch failure, fenced claim completion, concurrent ownership, and terminal validation failures
+  - failure-completion coverage exercises durable retry success, stale and duplicate completion, retry exhaustion, cancellation, configured schedules, and bounded token-redacted summaries
+  - queue-recovery coverage exercises atomic and idempotent recovery, duplicate/already-waiting membership, unknown/missing/malformed data preservation, invalid payload shapes, and all-or-nothing Redis failure behavior; worker-runtime tests cover recovery-before-consumer ordering and zero-grace startup failure
+  - dashboard coverage exercises healthy/stuck/empty catalogs, the exact expired-lease boundary, pending-age aggregation, JSON/HTML projection, legacy decoding defaults, and exclusion of claim/lease details
+- Recommended test gaps: none (High: 0, Medium: 0, Low: 0)
+- Top recommended test: none. No test gap recommended; each behavior-bearing reliability change in the commit window has focused contract or integration coverage proportional to its product risk.
+- Validation: `swift test --filter 'PressureArtifactWarmJobTests|PressureArtifactFailureCompletionJobTests|ModelArtifactQueueRecoveryTests|OperatorDashboardPressureArtifactTests|HrrrPressureByteRangeDownloaderTests|StormSetupConfigurationTests'` (80 tests passed across six suites)
+- Watchlist items:
+  - the delayed-startup-grace recovery-failure branch asynchronously shuts down the worker and lacks a direct lifecycle test; promote only if that branch changes or a deterministic shutdown harness becomes available, because the same recovery-before-consumer and failure-stop invariants are already covered through the zero-grace path
+- Implementation recommended: no
+- Out-of-scope repositories intentionally not scanned: all sibling repositories and external HRRR, Redis, PostgreSQL, and Vapor Queues implementations

--- a/docs/plans/location-driven-alert-reconciliation-progress.md
+++ b/docs/plans/location-driven-alert-reconciliation-progress.md
@@ -1,0 +1,373 @@
+# Location-Driven Active-Alert Reconciliation Progress
+
+## Overview
+
+Arcus Signal currently discovers notification relevance when an alert revision changes. This campaign adds the inverse discovery path for an installation whose authoritative presence changes, while retaining one server delivery pipeline and one ledger claim boundary.
+
+Epic status:
+- Active
+
+Primary GitHub epic:
+- `#207` - https://github.com/justinrooks/arcus-signal/issues/207
+
+Runbook:
+- `docs/plans/location-driven-alert-reconciliation-runbook.md`
+
+---
+
+## Global Decisions
+
+- Arcus Signal remains the sole watch/warning notification producer and deduplication authority.
+- Keep the API boundary as validate -> transactional persistence/intention -> queued worker work. No request-time APNs.
+- Reconcile only first usable presence, changed persisted targeting fingerprint, or unusable/hard-stale to usable transitions.
+- Define the targeting fingerprint from persisted H3 cell, county, forecast zone, and fire zone.
+- Do not trigger on upload source, labels, accuracy, or a fresh unchanged heartbeat.
+- Use `captured_at` and `LocationFreshnessPolicy`; `location_age_seconds` and `received_at` are not the current delivery-freshness authority.
+- Persist a durable reconciliation intent in the same transaction as the authoritative installation/presence change.
+- Query active current revisions for one installation. Do not invoke global alert fan-out from location work.
+- Use current-revision `notification_outbox.mode` and `.reason` to preserve H3 versus UGC fallback and existing copy semantics.
+- Add a backward-compatible optional installation constraint to `NotificationSendJob`; do not create a parallel last-mile delivery service unless this seam proves inadequate.
+- Preserve `UNIQUE(installation_id, series_id, revision_urn)` as the race and retry convergence point.
+- Treat duplicate discovery and duplicate queue handoff as safe; do not claim exactly-once APNs delivery.
+- Keep APNs failure/reclaim work in `#13` and general outbox concurrency work in `#6` out of scope.
+- Server deployment and validation must precede any separate client WatchEngine removal campaign.
+
+---
+
+## Confirmed Current State
+
+### Alert-driven flow
+
+1. `IngestNWSAlertsJob` fetches NWS events and calls `NWSIngestPersistence` in a database transaction.
+2. A new current revision writes a target-dispatch intent for any geometry and writes a UGC notification-dispatch intent immediately for nil or point geometry.
+3. `TargetEventRevisionJob` computes/persists H3 coverage for supported polygons, then writes an H3 notification-dispatch intent. Point or cover failure uses UGC fallback.
+4. `DispatchAgent` enqueues `NotificationSendJob` on the send lane and marks the notification outbox row done after queue handoff.
+5. `NotificationSendJob` requires the payload revision to equal `arcus_series.current_revision_urn`.
+6. Normal `.new`/`.update` work stops before candidate selection unless the series is active and neither `expires` nor `ends` is past.
+7. `NotificationCandidateStore` selects active, subscribed, token-bearing installations with `captured_at` no older than 24 hours using exact H3 membership or county/forecast-zone/fire-zone OR matching.
+8. `LocationFreshnessPolicy` classifies each candidate. Stale authorization/location records are recorded as missed and skipped; fresh/degraded candidates continue.
+9. `NotificationDeliveryStore.claim` performs `INSERT ... ON CONFLICT DO NOTHING` against the ledger identity `(installation_id, series_id, revision_urn)`.
+10. After a claim, `NotificationEngine` composes candidate-specific copy, the sender calls APNs, and the ledger becomes `sent` or terminal `failed`. A send-attempt summary and debug copy are recorded separately.
+
+### Presence flow
+
+1. `POST /api/v1/devices/location-snapshots` decodes the ArcusCore payload and validates identifiers, enums, non-negative age/accuracy, paired H3 fields, resolution, and a captured time no more than five minutes in the future.
+2. The route transaction upserts the installation and one presence row keyed by installation UUID.
+3. Presence with an older `captured_at` is ignored. Equal timestamps are accepted.
+4. Newer accepted records update timestamps, quality, scheme, and source. Optional H3/UGC fields and labels overwrite only when supplied, so omitted fields preserve prior authoritative values.
+5. The route returns success after logging the insert/update/stale-ignore outcome.
+6. No active-alert query, durable reconciliation intent, queue dispatch, delivery claim, or APNs work currently follows presence persistence.
+
+### Root capability gap
+
+Alert fan-out sees only installations matching when a revision is targeted. A later presence change can make that same active current revision relevant, but no inverse evaluation runs. Therefore an installation outside at issuance can enter the covered H3/UGC area and receive no server notification for that revision.
+
+---
+
+## Material Findings Versus Initial Assumptions
+
+- The named `NotificationCandidateStore` and `NotificationDeliveryStore` already exist on current `main`; they are not merely proposed architecture seams.
+- The ledger identity is confirmed exactly as `(installation_id, series_id, revision_urn)`. Mode and reason are recorded but do not participate in uniqueness.
+- The ledger gives at-most-one claim, not exactly-once or eventual APNs delivery. A crash after claim can leave `claimed`, and failed claims are terminal today.
+- `NotificationSendJob` owns lifecycle/revision gating, fan-out selection, freshness, claim, composition, APNs, completion, debug, and attempt telemetry. An installation constraint is smaller than extracting a new delivery subsystem.
+- Candidate SQL excludes records older than 24 hours before the richer freshness policy runs. Freshness is based on `captured_at` and authorization, not the uploaded `location_age_seconds`.
+- `DeviceController` preserves old H3/UGC values when an accepted partial payload omits them, including for `ugc-only`. The current candidate queries match persisted fields and do not filter on `cell_scheme`; reconciliation must preserve that behavior unless separately changed.
+- A series-level `arcus_geolocation` row is not revision-keyed. Its mere existence cannot safely determine the current revision's H3/UGC mode after a fallback revision. The current-revision notification-dispatch record is the safer mode provenance.
+- Current production queue dispatches use zero Vapor Queue retries by default. Bounded reconciliation retries can be added because the new path is idempotent, but this campaign does not repair APNs retry semantics.
+
+---
+
+## Target Flow
+
+```text
+accepted authoritative installation/presence transition
+  -> pure meaningful-transition decision
+  -> durable presence reconciliation intent in same DB transaction
+  -> best-effort API queue handoff plus worker scheduled drain
+  -> target-lane installation reconciliation job
+  -> installation-scoped active-current-revision H3/UGC lookup
+  -> send-lane NotificationSendJob constrained to one installation
+  -> existing lifecycle + freshness + atomic ledger claim
+  -> existing composition + APNs + sent/failed completion
+```
+
+Race result:
+
+```text
+alert-driven discovery -----\
+                             -> INSERT ledger claim -> one winner
+location-driven discovery --/
+```
+
+---
+
+## Issue Sequence
+
+Work sequentially:
+
+1. `#208` - https://github.com/justinrooks/arcus-signal/issues/208 - 01: Define meaningful presence reconciliation transitions
+2. `#209` - https://github.com/justinrooks/arcus-signal/issues/209 - 02: Add durable presence reconciliation intents
+3. `#210` - https://github.com/justinrooks/arcus-signal/issues/210 - 03: Record intents for authoritative presence transitions
+4. `#211` - https://github.com/justinrooks/arcus-signal/issues/211 - 04: Query matching active alerts for one installation
+5. `#212` - https://github.com/justinrooks/arcus-signal/issues/212 - 05: Constrain the existing send job to one installation
+6. `#213` - https://github.com/justinrooks/arcus-signal/issues/213 - 06: Dispatch and process installation reconciliation work
+7. `#214` - https://github.com/justinrooks/arcus-signal/issues/214 - 07: Verify end-to-end races, retries, and rollout readiness
+
+---
+
+## Existing Code Map
+
+Production:
+- `Sources/App/Controllers/DeviceController.swift`
+- `Sources/App/Models/Device/DeviceInstallationModel.swift`
+- `Sources/App/Models/Device/DevicePresenceModel.swift`
+- `Sources/App/Infrastructure/Notifications/LocationFreshnessPolicy.swift`
+- `Sources/App/Services/NWSIngestPersistence.swift`
+- `Sources/App/Jobs/IngestNWSAlertsJob.swift`
+- `Sources/App/Jobs/TargetEventRevisionJob.swift`
+- `Sources/App/lib/DispatchAgent.swift`
+- `Sources/App/Models/Notification/NotificationCandidateStore.swift`
+- `Sources/App/Models/Notification/NotificationDeliveryStore.swift`
+- `Sources/App/Jobs/NotificationSendJob.swift`
+- `Sources/App/Infrastructure/Notifications/NotificationEngine.swift`
+- `Sources/App/Migrations/CreateDevicePresence.swift`
+- `Sources/App/Migrations/CreateArcusGeolocation.swift`
+- `Sources/App/Migrations/CreateNotificationOutbox.swift`
+- `Sources/App/Migrations/CreateNotificationLedger.swift`
+- `Sources/App/configure.swift`
+- `Sources/App/Worker/ArcusQueueLane.swift`
+- `Sources/App/Worker/WorkerRuntime.swift`
+
+Focused tests:
+- `Tests/AppTests/DeviceControllerTests.swift`
+- `Tests/AppTests/NWSIngestPersistenceFlowTests.swift`
+- `Tests/AppTests/TargetEventRevisionJobFallbackTests.swift`
+- `Tests/AppTests/NotificationSendJobCandidateQueryTests.swift`
+- `Tests/AppTests/NotificationSendJobFreshnessDecisionTests.swift`
+- `Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift`
+- `Tests/AppTests/NotificationLedgerFreshnessPersistenceTests.swift`
+- `Tests/AppTests/NWSAlertLifecycleTests.swift`
+- `Tests/AppTests/IntegrationTestSupport.swift`
+
+---
+
+## Performance And Resilience Notes
+
+- The inverse query is bounded by one installation and the small set of active current series. Existing indexes cover series lifecycle, H3 arrays, UGC arrays, and notification-outbox series joins.
+- Only meaningful state transitions create reconciliation work, so ordinary foreground heartbeats do not scan active alerts.
+- The durable intent closes the database-commit/Redis-enqueue gap for accepted transitions. API queue handoff remains best effort; the worker schedule drains missed ready rows.
+- Duplicate outbox drain or job retry can enqueue the same constrained send more than once. The ledger uniqueness makes delivery claim convergence safe.
+- Reconciliation must load latest authoritative presence rather than treating the intent's historical fingerprint as delivery input. This prevents a delayed job from targeting an obsolete location.
+- Existing general outbox non-atomic drain behavior remains. Duplicates are acceptable here; lost committed intent is not.
+- Existing APNs failure behavior remains terminal and is not made reliable by this campaign.
+- Logs should expose reconciliation intent ID, installation ID, trigger category, matched alert count, constrained dispatch count, retry attempt, and error without APNs tokens or raw coordinates.
+
+---
+
+## Status Ledger
+
+### Issue #208 - 01: Define meaningful presence reconciliation transitions
+
+GitHub:
+- https://github.com/justinrooks/arcus-signal/issues/208
+
+Status: Complete
+
+Goal:
+- Add a pure, deterministic decision for first usable presence, persisted targeting-fingerprint change, and unusable/hard-stale to usable transition.
+
+Likely files:
+- `Sources/App/Infrastructure/Notifications/PresenceReconciliationTrigger.swift`
+- `Tests/AppTests/PresenceReconciliationTriggerTests.swift`
+
+Verification:
+- `swift test --filter PresenceReconciliationTriggerTests`
+
+Evidence:
+- Added `PresenceReconciliationTrigger` as a pure `Sendable` decision over authoritative persisted state.
+- Added nine deterministic matrix tests covering first usable, moved while usable, unusable-to-usable, stale-to-fresh, unchanged heartbeat, irrelevant changes, unusable-to-unusable, and delivery-state gates.
+- Focused verification passed on 2026-08-13.
+
+Stop condition:
+- Policy and matrix tests exist; no controller, queue, migration, query, or send behavior is wired.
+
+Handoff:
+- Issue #209 may add durable reconciliation intents; do not wire route or worker behavior into this policy slice.
+
+### Issue #209 - 02: Add durable presence reconciliation intents
+
+GitHub:
+- https://github.com/justinrooks/arcus-signal/issues/209
+
+Status: Pending
+
+Goal:
+- Add the minimal PostgreSQL model, migration, and store for immutable ready/done/dead reconciliation queue-handoff intents.
+
+Likely files:
+- `Sources/App/Models/Notification/PresenceReconciliationOutboxModel.swift`
+- `Sources/App/Migrations/CreatePresenceReconciliationOutbox.swift`
+- `Sources/App/Models/Notification/PresenceReconciliationOutboxStore.swift`
+- `Sources/App/configure.swift`
+- `Tests/AppTests/PresenceReconciliationOutboxTests.swift`
+
+Verification:
+- `swift test --filter PresenceReconciliationOutboxTests`
+- `swift test --filter DevicePresenceMigrationTests`
+
+Stop condition:
+- Schema and persistence semantics are tested and registered; no route or worker behavior consumes them.
+
+### Issue #210 - 03: Record intents for authoritative presence transitions
+
+GitHub:
+- https://github.com/justinrooks/arcus-signal/issues/210
+
+Status: Pending
+
+Goal:
+- Evaluate persisted before/after installation and presence state inside the existing route transaction and insert an intent only for meaningful usable transitions.
+
+Likely files:
+- `Sources/App/Controllers/DeviceController.swift`
+- `Sources/App/Infrastructure/Notifications/PresenceReconciliationTrigger.swift`
+- `Sources/App/Models/Notification/PresenceReconciliationOutboxStore.swift`
+- `Tests/AppTests/DeviceControllerTests.swift`
+
+Verification:
+- `swift test --filter DeviceControllerTests`
+- `swift test --filter PresenceReconciliationTriggerTests`
+
+Stop condition:
+- The route transaction durably records correct intents; it does not dispatch reconciliation or APNs work.
+
+### Issue #211 - 04: Query matching active alerts for one installation
+
+GitHub:
+- https://github.com/justinrooks/arcus-signal/issues/211
+
+Status: Pending
+
+Goal:
+- Add an installation-scoped active-current-revision lookup that preserves current H3 and UGC-fallback mode semantics.
+
+Likely files:
+- `Sources/App/Models/Notification/NotificationCandidateStore.swift`
+- `Tests/AppTests/NotificationActiveAlertQueryTests.swift`
+
+Verification:
+- `swift test --filter NotificationActiveAlertQueryTests`
+- `swift test --filter NotificationSendJobCandidateQueryTests`
+
+Stop condition:
+- Query tests cover H3, all three UGC fields, fallback mode, current revision, and lifecycle exclusions; no queue or delivery behavior changes.
+
+### Issue #212 - 05: Constrain the existing send job to one installation
+
+GitHub:
+- https://github.com/justinrooks/arcus-signal/issues/212
+
+Status: Pending
+
+Goal:
+- Make `NotificationSendJob` optionally select one installation without changing existing unconstrained alert-driven fan-out or last-mile semantics.
+
+Likely files:
+- `Sources/App/Jobs/NotificationSendJob.swift`
+- `Sources/App/Models/Notification/NotificationCandidateStore.swift`
+- `Tests/AppTests/NotificationSendJobCandidateQueryTests.swift`
+- `Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift`
+
+Verification:
+- `swift test --filter NotificationSendJobCandidateQueryTests`
+- `swift test --filter NotificationSendJobDeliveryBoundaryTests`
+- `swift test --filter NotificationEngineTests`
+
+Stop condition:
+- Optional constrained payload behavior and backward decoding are tested; no reconciliation job exists yet.
+
+### Issue #213 - 06: Dispatch and process installation reconciliation work
+
+GitHub:
+- https://github.com/justinrooks/arcus-signal/issues/213
+
+Status: Pending
+
+Goal:
+- Add best-effort API queue handoff, a worker scheduled outbox drain, and a bounded-retry target-lane job that dispatches installation-constrained send work for active matches.
+
+Likely files:
+- `Sources/App/Jobs/ReconcileInstallationAlertsJob.swift`
+- `Sources/App/Jobs/DispatchPresenceReconciliationScheduledJob.swift`
+- `Sources/App/Models/Notification/PresenceReconciliationOutboxStore.swift`
+- `Sources/App/Controllers/DeviceController.swift`
+- `Sources/App/configure.swift`
+- `Tests/AppTests/InstallationAlertReconciliationJobTests.swift`
+
+Verification:
+- `swift test --filter InstallationAlertReconciliationJobTests`
+- `swift test --filter DeviceControllerTests`
+- `swift test --filter AppTests.AppTests`
+
+Stop condition:
+- Durable intents reach the target lane and dispatch only installation-scoped send work; no end-to-end campaign expansion or client change.
+
+### Issue #214 - 07: Verify end-to-end races, retries, and rollout readiness
+
+GitHub:
+- https://github.com/justinrooks/arcus-signal/issues/214
+
+Status: Pending
+
+Goal:
+- Add final deterministic vertical coverage, align living architecture docs, and record deployment validation and client-removal gates.
+
+Likely files:
+- `Tests/AppTests/LocationDrivenAlertReconciliationFlowTests.swift`
+- `docs/architecture.md`
+- `docs/plans/location-driven-alert-reconciliation-progress.md`
+
+Verification:
+- `swift test --filter LocationDrivenAlertReconciliationFlowTests`
+- `swift test --filter Notification`
+- `swift test --filter Device`
+- `swift test --filter Reconciliation`
+- `swift build`
+- `swift test --no-parallel`
+
+Required vertical matrix:
+- outside at issuance, later enters active revision and sends once;
+- prior delivery and leave/re-enter do not resend;
+- new revision remains independently eligible;
+- first valid presence discovers an existing alert;
+- hard-stale/unusable to usable transition reconciles;
+- unchanged/irrelevant presence creates no intent or constrained send;
+- H3 and UGC fallback both work;
+- expired, ended, cancelled, and stale revisions are ignored;
+- alert-driven and location-driven discovery racing produces one ledger claim;
+- duplicate intent drain and reconciliation retry remain idempotent.
+
+Stop condition:
+- Full server capability and rollout evidence are documented. No client issue, repository change, or WatchEngine removal is created.
+
+---
+
+## Verification Ledger
+
+- Investigation verified local `main` at `8985a4d89e22b31bc6951acfbe3ba2886a973991`, matching the latest GitHub commit returned by the connector.
+- Read `AGENTS.md`, living/historical architecture docs, existing Epic Builder plan patterns, notification and presence production paths, migrations, and focused tests.
+- Searched GitHub for overlapping active-alert/location-reconciliation issues; none were found.
+- Related existing work: completed freshness epic `#51`; open outbox concurrency issue `#6`; open APNs retry issue `#13`.
+- GitHub connector verification confirmed epic `#207` is open with seven checklist children, and issues `#208` through `#214` are open, linked to `#207`, labeled `server`/`feature`/`codex`, and reference both campaign docs.
+- Placeholder and whitespace verification passed for both campaign docs after exact issue links were patched.
+- Planning-only task: project build and tests are not required until implementation because no production code changed.
+
+---
+
+## Handoff Notes
+
+- Future implementers should recover context from this progress doc, the runbook, and the current child issue instead of restating the investigation.
+- The first implementation slice is policy only. Do not jump directly into controller queue dispatch.
+- Preserve user-owned working-tree changes in `docs/Sql/Device.sql`, `docs/audits/weekly-bug-scan.md`, and `docs/audits/weekly-test-gap-audit.md`.
+- If implementation finds that current-revision notification-outbox mode is not reliable provenance, stop and document evidence before adding a new revision contract or schema field.
+- If an issue exceeds the likely files or review budget, split it before editing rather than broadening the slice.

--- a/docs/plans/location-driven-alert-reconciliation-runbook.md
+++ b/docs/plans/location-driven-alert-reconciliation-runbook.md
@@ -1,0 +1,249 @@
+# Location-Driven Active-Alert Reconciliation Runbook
+
+**Status:** Active
+**Applies To:** Installation movement into already-active NWS watches and warnings
+**Project:** Arcus Signal
+**Parent Issue:** https://github.com/justinrooks/arcus-signal/issues/207
+
+**Related Docs:**
+- `AGENTS.md`
+- `docs/architecture.md`
+- `docs/epics-stories.md`
+- `docs/plans/location-driven-alert-reconciliation-progress.md`
+- `docs/plans/architecture-recovery-runbook.md`
+- `docs/plans/architecture-recovery-progress.md`
+
+This runbook defines how to implement one location-driven reconciliation sub-issue at a time. It is an Arcus-Signal-only campaign.
+
+---
+
+## Purpose
+
+Allow Arcus Signal to discover notification relevance in both directions:
+
+```text
+alert/revision changed -> matching installations
+installation/presence changed -> matching active alerts
+                         \     /
+               one server delivery pipeline
+               one atomic ledger claim
+```
+
+The location-driven path closes the current gap where an installation can move into an already-active alert after that revision's alert-driven fan-out ran. It must enqueue worker work after authoritative presence persistence; the HTTP request must not send APNs.
+
+The invariant remains:
+
+> Discovery may happen more than once, but `notification_ledger` permits at most one claim for an installation, series, and revision.
+
+This is not an exactly-once APNs guarantee. Existing claimed/failed-row recovery and APNs retry limitations remain tracked separately.
+
+---
+
+## Source Of Truth
+
+Use this order:
+
+1. `AGENTS.md`
+2. `docs/architecture.md`
+3. This runbook
+4. `docs/plans/location-driven-alert-reconciliation-progress.md`
+5. The current GitHub child issue
+6. Current source, migrations, and focused tests touched by that issue
+7. `docs/epics-stories.md` as historical context only
+
+The living architecture and current source override historical stored-payload, retry, or exactly-once language.
+
+---
+
+## Required Read Order
+
+Before implementation:
+
+1. `AGENTS.md`
+2. `docs/architecture.md`
+3. `docs/plans/location-driven-alert-reconciliation-runbook.md`
+4. `docs/plans/location-driven-alert-reconciliation-progress.md`
+5. The current GitHub issue
+6. Relevant files from the code map in the progress doc
+
+Read `docs/epics-stories.md` only when historical intent is needed. Do not inspect or modify `project-arcus`.
+
+---
+
+## Minimal Prompt Contract
+
+```text
+Implement GitHub issue #NN for arcus-signal.
+
+Before coding, read:
+- docs/plans/location-driven-alert-reconciliation-runbook.md
+- docs/plans/location-driven-alert-reconciliation-progress.md
+- the GitHub issue body
+
+Work only that issue. Preserve the existing alert-driven path and ledger identity.
+Run the issue's focused verification, update the progress ledger, and stop.
+```
+
+---
+
+## Target Architecture
+
+### Presence transition
+
+`DeviceController` continues to validate and persist installation plus presence in one database transaction. A pure transition policy compares the authoritative before/after state and requests reconciliation only for:
+
+- first usable presence;
+- a changed persisted targeting fingerprint;
+- unusable or hard-stale presence becoming delivery-usable.
+
+The persisted targeting fingerprint consists of the fields the current candidate queries actually use: H3 cell, county, forecast zone, and fire zone. Freshness uses `captured_at` plus installation authorization through `LocationFreshnessPolicy`; `received_at`, `location_age_seconds`, upload source, labels, and ordinary heartbeat timestamps do not independently change targeting relevance.
+
+The policy must evaluate the persisted result, not raw optional payload fields. Current partial-update behavior preserves previously stored H3/UGC values when an upload omits them.
+
+### Durable queue handoff
+
+A meaningful transition writes an immutable presence-reconciliation intent in the same database transaction as the accepted authoritative state. After commit, the API may make a best-effort queue handoff. A worker-owned scheduled drain retries ready intents so a Redis enqueue failure does not erase the committed transition.
+
+Duplicate queue handoffs and reconciliation retries are acceptable. The reconciliation job and downstream ledger make them idempotent. Do not expand this campaign into the general outbox concurrency redesign tracked by GitHub issue `#6`.
+
+### Installation-to-alert lookup
+
+Add one installation-scoped inverse query beside existing notification candidate selection. It must:
+
+- load only the current revision of active, unexpired, unended series;
+- use the current revision's existing `notification_outbox` mode and reason as targeting provenance;
+- use `h3_cell = ANY(arcus_geolocation.h3_cells)` for H3 mode;
+- use the same county/forecast-zone/fire-zone OR semantics for UGC mode;
+- ignore cancelled, expired, ended, stale-revision, and terminal-only notification work;
+- avoid global alert fan-out.
+
+The existing current-revision notification-dispatch row is important: it preserves whether that revision was delivered through supported H3 coverage or UGC fallback. Do not infer the current mode solely from whether a series-level geolocation row exists; that row is not revision-keyed and can represent an earlier revision.
+
+Existing state, expiration, GIN H3-array, GIN UGC-array, and notification-outbox indexes appear sufficient for the expected active-alert set. Add an index only if focused query evidence proves it necessary.
+
+### Shared delivery
+
+Extend `NotificationSendJobPayload` with a backward-compatible optional installation constraint. With no constraint, alert-driven fan-out behaves unchanged. With an installation ID, candidate selection is restricted to that installation while retaining the same:
+
+- current-revision and lifecycle checks;
+- H3/UGC predicates;
+- freshness decision and stale-miss behavior;
+- atomic `NotificationDeliveryStore.claim`;
+- `NotificationEngine` composition;
+- APNs environment selection and send;
+- sent/failed ledger completion and attempt telemetry.
+
+Do not extract a second notification service unless implementation evidence shows the optional constraint cannot keep this path clear and testable.
+
+### Worker reconciliation
+
+The target-lane reconciliation job loads the installation's latest authoritative state, finds matching active current revisions, and dispatches installation-constrained `NotificationSendJob` payloads on the send lane. It does not compose or send APNs itself. Bounded retries may rediscover or redispatch the same work because all delivery attempts converge on the ledger claim.
+
+---
+
+## Required Guardrails
+
+- Keep Arcus Signal the only watch/warning notification eligibility, deduplication, and delivery authority.
+- Preserve `UNIQUE(installation_id, series_id, revision_urn)` on `notification_ledger`.
+- Preserve existing `.new` and `.update` notification reason and copy semantics; discovery source is operational metadata, not a new user-visible notification type.
+- Keep APNs worker-owned and asynchronous from the location HTTP request.
+- Use the latest persisted presence at reconciliation and again at constrained candidate delivery so stale queued work cannot target an obsolete location.
+- Treat source/reason fields as telemetry only; never make correctness depend on `backgroundLocationChange`, `significantChange`, or another client hint.
+- Preserve signed `Int64` H3 identifiers and current H3/UGC behavior.
+- Preserve first-valid, stale-to-usable, new-revision, leave/re-enter, and concurrent-discovery semantics.
+- Keep each slice within the repo review budget and add deterministic focused tests.
+- Update the progress doc after each completed child issue.
+
+---
+
+## Forbidden Scope
+
+- No `project-arcus` files, issues, or client WatchEngine removal.
+- No synchronous APNs delivery from `DeviceController`.
+- No server-side latitude/longitude storage.
+- No second notification history or deduplication table.
+- No new user-visible “entered alert area” reason or copy.
+- No global re-fan-out of every installation for each location upload.
+- No source-string-triggered correctness policy.
+- No APNs retry/reclaim redesign tracked by `#13`.
+- No notification-outbox atomic-claim redesign tracked by `#6`.
+- No broad `NotificationEngine`, ingest, queue, or persistence rewrite.
+
+---
+
+## Current Boundaries To Preserve
+
+| Concern | Current owner |
+|---|---|
+| Location request validation and installation/presence transaction | `Sources/App/Controllers/DeviceController.swift` |
+| Presence and installation state | `Sources/App/Models/Device/DevicePresenceModel.swift`, `DeviceInstallationModel.swift` |
+| Alert revision targeting and mode selection | `Sources/App/Jobs/TargetEventRevisionJob.swift`, `Sources/App/lib/DispatchAgent.swift` |
+| Candidate H3/UGC matching | `Sources/App/Models/Notification/NotificationCandidateStore.swift` |
+| Lifecycle, freshness, claim, composition, APNs, completion | `Sources/App/Jobs/NotificationSendJob.swift` |
+| Atomic delivery identity | `Sources/App/Models/Notification/NotificationDeliveryStore.swift`, `CreateNotificationLedger.swift` |
+| Notification wording | `Sources/App/Infrastructure/Notifications/NotificationEngine.swift` |
+| API/worker queue ownership | `Sources/App/configure.swift`, `Sources/App/Worker/WorkerRuntime.swift` |
+
+---
+
+## Sequential Execution Model
+
+Execute the child issues in the exact order recorded in the progress doc. Do not parallelize implementation issues.
+
+For each issue:
+
+1. Read this runbook, the progress doc, and the issue.
+2. State the smallest review unit and explicit non-goals.
+3. Add or update focused deterministic tests.
+4. Implement only the issue contract.
+5. Run the listed focused verification.
+6. Update the progress ledger with evidence and handoff notes.
+7. Stop.
+
+Intermediate slices may introduce dormant schema or helpers before wiring runtime behavior. They must remain backward-compatible and safe to deploy in sequence.
+
+---
+
+## Verification Defaults
+
+Prefer focused suites during implementation:
+
+```bash
+swift test --filter PresenceReconciliationTriggerTests
+swift test --filter PresenceReconciliationOutboxTests
+swift test --filter DeviceControllerTests
+swift test --filter NotificationActiveAlertQueryTests
+swift test --filter NotificationSendJobCandidateQueryTests
+swift test --filter NotificationSendJobDeliveryBoundaryTests
+swift test --filter InstallationAlertReconciliationJobTests
+```
+
+Before epic completion:
+
+```bash
+swift build
+swift test --filter Notification
+swift test --filter Device
+swift test --filter Reconciliation
+swift test --no-parallel
+```
+
+Use the actual final suite names if implementation chooses clearer names. Do not require live NWS, Redis, or APNs for behavioral tests; use the existing test queue, recording sender, and PostgreSQL integration harness.
+
+---
+
+## Quality Bar For `5.6 luna medium`
+
+- One child issue at a time, normally one behavior and 1-3 production files.
+- Exact required reading and focused validation are in every issue.
+- Tests pin observable behavior rather than implementation trivia.
+- SQL remains installation-scoped and lifecycle-bounded.
+- Duplicate discovery, queue retry, and alert/location races end at one ledger claim.
+- Existing alert-driven tests remain unchanged or are explicitly extended.
+- Any deviation from current H3/UGC, freshness, lifecycle, or copy semantics stops the slice for review.
+
+---
+
+## Rollout Gate
+
+Epic completion means the server capability is implemented and deterministically verified. Deployment must then validate reconciliation intents, match counts, constrained send attempts, and ledger outcomes in Arcus Signal. Only after that server validation may a separate SkyAware campaign remove the WatchEngine alert-notification producer. Client removal is not part of this epic.


### PR DESCRIPTION
# Summary
This branch defines a pure trigger that identifies meaningful presence reconciliation transitions from persisted state. It distinguishes first usable presence, moved-while-usable, and unusable-or-hard-stale-to-usable cases while ignoring heartbeat-only and other non-targeting changes, and it adds matrix coverage plus supporting campaign docs.

# What Changed
- Added a pure `PresenceReconciliationTrigger` decision type over persisted presence state and targeting fingerprint data.
- Defined usability from the persisted fingerprint together with `LocationFreshnessPolicy`, installation authorization, active/subscribed state, and APNs token presence.
- Reused the existing freshness thresholds and signed `Int64` H3 values unchanged.
- Added deterministic matrix tests for first usable presence, moved while usable, stale-to-fresh, unchanged heartbeat, source-only, label-only, and unusable-to-unusable cases.
- Updated the reconciliation runbook, progress ledger, and audit notes to document the trigger contract and campaign status.

# User Impact
No direct user-facing change yet. This is a pure policy slice that sets up the later reconciliation flow without wiring controller, queue, or delivery behavior.

# Testing
- `swift test --filter PresenceReconciliationTriggerTests`

# Notes
- No controller, queue, migration, or delivery behavior is wired in this branch.
- The trigger is intentionally deterministic and `Sendable` so later reconciliation work can build on it safely.