### PR TITLE
Add durable presence reconciliation intents

### DIFF
--- a/Sources/App/Migrations/CreatePresenceReconciliationOutbox.swift
+++ b/Sources/App/Migrations/CreatePresenceReconciliationOutbox.swift
@@ -1,0 +1,56 @@
+import Fluent
+import SQLKit
+
+struct CreatePresenceReconciliationOutbox: AsyncMigration {
+    func prepare(on database: any Database) async throws {
+        try await database.schema(PresenceReconciliationOutboxModel.schema)
+            .id()
+            .field(
+                "installation_id",
+                .uuid,
+                .required,
+                .references(DeviceInstallationModel.schema, "installation_id", onDelete: .cascade)
+            )
+            .field("presence_captured_at", .datetime, .required)
+            .field("trigger_category", .string, .required)
+            .field("targeting_fingerprint", .string, .required)
+            .field("state", .string, .required)
+            .field("attempt_count", .int, .required)
+            .field("last_error", .string)
+            .field("available_at", .datetime, .required)
+            .field("dispatched_at", .datetime)
+            .field("created_at", .datetime, .required)
+            .field("updated_at", .datetime, .required)
+            .unique(on: "installation_id", "presence_captured_at", "trigger_category", "targeting_fingerprint")
+            .create()
+
+        guard let sql = database as? any SQLDatabase else { return }
+
+        try await sql.raw("""
+            ALTER TABLE presence_reconciliation_outbox
+              ALTER COLUMN attempt_count SET DEFAULT 0,
+              ALTER COLUMN available_at SET DEFAULT now(),
+              ALTER COLUMN created_at SET DEFAULT now(),
+              ALTER COLUMN updated_at SET DEFAULT now();
+            """).run()
+
+        try await sql.raw("""
+            ALTER TABLE presence_reconciliation_outbox
+              ADD CONSTRAINT presence_reconciliation_outbox_state_check
+              CHECK (state IN ('ready', 'done', 'dead')),
+              ADD CONSTRAINT presence_reconciliation_outbox_trigger_category_check
+              CHECK (trigger_category IN ('firstUsablePresence', 'movedWhileUsable', 'becameUsable')),
+              ADD CONSTRAINT presence_reconciliation_outbox_attempt_count_check
+              CHECK (attempt_count >= 0);
+            """).run()
+
+        try await sql.raw("""
+            CREATE INDEX idx_presence_reconciliation_outbox_ready
+            ON presence_reconciliation_outbox (state, available_at, created_at, id);
+            """).run()
+    }
+
+    func revert(on database: any Database) async throws {
+        try await database.schema(PresenceReconciliationOutboxModel.schema).delete()
+    }
+}

--- a/Sources/App/Models/Notification/PresenceReconciliationOutboxModel.swift
+++ b/Sources/App/Models/Notification/PresenceReconciliationOutboxModel.swift
@@ -1,0 +1,86 @@
+import Fluent
+import Foundation
+
+enum PresenceReconciliationOutboxState: String, Codable, Sendable {
+    case ready
+    case done
+    case dead
+}
+
+final class PresenceReconciliationOutboxModel: Model, @unchecked Sendable {
+    static let schema = "presence_reconciliation_outbox"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Parent(key: "installation_id")
+    var installation: DeviceInstallationModel
+
+    @Field(key: "presence_captured_at")
+    var presenceCapturedAt: Date
+
+    @Field(key: "trigger_category")
+    var triggerCategoryRaw: String
+
+    @Field(key: "targeting_fingerprint")
+    var targetingFingerprint: String
+
+    @Field(key: "state")
+    var stateRaw: String
+
+    @Field(key: "attempt_count")
+    var attemptCount: Int
+
+    @OptionalField(key: "last_error")
+    var lastError: String?
+
+    @Field(key: "available_at")
+    var availableAt: Date
+
+    @OptionalField(key: "dispatched_at")
+    var dispatchedAt: Date?
+
+    @Timestamp(key: "created_at", on: .create)
+    var createdAt: Date?
+
+    @Timestamp(key: "updated_at", on: .update)
+    var updatedAt: Date?
+
+    init() {}
+
+    init(
+        id: UUID? = nil,
+        installationID: UUID,
+        presenceCapturedAt: Date,
+        triggerCategory: PresenceReconciliationTriggerCategory,
+        targetingFingerprint: String,
+        state: PresenceReconciliationOutboxState = .ready,
+        attemptCount: Int = 0,
+        lastError: String? = nil,
+        availableAt: Date = .now,
+        dispatchedAt: Date? = nil
+    ) {
+        self.id = id
+        self.$installation.id = installationID
+        self.presenceCapturedAt = presenceCapturedAt
+        self.triggerCategoryRaw = triggerCategory.rawValue
+        self.targetingFingerprint = targetingFingerprint
+        self.stateRaw = state.rawValue
+        self.attemptCount = attemptCount
+        self.lastError = lastError
+        self.availableAt = availableAt
+        self.dispatchedAt = dispatchedAt
+    }
+}
+
+extension PresenceReconciliationOutboxModel {
+    var triggerCategory: PresenceReconciliationTriggerCategory {
+        get { PresenceReconciliationTriggerCategory(rawValue: triggerCategoryRaw) ?? .firstUsablePresence }
+        set { triggerCategoryRaw = newValue.rawValue }
+    }
+
+    var state: PresenceReconciliationOutboxState {
+        get { PresenceReconciliationOutboxState(rawValue: stateRaw) ?? .ready }
+        set { stateRaw = newValue.rawValue }
+    }
+}

