### PR TITLE
Query matching active alerts for one installation

### DIFF
--- a/Sources/App/Models/Notification/NotificationCandidateStore.swift
+++ b/Sources/App/Models/Notification/NotificationCandidateStore.swift
@@ -19,7 +19,70 @@ struct NotificationCandidate: Decodable {
     }
 }
 
+struct NotificationActiveAlertMatch: Decodable, Sendable {
+    let seriesId: UUID
+    let revisionUrn: String
+    let mode: NotificationTargetMode
+    let reason: NotificationReason
+}
+
 struct NotificationCandidateStore {
+    func loadMatchingActiveAlerts(
+        for installationId: UUID,
+        evaluatedAt: Date,
+        on db: any Database
+    ) async throws -> [NotificationActiveAlertMatch] {
+        guard let sql = db as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        return try await sql.raw("""
+            SELECT
+                s.id AS "seriesId",
+                r.revision_urn AS "revisionUrn",
+                o.mode AS "mode",
+                o.reason AS "reason"
+            FROM device_presence p
+            CROSS JOIN arcus_series s
+            JOIN alert_revisions r
+              ON r.series_id = s.id
+             AND r.revision_urn = s.current_revision_urn
+            JOIN notification_outbox o
+              ON o.series_id = s.id
+             AND o.revision_urn = r.revision_urn
+            LEFT JOIN arcus_geolocation g
+              ON g.series_id = s.id
+            WHERE p.installation_id = \(bind: installationId)
+              AND s.state = \(bind: EventState.active.rawValue)
+              AND (s.expires IS NULL OR s.expires > \(bind: evaluatedAt))
+              AND (s.ends IS NULL OR s.ends > \(bind: evaluatedAt))
+              AND o.mode IN (
+                  \(bind: NotificationTargetMode.h3.rawValue),
+                  \(bind: NotificationTargetMode.ugc.rawValue)
+              )
+              AND o.reason IN (
+                  \(bind: NotificationReason.new.rawValue),
+                  \(bind: NotificationReason.update.rawValue)
+              )
+              AND (
+                    (
+                        o.mode = \(bind: NotificationTargetMode.h3.rawValue)
+                    AND p.h3_cell IS NOT NULL
+                    AND p.h3_cell = ANY(g.h3_cells)
+                    )
+                 OR (
+                        o.mode = \(bind: NotificationTargetMode.ugc.rawValue)
+                    AND (
+                           p.county = ANY(s.ugc_codes)
+                        OR p.zone = ANY(s.ugc_codes)
+                        OR p.fire_zone = ANY(s.ugc_codes)
+                    )
+                 )
+              )
+            """)
+            .all(decoding: NotificationActiveAlertMatch.self)
+    }
+
     func loadUGCCandidates(
         ugcCodes: [String],
         capturedAtOrAfter cutoff: Date,

--- a/Tests/AppTests/NotificationActiveAlertQueryTests.swift
+++ b/Tests/AppTests/NotificationActiveAlertQueryTests.swift
@@ -1,0 +1,241 @@
+@testable import App
+import Fluent
+import Foundation
+import Testing
+
+@Suite("Notification active alert query", .serialized)
+struct NotificationActiveAlertQueryTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func seedInstallation(
+        id: UUID,
+        h3Cell: Int64,
+        county: String,
+        zone: String,
+        fireZone: String,
+        on database: any Database
+    ) async throws {
+        try await DeviceInstallationModel(
+            installationId: id,
+            apnsDeviceToken: "token",
+            apnsEnvironment: .sandbox,
+            platform: .iOS,
+            osVersion: "26.0",
+            appVersion: "1.0.0",
+            buildNumber: "100",
+            locationAuth: .always,
+            lastSeenAt: now
+        ).create(on: database)
+
+        try await DevicePresenceModel(
+            installationId: id,
+            capturedAt: now,
+            receivedAt: now,
+            locationAgeSeconds: 0,
+            horizontalAccuracyMeters: 10,
+            cellScheme: .h3,
+            h3Cell: h3Cell,
+            h3Resolution: 8,
+            county: county,
+            zone: zone,
+            fireZone: fireZone,
+            source: .foregroundPrime,
+            countyLabel: "Test County",
+            fireZoneLabel: "Test Fire Zone"
+        ).create(on: database)
+    }
+
+    private func seedAlert(
+        mode: NotificationTargetMode,
+        reason: NotificationReason = .new,
+        state: EventState = .active,
+        expires: Date? = nil,
+        ends: Date? = nil,
+        ugcCodes: [String] = [],
+        h3Cells: [Int64]? = nil,
+        outboxUsesCurrentRevision: Bool = true,
+        on database: any Database
+    ) async throws -> (id: UUID, revisionUrn: String) {
+        let id = UUID()
+        let currentRevisionUrn = "urn:oid:\(UUID().uuidString.lowercased())"
+        let series = ArcusSeriesModel(
+            id: id,
+            source: "nws",
+            event: "Tornado Warning",
+            sourceURL: "https://api.weather.gov/alerts/\(id.uuidString.lowercased())",
+            currentRevisionUrn: currentRevisionUrn,
+            currentRevisionSent: now,
+            messageType: "alert",
+            contentFingerprint: String(repeating: "a", count: 64),
+            state: state.rawValue,
+            expires: expires,
+            ends: ends,
+            lastSeenActive: now,
+            severity: "severe",
+            urgency: "immediate",
+            certainty: "observed",
+            ugcCodes: ugcCodes
+        )
+        try await series.create(on: database)
+
+        try await ArcusEventRevisionModel(
+            seriesId: id,
+            revisionUrn: currentRevisionUrn,
+            messageType: "alert",
+            sent: now,
+            received: now,
+            referencedUrns: []
+        ).create(on: database)
+
+        let outboxRevisionUrn: String
+        if outboxUsesCurrentRevision {
+            outboxRevisionUrn = currentRevisionUrn
+        } else {
+            outboxRevisionUrn = "urn:oid:\(UUID().uuidString.lowercased())"
+            try await ArcusEventRevisionModel(
+                seriesId: id,
+                revisionUrn: outboxRevisionUrn,
+                messageType: "update",
+                sent: now.addingTimeInterval(-60),
+                received: now,
+                referencedUrns: []
+            ).create(on: database)
+        }
+
+        try await ArcusNotificationOutboxModel(
+            series: id,
+            revisionUrn: outboxRevisionUrn,
+            mode: mode.rawValue,
+            reason: reason.rawValue,
+            state: "done",
+            attempts: 1,
+            availableAt: now
+        ).create(on: database)
+
+        if let h3Cells {
+            try await ArcusGeolocationModel(
+                series: id,
+                geometry: .point(lon: -104.99, lat: 39.74),
+                geometryHash: "geometry-\(id)",
+                h3Cells: h3Cells,
+                h3Resolution: 8,
+                h3Hash: "h3-\(id)"
+            ).create(on: database)
+        }
+
+        return (id, currentRevisionUrn)
+    }
+
+    @Test("H3 and every UGC field match exactly for one installation")
+    func targetingSemanticsAndInstallationScope() async throws {
+        try await withIntegrationTestApplication(
+            setup: .configured(mode: .api, migrate: true)
+        ) { app in
+            try await withRollbackTransaction(on: app) { database in
+                let installationId = UUID()
+                let h3Cell: Int64 = 617_700_169_958_293_503
+                let codePrefix = UUID().uuidString.lowercased()
+                let county = "county-\(codePrefix)"
+                let zone = "zone-\(codePrefix)"
+                let fireZone = "fire-zone-\(codePrefix)"
+                try await seedInstallation(
+                    id: installationId,
+                    h3Cell: h3Cell,
+                    county: county,
+                    zone: zone,
+                    fireZone: fireZone,
+                    on: database
+                )
+
+                let h3 = try await seedAlert(mode: .h3, h3Cells: [h3Cell], on: database)
+                let countyMatch = try await seedAlert(mode: .ugc, ugcCodes: [county], on: database)
+                let zoneMatch = try await seedAlert(mode: .ugc, reason: .update, ugcCodes: [zone], on: database)
+                let fireZoneMatch = try await seedAlert(mode: .ugc, ugcCodes: [fireZone], on: database)
+                _ = try await seedAlert(mode: .h3, h3Cells: [h3Cell + 1], on: database)
+                _ = try await seedAlert(mode: .ugc, ugcCodes: ["COC000"], on: database)
+
+                let otherInstallationId = UUID()
+                try await seedInstallation(
+                    id: otherInstallationId,
+                    h3Cell: h3Cell + 2,
+                    county: "COC998",
+                    zone: "COZ998",
+                    fireZone: "COZ997",
+                    on: database
+                )
+                _ = try await seedAlert(mode: .h3, h3Cells: [h3Cell + 2], on: database)
+
+                let matches = try await NotificationCandidateStore().loadMatchingActiveAlerts(
+                    for: installationId,
+                    evaluatedAt: now,
+                    on: database
+                )
+
+                #expect(Set(matches.map(\.seriesId)) == [h3.id, countyMatch.id, zoneMatch.id, fireZoneMatch.id])
+                #expect(matches.contains {
+                    $0.seriesId == h3.id && $0.revisionUrn == h3.revisionUrn && $0.mode == .h3 && $0.reason == .new
+                })
+                #expect(matches.contains {
+                    $0.seriesId == zoneMatch.id && $0.revisionUrn == zoneMatch.revisionUrn
+                        && $0.mode == .ugc && $0.reason == .update
+                })
+            }
+        }
+    }
+
+    @Test("Only current, active, future, non-terminal work is returned")
+    func lifecycleRevisionAndFallbackProvenance() async throws {
+        try await withIntegrationTestApplication(
+            setup: .configured(mode: .api, migrate: true)
+        ) { app in
+            try await withRollbackTransaction(on: app) { database in
+                let installationId = UUID()
+                let h3Cell: Int64 = 617_700_169_958_293_503
+                let county = "county-\(UUID().uuidString.lowercased())"
+                try await seedInstallation(
+                    id: installationId,
+                    h3Cell: h3Cell,
+                    county: county,
+                    zone: "COZ001",
+                    fireZone: "COZ201",
+                    on: database
+                )
+
+                let fallback = try await seedAlert(
+                    mode: .ugc,
+                    reason: .update,
+                    expires: now.addingTimeInterval(60),
+                    ends: now.addingTimeInterval(120),
+                    ugcCodes: [county],
+                    h3Cells: [h3Cell],
+                    on: database
+                )
+                _ = try await seedAlert(mode: .ugc, state: .expired, ugcCodes: [county], on: database)
+                _ = try await seedAlert(mode: .ugc, state: .ended, ugcCodes: [county], on: database)
+                _ = try await seedAlert(mode: .ugc, state: .cancelled, ugcCodes: [county], on: database)
+                _ = try await seedAlert(mode: .ugc, expires: now, ugcCodes: [county], on: database)
+                _ = try await seedAlert(mode: .ugc, ends: now, ugcCodes: [county], on: database)
+                _ = try await seedAlert(
+                    mode: .ugc,
+                    ugcCodes: [county],
+                    outboxUsesCurrentRevision: false,
+                    on: database
+                )
+                _ = try await seedAlert(mode: .ugc, reason: .endedAllClear, ugcCodes: [county], on: database)
+                _ = try await seedAlert(mode: .ugc, reason: .cancelInError, ugcCodes: [county], on: database)
+
+                let matches = try await NotificationCandidateStore().loadMatchingActiveAlerts(
+                    for: installationId,
+                    evaluatedAt: now,
+                    on: database
+                )
+
+                #expect(matches.count == 1)
+                #expect(matches.first?.seriesId == fallback.id)
+                #expect(matches.first?.revisionUrn == fallback.revisionUrn)
+                #expect(matches.first?.mode == .ugc)
+                #expect(matches.first?.reason == .update)
+            }
+        }
+    }
+}

