### PR TITLE
Record intents for authoritative presence transitions

### DIFF
--- a/Sources/App/Controllers/DeviceController.swift
+++ b/Sources/App/Controllers/DeviceController.swift
@@ -101,7 +101,14 @@ struct DeviceController: RouteCollection {
         }
         
         let presenceOutcome = try await req.db.transaction { database in
-            _ = try await upsertDeviceInstallation(
+            let previousInstallation = try await DeviceInstallationModel.find(installationUUID, on: database)
+            let previousPresence = try await DevicePresenceModel.find(installationUUID, on: database)
+            let previousState = reconciliationState(
+                installation: previousInstallation,
+                presence: previousPresence
+            )
+
+            let installation = try await upsertDeviceInstallation(
                 installationId: installationUUID,
                 apnsDeviceToken: apnsDeviceToken,
                 apnsEnvironment: apnsEnvironment,
@@ -115,7 +122,7 @@ struct DeviceController: RouteCollection {
                 on: database
             )
             
-            return try await upsertDevicePresence(
+            let presenceOutcome = try await upsertDevicePresence(
                 installationId: installationUUID,
                 payload: payload,
                 cellScheme: cellScheme,
@@ -123,6 +130,30 @@ struct DeviceController: RouteCollection {
                 receivedAt: receivedAt,
                 on: database
             )
+
+            guard presenceOutcome != .staleIgnored,
+                  let presence = try await DevicePresenceModel.find(installationUUID, on: database) else {
+                return presenceOutcome
+            }
+
+            guard let currentState = reconciliationState(installation: installation, presence: presence) else {
+                return presenceOutcome
+            }
+            if let trigger = PresenceReconciliationTrigger.decide(
+                previous: previousState,
+                current: currentState,
+                now: receivedAt
+            ) {
+                _ = try await PresenceReconciliationOutboxStore().insert(
+                    installationID: installationUUID,
+                    presenceCapturedAt: presence.capturedAt,
+                    triggerCategory: trigger.category,
+                    targetingFingerprint: try StableContentHasher.sha256Hex(of: currentState.fingerprint),
+                    on: database
+                )
+            }
+
+            return presenceOutcome
         }
         
         // Avoid logging full APNS token in production logs.
@@ -412,4 +443,27 @@ private func upsertDevicePresence(
         try await existing.update(on: database)
         return .updated
     }
+}
+
+private func reconciliationState(
+    installation: DeviceInstallationModel?,
+    presence: DevicePresenceModel?
+) -> PresenceReconciliationState? {
+    guard let installation, let presence else {
+        return nil
+    }
+
+    return PresenceReconciliationState(
+        fingerprint: .init(
+            h3Cell: presence.h3Cell,
+            county: presence.county,
+            forecastZone: presence.zone,
+            fireZone: presence.fireZone
+        ),
+        capturedAt: presence.capturedAt,
+        locationAuth: installation.locationAuth,
+        isActive: installation.isActive,
+        isSubscribed: installation.isSubscribed,
+        hasAPNsToken: !installation.apnsDeviceToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    )
 }

--- a/Sources/App/Infrastructure/Notifications/PresenceReconciliationTrigger.swift
+++ b/Sources/App/Infrastructure/Notifications/PresenceReconciliationTrigger.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct PresenceTargetingFingerprint: Equatable, Sendable {
+public struct PresenceTargetingFingerprint: Encodable, Equatable, Sendable {
     public let h3Cell: Int64?
     public let county: String?
     public let forecastZone: String?
@@ -96,6 +96,13 @@ public struct PresenceReconciliationTrigger: Sendable, Equatable {
         freshnessPolicy: LocationFreshnessPolicy
     ) -> Bool {
         guard state.isActive, state.isSubscribed, state.hasAPNsToken else {
+            return false
+        }
+
+        guard state.fingerprint.h3Cell != nil
+                || state.fingerprint.county != nil
+                || state.fingerprint.forecastZone != nil
+                || state.fingerprint.fireZone != nil else {
             return false
         }
 

--- a/Tests/AppTests/DeviceControllerTests.swift
+++ b/Tests/AppTests/DeviceControllerTests.swift
@@ -1,5 +1,7 @@
 @testable import App
 import ArcusCore
+import Fluent
+import FluentSQL
 import Foundation
 import Testing
 import Vapor
@@ -22,31 +24,70 @@ struct DeviceControllerTests {
 
     private func makePayload(
         installationId: String,
-        source: LocationUploadSource
+        source: LocationUploadSource = .foregroundPrime,
+        capturedAt: Date = .now,
+        county: String? = "COC031",
+        zone: String? = "COZ041",
+        fireZone: String? = "COF241",
+        isSubscribed: Bool? = true,
+        auth: LocationAuth = .always,
+        cellScheme: CellScheme = .ugcOnly,
+        h3Cell: Int64? = nil,
+        h3Resolution: Int? = nil,
+        appVersion: String = "1.0.0"
     ) -> LocationSnapshotPushPayload {
         LocationSnapshotPushPayload(
-            capturedAt: Date(timeIntervalSince1970: 1_717_513_600),
+            capturedAt: capturedAt,
             locationAgeSeconds: 12,
             horizontalAccuracyMeters: 25,
-            cellScheme: CellScheme.ugcOnly.rawValue,
-            h3Cell: nil,
-            h3Resolution: nil,
-            county: "COC031",
-            zone: "COZ041",
-            fireZone: "COF241",
+            cellScheme: cellScheme.rawValue,
+            h3Cell: h3Cell,
+            h3Resolution: h3Resolution,
+            county: county,
+            zone: zone,
+            fireZone: fireZone,
             apnsDeviceToken: "abcd1234efgh5678ijkl9012mnop3456",
             installationId: installationId,
             source: source.rawValue,
-            auth: LocationAuth.always.rawValue,
-            appVersion: "1.0.0",
+            auth: auth.rawValue,
+            appVersion: appVersion,
             buildNumber: "100",
             platform: Platform.iOS.rawValue,
             osVersion: "26.0",
             apnsEnvironment: APNsEnvironment.sandbox.rawValue,
             countyLabel: "Boulder County",
             fireZoneLabel: "Front Range",
-            isSubscribed: true
+            isSubscribed: isSubscribed
         )
+    }
+
+    private func submit(
+        _ payload: LocationSnapshotPushPayload,
+        to app: Application,
+        expecting status: HTTPResponseStatus = .ok
+    ) async throws {
+        try await app.testing().test(
+            .POST,
+            "api/v1/devices/location-snapshots",
+            beforeRequest: { req in
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .iso8601
+                req.headers.contentType = .json
+                req.body = .init(data: try encoder.encode(payload))
+            },
+            afterResponse: { res async in
+                #expect(res.status == status)
+            }
+        )
+    }
+
+    private func intents(
+        for installationID: UUID,
+        in app: Application
+    ) async throws -> [PresenceReconciliationOutboxModel] {
+        try await PresenceReconciliationOutboxModel.query(on: app.db)
+            .filter(\.$installation.$id == installationID)
+            .all()
     }
 
     @Test("POST /api/v1/devices/location-snapshots persists expanded source values")
@@ -61,24 +102,245 @@ struct DeviceControllerTests {
                     source: source
                 )
 
-                try await app.testing().test(
-                    .POST,
-                    "api/v1/devices/location-snapshots",
-                    beforeRequest: { req in
-                        let encoder = JSONEncoder()
-                        encoder.dateEncodingStrategy = .iso8601
-                        req.headers.contentType = .json
-                        req.body = .init(data: try encoder.encode(payload))
-                    },
-                    afterResponse: { res async in
-                        #expect(res.status == .ok)
-                    }
-                )
+                try await submit(payload, to: app)
 
                 let storedPresence = try await DevicePresenceModel.find(installationID, on: app.db)
                 #expect(storedPresence != nil)
                 #expect(storedPresence?.source == source)
             }
+        }
+    }
+
+    @Test("first usable presence records a reconciliation intent")
+    func firstUsablePresenceRecordsIntent() async throws {
+        try await withApp { app in
+            let installationID = UUID()
+            let capturedAt = Date()
+
+            try await submit(makePayload(installationId: installationID.uuidString, capturedAt: capturedAt), to: app)
+
+            let intent = try #require(try await intents(for: installationID, in: app).first)
+            #expect(abs(intent.presenceCapturedAt.timeIntervalSince(capturedAt)) < 1)
+            #expect(intent.triggerCategory == .firstUsablePresence)
+        }
+    }
+
+    @Test("changed persisted targeting fields record a movement intent")
+    func targetingFingerprintChangeRecordsIntent() async throws {
+        try await withApp { app in
+            let installationID = UUID()
+            let capturedAt = Date().addingTimeInterval(-30)
+            try await submit(makePayload(installationId: installationID.uuidString, capturedAt: capturedAt), to: app)
+            try await submit(makePayload(
+                installationId: installationID.uuidString,
+                capturedAt: capturedAt.addingTimeInterval(1),
+                county: "COC013"
+            ), to: app)
+
+            let intents = try await intents(for: installationID, in: app)
+            #expect(intents.map(\.triggerCategory).contains(.firstUsablePresence))
+            #expect(intents.map(\.triggerCategory).contains(.movedWhileUsable))
+        }
+    }
+
+    @Test("equal captured timestamps are accepted and record movement")
+    func equalTimestampChangeRecordsMovementIntent() async throws {
+        try await withApp { app in
+            let installationID = UUID()
+            let capturedAt = Date().addingTimeInterval(-30)
+            try await submit(makePayload(installationId: installationID.uuidString, capturedAt: capturedAt), to: app)
+            try await submit(makePayload(
+                installationId: installationID.uuidString,
+                capturedAt: capturedAt,
+                county: "COC013"
+            ), to: app)
+
+            let intents = try await intents(for: installationID, in: app)
+            let presence = try #require(try await DevicePresenceModel.find(installationID, on: app.db))
+            #expect(intents.map(\.triggerCategory).contains(.movedWhileUsable))
+            #expect(presence.county == "COC013")
+        }
+    }
+
+    @Test("installation usability changes are evaluated after persistence")
+    func installationUsabilityChangeRecordsIntent() async throws {
+        try await withApp { app in
+            let installationID = UUID()
+            let capturedAt = Date().addingTimeInterval(-30)
+            try await submit(makePayload(
+                installationId: installationID.uuidString,
+                capturedAt: capturedAt,
+                isSubscribed: false
+            ), to: app)
+            try await submit(makePayload(
+                installationId: installationID.uuidString,
+                capturedAt: capturedAt.addingTimeInterval(1),
+                isSubscribed: true
+            ), to: app)
+
+            let intents = try await intents(for: installationID, in: app)
+            #expect(intents.count == 1)
+            #expect(intents.first?.triggerCategory == .becameUsable)
+        }
+    }
+
+    @Test("intent insertion failure rolls back the location transaction")
+    func intentInsertionFailureRollsBackLocationTransaction() async throws {
+        try await withApp { app in
+            guard let sql = app.db as? any SQLDatabase else {
+                throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+            }
+
+            let installationID = UUID()
+            let fingerprint = try StableContentHasher.sha256Hex(of: PresenceTargetingFingerprint(
+                h3Cell: nil,
+                county: "COC031",
+                forecastZone: "COZ041",
+                fireZone: "COF241"
+            ))
+            try await sql.raw("""
+                ALTER TABLE presence_reconciliation_outbox
+                ADD CONSTRAINT device_controller_test_reject_intent_check
+                CHECK (targeting_fingerprint <> '\(unsafeRaw: fingerprint)') NOT VALID
+                """).run()
+            do {
+                try await submit(
+                    makePayload(installationId: installationID.uuidString),
+                    to: app,
+                    expecting: .internalServerError
+                )
+            } catch {
+                try? await sql.raw("""
+                    ALTER TABLE presence_reconciliation_outbox
+                    DROP CONSTRAINT device_controller_test_reject_intent_check
+                    """).run()
+                throw error
+            }
+            try await sql.raw("""
+                ALTER TABLE presence_reconciliation_outbox
+                DROP CONSTRAINT device_controller_test_reject_intent_check
+                """).run()
+
+            #expect(try await DeviceInstallationModel.find(installationID, on: app.db) == nil)
+            #expect(try await DevicePresenceModel.find(installationID, on: app.db) == nil)
+            #expect(try await intents(for: installationID, in: app).isEmpty)
+        }
+    }
+
+    @Test("hard-stale presence becoming usable records an intent")
+    func stalePresenceBecomingUsableRecordsIntent() async throws {
+        try await withApp { app in
+            let installationID = UUID()
+            let staleCapturedAt = Date().addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold - 1)
+            try await submit(makePayload(installationId: installationID.uuidString, capturedAt: staleCapturedAt), to: app)
+            try await submit(makePayload(
+                installationId: installationID.uuidString,
+                capturedAt: Date()
+            ), to: app)
+
+            let intents = try await intents(for: installationID, in: app)
+            #expect(intents.count == 1)
+            #expect(intents.first?.triggerCategory == .becameUsable)
+        }
+    }
+
+    @Test("heartbeats and source changes do not record extra intents")
+    func heartbeatAndSourceChangesDoNotRecordExtraIntents() async throws {
+        try await withApp { app in
+            let installationID = UUID()
+            let capturedAt = Date().addingTimeInterval(-30)
+            try await submit(makePayload(installationId: installationID.uuidString, capturedAt: capturedAt), to: app)
+            try await submit(makePayload(
+                installationId: installationID.uuidString,
+                source: .backgroundLocationChange,
+                capturedAt: capturedAt.addingTimeInterval(1),
+                appVersion: "1.0.1"
+            ), to: app)
+
+            let intents = try await intents(for: installationID, in: app)
+            #expect(intents.count == 1)
+        }
+    }
+
+    @Test("targetless presence does not record an intent until targeting becomes usable")
+    func targetlessPresenceDoesNotRecordIntent() async throws {
+        try await withApp { app in
+            let installationID = UUID()
+            let capturedAt = Date().addingTimeInterval(-30)
+            try await submit(makePayload(
+                installationId: installationID.uuidString,
+                capturedAt: capturedAt,
+                county: nil,
+                zone: nil,
+                fireZone: nil
+            ), to: app)
+
+            #expect(try await intents(for: installationID, in: app).isEmpty)
+
+            try await submit(makePayload(
+                installationId: installationID.uuidString,
+                capturedAt: capturedAt.addingTimeInterval(1),
+                county: "COC013",
+                zone: nil,
+                fireZone: nil
+            ), to: app)
+
+            let intents = try await intents(for: installationID, in: app)
+            #expect(intents.count == 1)
+            #expect(intents.first?.triggerCategory == .becameUsable)
+        }
+    }
+
+    @Test("partial presence updates evaluate the persisted targeting fingerprint")
+    func partialPresenceUpdateUsesPersistedTargetingFields() async throws {
+        try await withApp { app in
+            let installationID = UUID()
+            let capturedAt = Date().addingTimeInterval(-30)
+            let h3Cell: Int64 = 617_700_169_958_293_503
+            try await submit(makePayload(
+                installationId: installationID.uuidString,
+                capturedAt: capturedAt,
+                cellScheme: .h3,
+                h3Cell: h3Cell,
+                h3Resolution: 8
+            ), to: app)
+            try await submit(makePayload(
+                installationId: installationID.uuidString,
+                capturedAt: capturedAt.addingTimeInterval(1),
+                county: "COC013",
+                zone: nil,
+                fireZone: nil
+            ), to: app)
+
+            let intent = try #require(try await intents(for: installationID, in: app)
+                .first { $0.triggerCategory == .movedWhileUsable })
+            let expectedFingerprint = try StableContentHasher.sha256Hex(of: PresenceTargetingFingerprint(
+                h3Cell: h3Cell,
+                county: "COC013",
+                forecastZone: "COZ041",
+                fireZone: "COF241"
+            ))
+            #expect(intent.targetingFingerprint == expectedFingerprint)
+        }
+    }
+
+    @Test("older presence is ignored without recording an intent")
+    func olderPresenceDoesNotRecordIntent() async throws {
+        try await withApp { app in
+            let installationID = UUID()
+            let capturedAt = Date().addingTimeInterval(-30)
+            try await submit(makePayload(installationId: installationID.uuidString, capturedAt: capturedAt), to: app)
+            try await submit(makePayload(
+                installationId: installationID.uuidString,
+                capturedAt: capturedAt.addingTimeInterval(-1),
+                county: "COC013"
+            ), to: app)
+
+            let intents = try await intents(for: installationID, in: app)
+            let presence = try #require(try await DevicePresenceModel.find(installationID, on: app.db))
+            #expect(intents.count == 1)
+            #expect(abs(presence.capturedAt.timeIntervalSince(capturedAt)) < 1)
+            #expect(presence.county == "COC031")
         }
     }
 }

--- a/Tests/AppTests/PresenceReconciliationTriggerTests.swift
+++ b/Tests/AppTests/PresenceReconciliationTriggerTests.swift
@@ -159,4 +159,22 @@ struct PresenceReconciliationTriggerTests {
             #expect(trigger == nil)
         }
     }