--- a/Sources/App/Models/Notification/PresenceReconciliationOutboxStore.swift
+++ b/Sources/App/Models/Notification/PresenceReconciliationOutboxStore.swift
@@ -1,0 +1,134 @@
+import Fluent
+import FluentSQL
+import Foundation
+import Vapor
+
+struct PresenceReconciliationOutboxInsertResult: Sendable {
+    let inserted: Bool
+    let id: UUID?
+}
+
+struct PresenceReconciliationOutboxStore: Sendable {
+    func insert(
+        installationID: UUID,
+        presenceCapturedAt: Date,
+        triggerCategory: PresenceReconciliationTriggerCategory,
+        targetingFingerprint: String,
+        availableAt: Date = .now,
+        on database: any Database
+    ) async throws -> PresenceReconciliationOutboxInsertResult {
+        guard let sql = database as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        let row = try await sql.raw("""
+            INSERT INTO presence_reconciliation_outbox
+                (id, installation_id, presence_captured_at, trigger_category,
+                 targeting_fingerprint, state, attempt_count, available_at,
+                 created_at, updated_at)
+            VALUES
+                (gen_random_uuid(), \(bind: installationID), \(bind: presenceCapturedAt),
+                 \(bind: triggerCategory.rawValue), \(bind: targetingFingerprint),
+                 \(bind: PresenceReconciliationOutboxState.ready.rawValue), 0,
+                 \(bind: availableAt), NOW(), NOW())
+            ON CONFLICT (installation_id, presence_captured_at, trigger_category, targeting_fingerprint)
+            DO NOTHING
+            RETURNING id
+            """).first()
+
+        guard let row else {
+            return PresenceReconciliationOutboxInsertResult(inserted: false, id: nil)
+        }
+
+        return PresenceReconciliationOutboxInsertResult(
+            inserted: true,
+            id: try row.decode(column: "id", as: UUID.self)
+        )
+    }
+
+    func readyIntents(
+        availableThrough cutoff: Date,
+        limit: Int,
+        on database: any Database
+    ) async throws -> [PresenceReconciliationOutboxModel] {
+        try await PresenceReconciliationOutboxModel.query(on: database)
+            .filter(\.$stateRaw == PresenceReconciliationOutboxState.ready.rawValue)
+            .filter(\.$availableAt <= cutoff)
+            .sort(\.$availableAt, .ascending)
+            .sort(\.$createdAt, .ascending)
+            .sort(\.$id, .ascending)
+            .limit(limit)
+            .all()
+    }
+
+    func recordQueueHandoffSuccess(
+        intentID: UUID,
+        on database: any Database
+    ) async throws -> Bool {
+        try await updateReadyIntent(
+            id: intentID,
+            set: """
+                state = \(bind: PresenceReconciliationOutboxState.done.rawValue),
+                attempt_count = attempt_count + 1,
+                last_error = NULL,
+                dispatched_at = NOW(),
+                updated_at = NOW()
+                """,
+            on: database
+        )
+    }
+
+    func recordQueueHandoffFailure(
+        intentID: UUID,
+        error: String,
+        nextAvailableAt: Date,
+        on database: any Database
+    ) async throws -> Bool {
+        try await updateReadyIntent(
+            id: intentID,
+            set: """
+                attempt_count = attempt_count + 1,
+                last_error = \(bind: error),
+                available_at = \(bind: nextAvailableAt),
+                updated_at = NOW()
+                """,
+            on: database
+        )
+    }
+
+    func markDead(
+        intentID: UUID,
+        error: String,
+        on database: any Database
+    ) async throws -> Bool {
+        try await updateReadyIntent(
+            id: intentID,
+            set: """
+                state = \(bind: PresenceReconciliationOutboxState.dead.rawValue),
+                last_error = \(bind: error),
+                updated_at = NOW()
+                """,
+            on: database
+        )
+    }
+
+    private func updateReadyIntent(
+        id: UUID,
+        set: SQLQueryString,
+        on database: any Database
+    ) async throws -> Bool {
+        guard let sql = database as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        let row = try await sql.raw("""
+            UPDATE presence_reconciliation_outbox
+            SET \(set)
+            WHERE id = \(bind: id)
+              AND state = \(bind: PresenceReconciliationOutboxState.ready.rawValue)
+            RETURNING id
+            """).first()
+
+        return row != nil
+    }
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -126,6 +126,7 @@ private func configureMigrations(on app: Application) {
     app.migrations.add(CreateOperatorDashboardSnapshots())
     app.migrations.add(CreatePressureArtifactCatalog())
     app.migrations.add(AddClaimFencingToPressureArtifactCatalog())
+    app.migrations.add(CreatePresenceReconciliationOutbox())
 }
 
 private func configureAPNs(on app: Application) async throws {

--- a/Tests/AppTests/PresenceReconciliationOutboxTests.swift
+++ b/Tests/AppTests/PresenceReconciliationOutboxTests.swift
@@ -1,0 +1,252 @@
+@testable import App
+import Fluent
+import FluentSQL
+import Foundation
+import Testing
+import Vapor
+
+@Suite("Presence reconciliation outbox persistence", .serialized)
+struct PresenceReconciliationOutboxTests {
+    private let store = PresenceReconciliationOutboxStore()
+
+    private func withApp(test: (Application) async throws -> Void) async throws {
+        let app = try await Application.make(.testing)
+        do {
+            try await configure(app, mode: .api)
+            try await app.autoMigrate()
+            try await test(app)
+        } catch {
+            try? await app.asyncShutdown()
+            throw error
+        }
+        try await app.asyncShutdown()
+    }
+
+    private func createInstallation(
+        id: UUID,
+        on database: any Database
+    ) async throws {
+        try await DeviceInstallationModel(
+            installationId: id,
+            apnsDeviceToken: "test-apns-token",
+            apnsEnvironment: .sandbox,
+            platform: .iOS,
+            osVersion: "26.0",
+            appVersion: "1.0.0",
+            buildNumber: "100",
+            locationAuth: .always,
+            lastSeenAt: .now,
+            isSubscribed: true
+        ).create(on: database)
+    }
+
+    @Test("migration can revert and prepare the outbox table")
+    func migrationCanRevertAndPrepareTheTable() async throws {
+        try await withApp { app in
+            try await withRollbackTransaction(on: app) { database in
+                guard let sql = database as? any SQLDatabase else {
+                    throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+                }
+                try await sql.raw(
+                    "LOCK TABLE presence_reconciliation_outbox IN ACCESS EXCLUSIVE MODE"
+                ).run()
+
+                let migration = CreatePresenceReconciliationOutbox()
+                try await migration.revert(on: database)
+                try await migration.prepare(on: database)
+
+                let installationID = UUID()
+                try await createInstallation(id: installationID, on: database)
+                try await PresenceReconciliationOutboxModel(
+                    installationID: installationID,
+                    presenceCapturedAt: .now,
+                    triggerCategory: .firstUsablePresence,
+                    targetingFingerprint: "opaque-fingerprint"
+                ).create(on: database)
+
+                let rows = try await PresenceReconciliationOutboxModel.query(on: database).all()
+                #expect(rows.count == 1)
+            }
+        }
+    }
+
+    @Test("insert participates in the caller-owned transaction")
+    func insertParticipatesInCallerOwnedTransaction() async throws {
+        try await withApp { app in
+            let installationID = UUID()
+
+            try await withRollbackTransaction(on: app) { database in
+                try await createInstallation(id: installationID, on: database)
+                let result = try await store.insert(
+                    installationID: installationID,
+                    presenceCapturedAt: Date(timeIntervalSince1970: 1_717_513_600),
+                    triggerCategory: .firstUsablePresence,
+                    targetingFingerprint: "opaque-fingerprint",
+                    on: database
+                )
+
+                #expect(result.inserted)
+                #expect(result.id != nil)
+                #expect(try await PresenceReconciliationOutboxModel.query(on: database).count() == 1)
+            }
+
+            #expect(try await PresenceReconciliationOutboxModel.query(on: app.db).count() == 0)
+        }
+    }
+
+    @Test("duplicate immutable intents are absorbed by the database identity")
+    func duplicateIntentsAreAbsorbedByTheDatabaseIdentity() async throws {
+        try await withApp { app in
+            try await withRollbackTransaction(on: app) { database in
+                let installationID = UUID()
+                try await createInstallation(id: installationID, on: database)
+                let capturedAt = Date(timeIntervalSince1970: 1_717_513_600)
+
+                let first = try await store.insert(
+                    installationID: installationID,
+                    presenceCapturedAt: capturedAt,
+                    triggerCategory: .movedWhileUsable,
+                    targetingFingerprint: "opaque-fingerprint",
+                    on: database
+                )
+                let duplicate = try await store.insert(
+                    installationID: installationID,
+                    presenceCapturedAt: capturedAt,
+                    triggerCategory: .movedWhileUsable,
+                    targetingFingerprint: "opaque-fingerprint",
+                    on: database
+                )
+
+                #expect(first.inserted)
+                #expect(!duplicate.inserted)
+                #expect(try await PresenceReconciliationOutboxModel.query(on: database).count() == 1)
+            }
+        }
+    }
+
+    @Test("ready intents are selected by deterministic availability order")
+    func readyIntentsAreSelectedByAvailabilityOrder() async throws {
+        try await withApp { app in
+            try await withRollbackTransaction(on: app) { database in
+                let installationID = UUID()
+                try await createInstallation(id: installationID, on: database)
+                let base = Date(timeIntervalSince1970: 1_717_513_600)
+
+                let later = try await store.insert(
+                    installationID: installationID,
+                    presenceCapturedAt: base.addingTimeInterval(1),
+                    triggerCategory: .firstUsablePresence,
+                    targetingFingerprint: "later",
+                    availableAt: base.addingTimeInterval(20),
+                    on: database
+                )
+                let earlier = try await store.insert(
+                    installationID: installationID,
+                    presenceCapturedAt: base.addingTimeInterval(2),
+                    triggerCategory: .movedWhileUsable,
+                    targetingFingerprint: "earlier",
+                    availableAt: base.addingTimeInterval(10),
+                    on: database
+                )
+                let future = try await store.insert(
+                    installationID: installationID,
+                    presenceCapturedAt: base.addingTimeInterval(3),
+                    triggerCategory: .becameUsable,
+                    targetingFingerprint: "future",
+                    availableAt: base.addingTimeInterval(40),
+                    on: database
+                )
+
+                let ready = try await store.readyIntents(
+                    availableThrough: base.addingTimeInterval(20),
+                    limit: 10,
+                    on: database
+                )
+
+                #expect(ready.map(\.id) == [earlier.id, later.id])
+                #expect(!ready.contains { $0.id == future.id })
+            }
+        }
+    }
+
+    @Test("queue-handoff outcomes retain retry metadata and cannot overwrite completion")
+    func queueHandoffOutcomesRetainRetryMetadataAndCannotOverwriteCompletion() async throws {
+        try await withApp { app in
+            try await withRollbackTransaction(on: app) { database in
+                let installationID = UUID()
+                try await createInstallation(id: installationID, on: database)
+                let inserted = try await store.insert(
+                    installationID: installationID,
+                    presenceCapturedAt: Date(timeIntervalSince1970: 1_717_513_600),
+                    triggerCategory: .firstUsablePresence,
+                    targetingFingerprint: "opaque-fingerprint",
+                    on: database
+                )
+                let intentID = try #require(inserted.id)
+                let retryAt = Date(timeIntervalSince1970: 1_717_513_660)
+
+                #expect(try await store.recordQueueHandoffFailure(
+                    intentID: intentID,
+                    error: "redis unavailable",
+                    nextAvailableAt: retryAt,
+                    on: database
+                ))
+
+                let failed = try #require(try await PresenceReconciliationOutboxModel.find(intentID, on: database))
+                #expect(failed.state == .ready)
+                #expect(failed.attemptCount == 1)
+                #expect(failed.lastError == "redis unavailable")
+                #expect(failed.availableAt == retryAt)
+
+                #expect(try await store.recordQueueHandoffSuccess(intentID: intentID, on: database))
+
+                let completed = try #require(try await PresenceReconciliationOutboxModel.find(intentID, on: database))
+                #expect(completed.state == .done)
+                #expect(completed.attemptCount == 2)
+                #expect(completed.lastError == nil)
+                #expect(completed.dispatchedAt != nil)
+                #expect(!(try await store.recordQueueHandoffFailure(
+                    intentID: intentID,
+                    error: "late error",
+                    nextAvailableAt: retryAt,
+                    on: database
+                )))
+            }
+        }
+    }
+
+    @Test("terminal handoff failure cannot be retried or completed")
+    func terminalHandoffFailureCannotBeRetriedOrCompleted() async throws {
+        try await withApp { app in
+            try await withRollbackTransaction(on: app) { database in
+                let installationID = UUID()
+                try await createInstallation(id: installationID, on: database)
+                let inserted = try await store.insert(
+                    installationID: installationID,
+                    presenceCapturedAt: Date(timeIntervalSince1970: 1_717_513_600),
+                    triggerCategory: .firstUsablePresence,
+                    targetingFingerprint: "opaque-fingerprint",
+                    on: database
+                )
+                let intentID = try #require(inserted.id)
+
+                #expect(try await store.markDead(
+                    intentID: intentID,
+                    error: "retry budget exhausted",
+                    on: database
+                ))
+
+                let dead = try #require(try await PresenceReconciliationOutboxModel.find(intentID, on: database))
+                #expect(dead.state == .dead)
+                #expect(dead.lastError == "retry budget exhausted")
+                #expect(!(try await store.recordQueueHandoffSuccess(intentID: intentID, on: database)))
+                #expect(!(try await store.recordQueueHandoffFailure(
+                    intentID: intentID,
+                    error: "late error",
+                    nextAvailableAt: .now,
+                    on: database
+                )))
+            }
+        }
+    }
+}

