### PR TITLE
Constrain notification send jobs to one installation

### DIFF
--- a/Sources/App/Jobs/NotificationSendJob.swift
+++ b/Sources/App/Jobs/NotificationSendJob.swift
@@ -44,17 +44,20 @@ public struct NotificationSendJobPayload: Codable, Sendable {
     let revisionUrn: String
     let mode: NotificationTargetMode
     let reason: NotificationReason
+    let installationId: UUID?
     
     init(
         seriesId: UUID,
         revisionUrn: String,
         mode: NotificationTargetMode,
-        reason: NotificationReason
+        reason: NotificationReason,
+        installationId: UUID? = nil
     ) {
         self.seriesId = seriesId
         self.revisionUrn = revisionUrn
         self.mode = mode
         self.reason = reason
+        self.installationId = installationId
     }
 }
 
@@ -245,6 +248,7 @@ public struct NotificationSendJob: AsyncJob {
             let h3Candidates = try await candidateStore.loadH3Candidates(
                 cells: geo.h3Cells,
                 capturedAtOrAfter: presenceCutoff,
+                installationId: payload.installationId,
                 on: context.application.db
             )
             
@@ -265,6 +269,7 @@ public struct NotificationSendJob: AsyncJob {
             let ugcCandidates = try await candidateStore.loadUGCCandidates(
                 ugcCodes: series.ugcCodes,
                 capturedAtOrAfter: presenceCutoff,
+                installationId: payload.installationId,
                 on: context.application.db
             )
 

--- a/Sources/App/Models/Notification/NotificationCandidateStore.swift
+++ b/Sources/App/Models/Notification/NotificationCandidateStore.swift
@@ -86,6 +86,7 @@ struct NotificationCandidateStore {
     func loadUGCCandidates(
         ugcCodes: [String],
         capturedAtOrAfter cutoff: Date,
+        installationId: UUID? = nil,
         on db: any Database
     ) async throws -> [NotificationCandidate] {
         guard let sql = db as? any SQLDatabase else {
@@ -107,6 +108,7 @@ struct NotificationCandidateStore {
             WHERE i.is_active = TRUE
               AND i.is_subscribed = TRUE
               AND i.apns_device_token <> ''
+              AND (\(bind: installationId)::uuid IS NULL OR i.installation_id = \(bind: installationId)::uuid)
               AND p.captured_at >= \(bind: cutoff)
               AND (
                   p.county  = ANY(\(bind: ugcCodes)::text[])
@@ -120,6 +122,7 @@ struct NotificationCandidateStore {
     func loadH3Candidates(
         cells: [Int64],
         capturedAtOrAfter cutoff: Date,
+        installationId: UUID? = nil,
         on db: any Database
     ) async throws -> [NotificationCandidate] {
         guard let sql = db as? any SQLDatabase else {
@@ -143,6 +146,7 @@ struct NotificationCandidateStore {
             WHERE i.is_active = TRUE
               AND i.is_subscribed = TRUE
               AND i.apns_device_token <> ''
+              AND (\(bind: installationId)::uuid IS NULL OR i.installation_id = \(bind: installationId)::uuid)
               AND p.h3_cell IS NOT NULL
               AND p.h3_cell = ANY(\(bind: cells)::bigint[])
               AND p.captured_at >= \(bind: cutoff)

--- a/Tests/AppTests/NotificationSendJobCandidateQueryTests.swift
+++ b/Tests/AppTests/NotificationSendJobCandidateQueryTests.swift
@@ -227,4 +227,72 @@ struct NotificationSendJobCandidateQueryTests {
             }
         }
     }
+
+    @Test("installation constraint applies to H3 and UGC candidates")
+    func installationConstraintAppliesToBothCandidatePaths() async throws {
+        try await withIntegrationTestApplication(
+            setup: .directPostgres,
+            prepare: { app in try await bootstrapTables(on: app.db) }
+        ) { app in
+            try await withRollbackTransaction(on: app) { database in
+                let h3Cell = Int64(
+                    UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(15),
+                    radix: 16
+                )!
+                let otherH3Cell = h3Cell + 1
+                let ugcCode = "test-\(UUID().uuidString)"
+                let h3Target = UUID()
+                let movedH3Target = UUID()
+                let ugcTarget = UUID()
+                let movedUGCTarget = UUID()
+
+                try await seedCandidate(id: h3Target, capturedAt: now, h3Cell: h3Cell, county: nil, on: database)
+                try await seedCandidate(
+                    id: movedH3Target,
+                    capturedAt: now,
+                    h3Cell: otherH3Cell,
+                    county: nil,
+                    on: database
+                )
+                try await seedCandidate(id: ugcTarget, capturedAt: now, h3Cell: nil, county: ugcCode, on: database)
+                try await seedCandidate(
+                    id: movedUGCTarget,
+                    capturedAt: now,
+                    h3Cell: nil,
+                    county: "other-\(ugcCode)",
+                    on: database
+                )
+
+                let h3Candidates = try await NotificationCandidateStore().loadH3Candidates(
+                    cells: [h3Cell],
+                    capturedAtOrAfter: now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold),
+                    installationId: h3Target,
+                    on: database
+                )
+                let movedH3Candidates = try await NotificationCandidateStore().loadH3Candidates(
+                    cells: [h3Cell],
+                    capturedAtOrAfter: now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold),
+                    installationId: movedH3Target,
+                    on: database
+                )
+                let ugcCandidates = try await NotificationCandidateStore().loadUGCCandidates(
+                    ugcCodes: [ugcCode],
+                    capturedAtOrAfter: now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold),
+                    installationId: ugcTarget,
+                    on: database
+                )
+                let movedUGCCandidates = try await NotificationCandidateStore().loadUGCCandidates(
+                    ugcCodes: [ugcCode],
+                    capturedAtOrAfter: now.addingTimeInterval(-LocationFreshnessPolicy.hardStaleThreshold),
+                    installationId: movedUGCTarget,
+                    on: database
+                )
+
+                #expect(h3Candidates.map(\.id) == [h3Target])
+                #expect(movedH3Candidates.isEmpty)
+                #expect(ugcCandidates.map(\.id) == [ugcTarget])
+                #expect(movedUGCCandidates.isEmpty)
+            }
+        }
+    }
 }

--- a/Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift
+++ b/Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift
@@ -38,6 +38,27 @@ struct NotificationSendJobDeliveryBoundaryTests {
             """).run()
 
         try await sql.raw("""
+            CREATE TABLE IF NOT EXISTS device_presence (
+                installation_id UUID PRIMARY KEY REFERENCES device_installations(installation_id) ON DELETE CASCADE,
+                captured_at TIMESTAMP NOT NULL,
+                received_at TIMESTAMP NOT NULL,
+                location_age_seconds DOUBLE PRECISION NOT NULL,
+                horizontal_accuracy_meters DOUBLE PRECISION NOT NULL,
+                cell_scheme TEXT NOT NULL,
+                h3_cell BIGINT,
+                h3_resolution INTEGER,
+                county TEXT,
+                zone TEXT,
+                fire_zone TEXT,
+                source TEXT NOT NULL,
+                created_at TIMESTAMP NOT NULL,
+                updated_at TIMESTAMP NOT NULL,
+                county_label TEXT,
+                fire_zone_label TEXT
+            );
+            """).run()
+
+        try await sql.raw("""
             CREATE TABLE IF NOT EXISTS arcus_series (
                 id UUID PRIMARY KEY,
                 source TEXT NOT NULL,
@@ -203,6 +224,13 @@ struct NotificationSendJobDeliveryBoundaryTests {
         )
     }
 
+    private func makeUniqueH3Cell() -> Int64 {
+        Int64(
+            UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(15),
+            radix: 16
+        )!
+    }
+
     private func seedInstallation(id: UUID, locationAuth: LocationAuth, on db: any Database) async throws {
         guard let sql = db as? any SQLDatabase else {
             throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
@@ -257,6 +285,53 @@ struct NotificationSendJobDeliveryBoundaryTests {
             """).run()
     }
 
+    private func seedH3Presence(
+        installationID: UUID,
+        h3Cell: Int64,
+        capturedAt: Date,
+        on db: any Database
+    ) async throws {
+        guard let sql = db as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        try await sql.raw("""
+            INSERT INTO device_presence
+                (installation_id, captured_at, received_at, location_age_seconds, horizontal_accuracy_meters,
+                 cell_scheme, h3_cell, h3_resolution, county, zone, fire_zone, source, created_at, updated_at,
+                 county_label, fire_zone_label)
+            VALUES
+                (\(bind: installationID), \(bind: capturedAt), \(bind: capturedAt), 0, 0, 'h3',
+                 \(bind: h3Cell), 8, NULL, NULL, NULL, 'foreground', NOW(), NOW(), 'Test County', NULL)
+            """).run()
+    }
+
+    private func seedH3Candidate(
+        installationID: UUID,
+        h3Cell: Int64,
+        capturedAt: Date,
+        on db: any Database
+    ) async throws {
+        try await seedInstallation(id: installationID, locationAuth: .always, on: db)
+        try await seedH3Presence(
+            installationID: installationID,
+            h3Cell: h3Cell,
+            capturedAt: capturedAt,
+            on: db
+        )
+    }
+
+    private func seedGeolocation(seriesID: UUID, h3Cell: Int64, on db: any Database) async throws {
+        try await ArcusGeolocationModel(
+            series: seriesID,
+            geometry: .point(lon: 0, lat: 0),
+            geometryHash: String(repeating: "a", count: 64),
+            h3Cells: [h3Cell],
+            h3Resolution: 8,
+            h3Hash: String(repeating: "b", count: 64)
+        ).create(on: db)
+    }
+
     private func makeSeries(id: UUID, revisionUrn: String, now: Date) -> ArcusSeriesModel {
         ArcusSeriesModel(
             id: id,
@@ -291,6 +366,24 @@ struct NotificationSendJobDeliveryBoundaryTests {
             countyLabel: "Test County",
             fireZoneLabel: nil
         )
+    }
+
+    @Test("legacy payloads decode without an installation constraint")
+    func legacyPayloadDecodesWithoutInstallationConstraint() throws {
+        let seriesID = UUID()
+        let data = Data("""
+            {
+              "seriesId": "\(seriesID.uuidString)",
+              "revisionUrn": "urn:oid:legacy",
+              "mode": "h3",
+              "reason": "new"
+            }
+            """.utf8)
+
+        let payload = try JSONDecoder().decode(NotificationSendJobPayload.self, from: data)
+
+        #expect(payload.seriesId == seriesID)
+        #expect(payload.installationId == nil)
     }
 
     @Test("stale candidates are blocked before ledger and persist one stale miss across retries")
@@ -468,7 +561,8 @@ struct NotificationSendJobDeliveryBoundaryTests {
                 seriesId: seriesID,
                 revisionUrn: revisionUrn,
                 mode: .h3,
-                reason: .new
+                reason: .new,
+                installationId: installationID
             )
 
             try await seedInstallation(id: installationID, locationAuth: .always, on: app.db)
@@ -502,6 +596,92 @@ struct NotificationSendJobDeliveryBoundaryTests {
                 .filter(\.$recordKind == NotificationDebugRecordKind.candidate.rawValue)
                 .count()
             #expect(debugCount == 1)
+        }
+    }
+
+    @Test("constrained and unconstrained dequeue attempts converge on one claim")
+    func concurrentConstrainedAndUnconstrainedAttemptsConvergeOnOneClaim() async throws {
+        try await withIntegrationTestApplication(
+            setup: .directPostgres,
+            prepare: { app in try await bootstrapTables(on: app.db) }
+        ) { app in
+            let sender = GatedRecordingNotificationSender()
+            let job = NotificationSendJob(sender: sender)
+            let constrainedContext = makeQueueContext(app: app)
+            let unconstrainedContext = makeQueueContext(app: app)
+            let seriesID = UUID()
+            let revisionUrn = "urn:oid:concurrent-constraint-\(UUID().uuidString.lowercased())"
+            let h3Cell = makeUniqueH3Cell()
+            let installationID = UUID()
+            let otherInstallationID = UUID()
+
+            try await seedSeries(id: seriesID, revisionUrn: revisionUrn, on: app.db)
+            try await seedRevision(seriesID: seriesID, revisionUrn: revisionUrn, on: app.db)
+            try await seedGeolocation(seriesID: seriesID, h3Cell: h3Cell, on: app.db)
+            try await seedH3Candidate(
+                installationID: installationID,
+                h3Cell: h3Cell,
+                capturedAt: Date(),
+                on: app.db
+            )
+            try await seedH3Candidate(
+                installationID: otherInstallationID,
+                h3Cell: h3Cell,
+                capturedAt: Date(),
+                on: app.db
+            )
+
+            async let constrained: Void = job.dequeue(
+                constrainedContext,
+                .init(
+                    seriesId: seriesID,
+                    revisionUrn: revisionUrn,
+                    mode: .h3,
+                    reason: .new,
+                    installationId: installationID
+                )
+            )
+            await sender.waitForFirstSend()
+
+            async let unconstrained: Void = job.dequeue(
+                unconstrainedContext,
+                .init(
+                    seriesId: seriesID,
+                    revisionUrn: revisionUrn,
+                    mode: .h3,
+                    reason: .new
+                )
+            )
+            await sender.waitForSendCount(2)
+            await sender.releaseFirstSend()
+            _ = try await (constrained, unconstrained)
+
+            let ledgerCount = try await NotificationLedgerModel.query(on: app.db)
+                .filter(\.$deviceInstallation.$id == installationID)
+                .filter(\.$series.$id == seriesID)
+                .filter(\.$revisionUrn == revisionUrn)
+                .count()
+            let otherLedgerCount = try await NotificationLedgerModel.query(on: app.db)
+                .filter(\.$deviceInstallation.$id == otherInstallationID)
+                .filter(\.$series.$id == seriesID)
+                .filter(\.$revisionUrn == revisionUrn)
+                .count()
+            let attempts = try await NotificationSendAttemptModel.query(on: app.db)
+                .filter(\.$series.$id == seriesID)
+                .filter(\.$revisionUrn == revisionUrn)
+                .all()
+
+            #expect(ledgerCount == 1)
+            #expect(otherLedgerCount == 1)
+            #expect(attempts.count == 2)
+            let constrainedAttempt = try #require(attempts.first { $0.candidateCount == 1 })
+            let unconstrainedAttempt = try #require(attempts.first { $0.candidateCount == 2 })
+            #expect(constrainedAttempt.claimedCount == 1)
+            #expect(unconstrainedAttempt.claimedCount == 1)
+            #expect(unconstrainedAttempt.sentCount == 1)
+            #expect(attempts.reduce(0) { $0 + $1.claimedCount } == 2)
+            #expect(attempts.reduce(0) { $0 + $1.sentCount } == 2)
+            #expect(await sender.sendCount == 2)
         }
     }
 
@@ -611,6 +791,62 @@ private actor RecordingNotificationSender: NotificationSender {
         environment _: APNsEnvironment
     ) async throws {
         sendCount += 1
+    }
+}
+
+private actor GatedRecordingNotificationSender: NotificationSender {
+    private(set) var sendCount = 0
+    private var firstSendStarted = false
+    private var firstSendStartedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var sendCountWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+    private var firstSendRelease: CheckedContinuation<Void, Never>?
+
+    func waitForFirstSend() async {
+        guard !firstSendStarted else { return }
+
+        await withCheckedContinuation { continuation in
+            firstSendStartedWaiters.append(continuation)
+        }
+    }
+
+    func waitForSendCount(_ expectedCount: Int) async {
+        guard sendCount < expectedCount else { return }
+
+        await withCheckedContinuation { continuation in
+            sendCountWaiters.append((expectedCount, continuation))
+        }
+    }
+
+    func releaseFirstSend() {
+        firstSendRelease?.resume()
+        firstSendRelease = nil
+    }
+
+    func sendNotification(
+        app _: Application,
+        with _: AlertDetails,
+        hotAlertPayload _: HotAlertAPNsPayload,
+        to _: String,
+        environment _: APNsEnvironment
+    ) async throws {
+        sendCount += 1
+
+        if sendCount == 1 {
+            firstSendStarted = true
+            let waiters = firstSendStartedWaiters
+            firstSendStartedWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+
+        let readyWaiters = sendCountWaiters.filter { $0.count <= sendCount }
+        sendCountWaiters.removeAll { $0.count <= sendCount }
+        readyWaiters.forEach { $0.continuation.resume() }
+
+        if sendCount == 1 {
+            await withCheckedContinuation { continuation in
+                firstSendRelease = continuation
+            }
+        }
     }
 }
 

--- a/docs/plans/location-driven-alert-reconciliation-progress.md
+++ b/docs/plans/location-driven-alert-reconciliation-progress.md
@@ -292,7 +292,7 @@ Handoff:
 GitHub:
 - https://github.com/justinrooks/arcus-signal/issues/212
 
-Status: Pending
+Status: Implemented — Awaiting Human Review
 
 Goal:
 - Make `NotificationSendJob` optionally select one installation without changing existing unconstrained alert-driven fan-out or last-mile semantics.
@@ -310,6 +310,15 @@ Verification:
 
 Stop condition:
 - Optional constrained payload behavior and backward decoding are tested; no reconciliation job exists yet.
+
+Evidence:
+- Added an optional installation ID to `NotificationSendJobPayload`; payloads queued before this field existed continue to decode with no constraint.
+- H3 and UGC candidate queries restrict to the requested installation when present and retain current fan-out when absent.
+- Focused tests cover constrained matching, moved-away no-op behavior, existing-claim no-op behavior, and concurrent constrained/unconstrained discovery converging at the ledger identity.
+- All three focused verification suites passed on 2026-08-13.
+
+Handoff:
+- After review and merge, issue #213 may dispatch installation-constrained send jobs from worker-owned reconciliation. This slice does not add reconciliation dispatch or processing.
 
 ### Issue #213 - 06: Dispatch and process installation reconciliation work
 


### PR DESCRIPTION
# Summary
Adds an optional installation constraint to the existing notification send job so reconciliation can reuse the current delivery pipeline for one installation while preserving legacy fan-out behavior.

# What Changed
- Extends send-job payloads with an optional installation ID, while keeping older queued payloads decodable.
- Applies the optional installation filter to both H3 and UGC candidate queries.
- Adds focused coverage for constrained selection, moved-away candidates, legacy payload decoding, and concurrent constrained/unconstrained attempts.
- Updates the reconciliation progress handoff to record the implemented slice and its verification evidence.

# User Impact
No direct user-facing change for existing alert-driven fan-out. Future reconciliation dispatch can target a single installation without rerunning global candidate selection.

# Testing
- `swift test --filter NotificationSendJobCandidateQueryTests`
- `swift test --filter NotificationSendJobDeliveryBoundaryTests`
- `swift test --filter NotificationEngineTests`

# Notes
- Reuses the existing ledger claim and delivery semantics; reconciliation dispatch remains out of scope for this slice.
- Closes #212