+
+    @Test("a presence without targeting fields is not usable")
+    func targetlessPresenceDoesNotTrigger() {
+        let targetless = PresenceTargetingFingerprint(
+            h3Cell: nil,
+            county: nil,
+            forecastZone: nil,
+            fireZone: nil
+        )
+
+        let trigger = PresenceReconciliationTrigger.decide(
+            previous: nil,
+            current: state(fingerprint: targetless),
+            now: now
+        )
+
+        #expect(trigger == nil)
+    }
 }

--- a/docs/plans/location-driven-alert-reconciliation-progress.md
+++ b/docs/plans/location-driven-alert-reconciliation-progress.md
@@ -231,7 +231,7 @@ Handoff:
 GitHub:
 - https://github.com/justinrooks/arcus-signal/issues/210
 
-Status: Pending
+Status: Complete
 
 Goal:
 - Evaluate persisted before/after installation and presence state inside the existing route transaction and insert an intent only for meaningful usable transitions.
@@ -248,6 +248,14 @@ Verification:
 
 Stop condition:
 - The route transaction durably records correct intents; it does not dispatch reconciliation or APNs work.
+
+Evidence:
+- The location-snapshot transaction captures authoritative before/after installation and presence state, evaluates the established trigger after persistence, and inserts the immutable reconciliation intent only for accepted meaningful usable transitions.
+- Older `captured_at` uploads remain ignored without an intent; partial updates hash the persisted targeting fingerprint, preserving omitted H3/UGC fields.
+- `swift test --filter DeviceControllerTests` and `swift test --filter PresenceReconciliationTriggerTests` passed on 2026-08-13.
+
+Handoff:
+- Issue #211 may add the installation-scoped active-current-revision query. This route still does not dispatch, query alerts, or send APNs.
 
 ### Issue #211 - 04: Query matching active alerts for one installation
 


### PR DESCRIPTION
# Summary
Closes #210. Record a durable reconciliation intent inside the existing location-snapshot transaction when an accepted installation/presence update creates a meaningful usable transition.

# What Changed
- Capture authoritative pre-update installation/presence state and evaluate the established trigger against the persisted post-update state.
- Insert an immutable reconciliation outbox intent only when the trigger fires, hashing the persisted targeting fingerprint.
- Preserve stale-upload ignore behavior, equal-timestamp acceptance, partial-field preservation, and no-op heartbeat/source-only behavior.
- Add controller and trigger coverage for usable transitions and targetless presence.

# User Impact
No direct user-facing change yet; this records durable reconciliation work for downstream processing while the route still performs no alert scan or APNs delivery.

# Testing
- `swift test --filter DeviceControllerTests` (recorded as passing in the committed progress evidence on 2026-08-13)
- `swift test --filter PresenceReconciliationTriggerTests` (recorded as passing in the committed progress evidence on 2026-08-13)

# Notes
- Queue dispatch, active-alert queries, APNs delivery, preferences changes, and client work remain out of scope.