--- a/docs/plans/location-driven-alert-reconciliation-progress.md
+++ b/docs/plans/location-driven-alert-reconciliation-progress.md
@@ -199,7 +199,7 @@ Handoff:
 GitHub:
 - https://github.com/justinrooks/arcus-signal/issues/209
 
-Status: Pending
+Status: Complete
 
 Goal:
 - Add the minimal PostgreSQL model, migration, and store for immutable ready/done/dead reconciliation queue-handoff intents.
@@ -217,6 +217,14 @@ Verification:
 
 Stop condition:
 - Schema and persistence semantics are tested and registered; no route or worker behavior consumes them.
+
+Evidence:
+- Added `presence_reconciliation_outbox` with immutable installation/presence/trigger/fingerprint identity, ready/done/dead handoff state, retry metadata, and deterministic ready-drain index.
+- Added a transaction-owned store for idempotent intent insertion and guarded queue-handoff outcome updates.
+- `swift test --filter PresenceReconciliationOutboxTests` and `swift test --filter DevicePresenceMigrationTests` passed on 2026-08-13.
+
+Handoff:
+- Issue #210 should create intents only inside the accepted `DeviceController` transaction; it must not dispatch or consume them.
 
 ### Issue #210 - 03: Record intents for authoritative presence transitions
 