--- a/docs/plans/location-driven-alert-reconciliation-progress.md
+++ b/docs/plans/location-driven-alert-reconciliation-progress.md
@@ -262,7 +262,7 @@ Handoff:
 GitHub:
 - https://github.com/justinrooks/arcus-signal/issues/211
 
-Status: Pending
+Status: Implemented — Awaiting Human Review
 
 Goal:
 - Add an installation-scoped active-current-revision lookup that preserves current H3 and UGC-fallback mode semantics.
@@ -277,6 +277,15 @@ Verification:
 
 Stop condition:
 - Query tests cover H3, all three UGC fields, fallback mode, current revision, and lifecycle exclusions; no queue or delivery behavior changes.
+
+Evidence:
+- Added an installation-scoped inverse lookup that returns current series/revision identity plus existing H3/UGC mode and `.new`/`.update` reason provenance.
+- H3 exact membership, county/forecast-zone/fire-zone OR matching, current-revision UGC fallback despite an older series geolocation row, and lifecycle/reason exclusions are covered by PostgreSQL integration tests.
+- Existing indexes remain sufficient for this bounded lookup; no schema or index change was added.
+- `swift test --filter NotificationActiveAlertQueryTests` and `swift test --filter NotificationSendJobCandidateQueryTests` passed on 2026-08-13.
+
+Handoff:
+- After review and merge, issue #212 may add the backward-compatible installation constraint to the existing send job. This slice does not dispatch queue work or alter delivery behavior.
 
 ### Issue #212 - 05: Constrain the existing send job to one installation
 


### PR DESCRIPTION
# Summary
Adds an installation-scoped inverse lookup for active, current alert revisions using the existing H3 and UGC targeting semantics. Closes #211.

# What Changed
- Added a query returning matching series/revision identity with notification mode and reason provenance.
- Restricted matches to active, non-expired, non-ended series and current revisions with .new/.update notification reasons.
- Preserved exact H3 membership and county/forecast-zone/fire-zone UGC matching.
- Added PostgreSQL integration coverage for installation scope, matching semantics, revision selection, and lifecycle/reason exclusions.
- Updated the reconciliation progress record with the implementation evidence.

# User Impact
No direct user-visible impact in this slice; this provides the installation-scoped match set needed by subsequent constrained delivery work.

# Testing
- `swift test --filter NotificationActiveAlertQueryTests` passed on 2026-08-13.
- `swift test --filter NotificationSendJobCandidateQueryTests` passed on 2026-08-13.

# Notes
- No schema or index changes.
- No queue, controller, ledger, or APNs delivery behavior changes.