### PR DESCRIPTION
# Summary
This branch adds a durable PostgreSQL-backed outbox for meaningful presence reconciliation requests. It stores immutable intent metadata, provides deterministic ready-drain ordering and guarded handoff updates, registers the migration, and adds focused PostgreSQL coverage for the new persistence contract.

# What Changed
- Added `PresenceReconciliationOutboxModel` to persist installation identity, presence capture time, trigger category, targeting fingerprint, queue-handoff state, retry metadata, and timestamps.
- Added `PresenceReconciliationOutboxStore` to insert intents inside a caller-owned transaction, read ready work in deterministic order, and record queue-handoff success, failure, or terminal state.
- Added `CreatePresenceReconciliationOutbox` to create the table, constraints, uniqueness rule, and ready-drain index, and registered the migration in app configuration.
- Added focused PostgreSQL tests for migration prepare/revert, transactional insert behavior, duplicate-intent absorption, ready ordering, and handoff state transitions.
- Updated the reconciliation progress ledger with the issue status and implementation evidence.

# User Impact
No direct user-facing change yet. This branch only persists and characterizes reconciliation intents so later issues can consume them safely.

# Testing
- `swift test --filter PresenceReconciliationOutboxTests`
- `swift test --filter DevicePresenceMigrationTests`
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency`

# Notes
- Duplicate intents are intentionally absorbed by the database identity instead of being treated as delivery history.
- The branch does not wire any route, queue consumer, active-alert lookup, or APNs behavior into the outbox yet.