### PR TITLE
Dispatch and process installation reconciliation work

### DIFF
--- a/Sources/App/Controllers/DeviceController.swift
+++ b/Sources/App/Controllers/DeviceController.swift
@@ -15,6 +15,11 @@ private enum DevicePresenceUpsertOutcome: String {
     case staleIgnored
 }
 
+private struct DevicePresenceCommitResult {
+    let outcome: DevicePresenceUpsertOutcome
+    let reconciliationHandoff: PresenceReconciliationHandoffRequest?
+}
+
 struct DeviceController: RouteCollection {
     func boot(routes: any RoutesBuilder) throws {
         let devices = routes.grouped("api", "v1", "devices")
@@ -100,10 +105,10 @@ struct DeviceController: RouteCollection {
             break
         }
         
-        let presenceOutcome = try await req.db.transaction { database in
+        let commitResult = try await req.db.transaction { database in
             let previousInstallation = try await DeviceInstallationModel.find(installationUUID, on: database)
             let previousPresence = try await DevicePresenceModel.find(installationUUID, on: database)
-            let previousState = reconciliationState(
+            let previousState = PresenceReconciliationState(
                 installation: previousInstallation,
                 presence: previousPresence
             )
@@ -133,27 +138,51 @@ struct DeviceController: RouteCollection {
 
             guard presenceOutcome != .staleIgnored,
                   let presence = try await DevicePresenceModel.find(installationUUID, on: database) else {
-                return presenceOutcome
+                return DevicePresenceCommitResult(outcome: presenceOutcome, reconciliationHandoff: nil)
             }
 
-            guard let currentState = reconciliationState(installation: installation, presence: presence) else {
-                return presenceOutcome
+            guard let currentState = PresenceReconciliationState(
+                installation: installation,
+                presence: presence
+            ) else {
+                return DevicePresenceCommitResult(outcome: presenceOutcome, reconciliationHandoff: nil)
             }
+            var reconciliationHandoff: PresenceReconciliationHandoffRequest?
             if let trigger = PresenceReconciliationTrigger.decide(
                 previous: previousState,
                 current: currentState,
                 now: receivedAt
             ) {
-                _ = try await PresenceReconciliationOutboxStore().insert(
+                let insertResult = try await PresenceReconciliationOutboxStore().insert(
                     installationID: installationUUID,
                     presenceCapturedAt: presence.capturedAt,
                     triggerCategory: trigger.category,
                     targetingFingerprint: try StableContentHasher.sha256Hex(of: currentState.fingerprint),
                     on: database
                 )
+                if let intentId = insertResult.id {
+                    reconciliationHandoff = .init(
+                        intentId: intentId,
+                        installationId: installationUUID,
+                        triggerCategory: trigger.category,
+                        priorAttemptCount: 0
+                    )
+                }
             }
 
-            return presenceOutcome
+            return DevicePresenceCommitResult(
+                outcome: presenceOutcome,
+                reconciliationHandoff: reconciliationHandoff
+            )
+        }
+
+        if let reconciliationHandoff = commitResult.reconciliationHandoff {
+            await req.application.presenceReconciliationHandoff.handoff(
+                reconciliationHandoff,
+                on: req.application,
+                database: req.db,
+                logger: req.logger
+            )
         }
         
         // Avoid logging full APNS token in production logs.
@@ -178,7 +207,7 @@ struct DeviceController: RouteCollection {
                 "platform": .string(payload.platform),
                 "osVersion": .string(payload.osVersion),
                 "apnsEnvironment": .string(payload.apnsEnvironment),
-                "presenceOutcome": .string(presenceOutcome.rawValue)
+                "presenceOutcome": .string(commitResult.outcome.rawValue)
             ]
         )
         
@@ -443,27 +472,4 @@ private func upsertDevicePresence(
         try await existing.update(on: database)
         return .updated
     }
-}
-
-private func reconciliationState(
-    installation: DeviceInstallationModel?,
-    presence: DevicePresenceModel?
-) -> PresenceReconciliationState? {
-    guard let installation, let presence else {
-        return nil
-    }
-
-    return PresenceReconciliationState(
-        fingerprint: .init(
-            h3Cell: presence.h3Cell,
-            county: presence.county,
-            forecastZone: presence.zone,
-            fireZone: presence.fireZone
-        ),
-        capturedAt: presence.capturedAt,
-        locationAuth: installation.locationAuth,
-        isActive: installation.isActive,
-        isSubscribed: installation.isSubscribed,
-        hasAPNsToken: !installation.apnsDeviceToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    )
 }

--- a/Sources/App/Infrastructure/Notifications/PresenceReconciliationTrigger.swift
+++ b/Sources/App/Infrastructure/Notifications/PresenceReconciliationTrigger.swift
@@ -49,7 +49,7 @@ public struct PresenceReconciliationState: Sendable {
     }
 }
 
-public enum PresenceReconciliationTriggerCategory: String, Sendable, Equatable {
+public enum PresenceReconciliationTriggerCategory: String, Codable, Sendable, Equatable {
     case firstUsablePresence
     case movedWhileUsable
     case becameUsable
@@ -90,10 +90,10 @@ public struct PresenceReconciliationTrigger: Sendable, Equatable {
         return Self(category: .movedWhileUsable)
     }
 
-    private static func isUsable(
+    static func isUsable(
         _ state: PresenceReconciliationState,
         now: Date,
-        freshnessPolicy: LocationFreshnessPolicy
+        freshnessPolicy: LocationFreshnessPolicy = .init()
     ) -> Bool {
         guard state.isActive, state.isSubscribed, state.hasAPNsToken else {
             return false
@@ -112,5 +112,32 @@ public struct PresenceReconciliationTrigger: Sendable, Equatable {
             now: now
         )
         return freshness.state != .stale
+    }
+}
+
+extension PresenceReconciliationState {
+    init?(
+        installation: DeviceInstallationModel?,
+        presence: DevicePresenceModel?
+    ) {
+        guard let installation, let presence else {
+            return nil
+        }
+
+        self.init(
+            fingerprint: .init(
+                h3Cell: presence.h3Cell,
+                county: presence.county,
+                forecastZone: presence.zone,
+                fireZone: presence.fireZone
+            ),
+            capturedAt: presence.capturedAt,
+            locationAuth: installation.locationAuth,
+            isActive: installation.isActive,
+            isSubscribed: installation.isSubscribed,
+            hasAPNsToken: !installation.apnsDeviceToken
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .isEmpty
+        )
     }
 }

--- a/Sources/App/Jobs/DispatchPresenceReconciliationScheduledJob.swift
+++ b/Sources/App/Jobs/DispatchPresenceReconciliationScheduledJob.swift
@@ -1,0 +1,52 @@
+import Fluent
+import Queues
+import Vapor
+
+struct DispatchPresenceReconciliationScheduledJob: AsyncScheduledJob {
+    static let batchLimit = 100
+
+    private let store: PresenceReconciliationOutboxStore
+
+    init(store: PresenceReconciliationOutboxStore = .init()) {
+        self.store = store
+    }
+
+    func run(context: QueueContext) async throws {
+        try await dispatchReady(context: context, on: context.application.db)
+    }
+
+    func dispatchReady(
+        context: QueueContext,
+        on database: any Database
+    ) async throws {
+        let intents = try await store.readyIntents(
+            availableThrough: .now,
+            limit: Self.batchLimit,
+            on: database
+        )
+
+        context.logger.info(
+            "Dispatching ready presence reconciliation intents.",
+            metadata: ["intentCount": .stringConvertible(intents.count)]
+        )
+
+        for intent in intents {
+            guard let intentId = intent.id else {
+                context.logger.error("Ready presence reconciliation intent has no identifier.")
+                continue
+            }
+
+            await context.application.presenceReconciliationHandoff.handoff(
+                .init(
+                    intentId: intentId,
+                    installationId: intent.$installation.id,
+                    triggerCategory: intent.triggerCategory,
+                    priorAttemptCount: intent.attemptCount
+                ),
+                on: context.application,
+                database: database,
+                logger: context.logger
+            )
+        }
+    }
+}

--- a/Sources/App/Jobs/ReconcileInstallationAlertsJob.swift
+++ b/Sources/App/Jobs/ReconcileInstallationAlertsJob.swift
@@ -1,0 +1,273 @@
+import Fluent
+import Foundation
+import Logging
+import Queues
+import Vapor
+
+struct ReconcileInstallationAlertsJobPayload: Codable, Sendable {
+    let intentId: UUID
+    let installationId: UUID
+    let triggerCategory: PresenceReconciliationTriggerCategory
+}
+
+struct PresenceReconciliationHandoffRequest: Sendable {
+    let intentId: UUID
+    let installationId: UUID
+    let triggerCategory: PresenceReconciliationTriggerCategory
+    let priorAttemptCount: Int
+}
+
+protocol ReconcileInstallationAlertsJobDispatching: Sendable {
+    func dispatch(
+        _ payload: ReconcileInstallationAlertsJobPayload,
+        on application: Application
+    ) async throws
+}
+
+struct DefaultReconcileInstallationAlertsJobDispatcher: ReconcileInstallationAlertsJobDispatching {
+    func dispatch(
+        _ payload: ReconcileInstallationAlertsJobPayload,
+        on application: Application
+    ) async throws {
+        try await application.queues
+            .queue(ArcusQueueLane.target.queueName)
+            .dispatch(
+                ReconcileInstallationAlertsJob.self,
+                payload,
+                maxRetryCount: ReconcileInstallationAlertsJob.maximumRetryCount
+            )
+    }
+}
+
+protocol PresenceReconciliationHandoffPerforming: Sendable {
+    func handoff(
+        _ request: PresenceReconciliationHandoffRequest,
+        on application: Application,
+        database: any Database,
+        logger: Logger
+    ) async
+}
+
+struct PresenceReconciliationHandoff: PresenceReconciliationHandoffPerforming {
+    private static let retryDelays: [TimeInterval] = [60, 300, 900, 3_600]
+
+    private let store: PresenceReconciliationOutboxStore
+    private let dispatcher: any ReconcileInstallationAlertsJobDispatching
+
+    init(
+        store: PresenceReconciliationOutboxStore = .init(),
+        dispatcher: any ReconcileInstallationAlertsJobDispatching = DefaultReconcileInstallationAlertsJobDispatcher()
+    ) {
+        self.store = store
+        self.dispatcher = dispatcher
+    }
+
+    func handoff(
+        _ request: PresenceReconciliationHandoffRequest,
+        on application: Application,
+        database: any Database,
+        logger: Logger
+    ) async {
+        let attempt = request.priorAttemptCount + 1
+        let metadata = metadata(for: request, attempt: attempt)
+
+        do {
+            try await dispatcher.dispatch(
+                .init(
+                    intentId: request.intentId,
+                    installationId: request.installationId,
+                    triggerCategory: request.triggerCategory
+                ),
+                on: application
+            )
+            let updated = try await store.recordQueueHandoffSuccess(
+                intentID: request.intentId,
+                on: database
+            )
+            logger.info(
+                "Presence reconciliation queue handoff succeeded.",
+                metadata: metadata.merging([
+                    "outboxUpdated": .stringConvertible(updated)
+                ]) { _, new in new }
+            )
+        } catch {
+            let errorType = String(describing: type(of: error))
+            let nextAvailableAt = Date().addingTimeInterval(retryDelay(after: request.priorAttemptCount))
+
+            do {
+                let updated = try await store.recordQueueHandoffFailure(
+                    intentID: request.intentId,
+                    error: errorType,
+                    nextAvailableAt: nextAvailableAt,
+                    on: database
+                )
+                logger.error(
+                    "Presence reconciliation queue handoff failed; durable intent remains ready.",
+                    metadata: metadata.merging([
+                        "errorType": .string(errorType),
+                        "nextAvailableAt": .string(nextAvailableAt.ISO8601Format()),
+                        "outboxUpdated": .stringConvertible(updated)
+                    ]) { _, new in new }
+                )
+            } catch {
+                logger.error(
+                    "Presence reconciliation queue handoff and fallback update failed.",
+                    metadata: metadata.merging([
+                        "dispatchErrorType": .string(errorType),
+                        "fallbackErrorType": .string(String(describing: type(of: error)))
+                    ]) { _, new in new }
+                )
+            }
+        }
+    }
+
+    private func retryDelay(after priorAttemptCount: Int) -> TimeInterval {
+        Self.retryDelays[min(max(0, priorAttemptCount), Self.retryDelays.count - 1)]
+    }
+
+    private func metadata(
+        for request: PresenceReconciliationHandoffRequest,
+        attempt: Int
+    ) -> Logger.Metadata {
+        [
+            "intentId": .string(request.intentId.uuidString),
+            "installationId": .string(request.installationId.uuidString),
+            "trigger": .string(request.triggerCategory.rawValue),
+            "handoffAttempt": .stringConvertible(attempt)
+        ]
+    }
+}
+
+struct ReconcileInstallationAlertsJob: AsyncJob {
+    typealias Payload = ReconcileInstallationAlertsJobPayload
+
+    static let retryDelaysSeconds = [15, 60, 300]
+    static var maximumRetryCount: Int { retryDelaysSeconds.count }
+
+    private let candidateStore: NotificationCandidateStore
+
+    init(candidateStore: NotificationCandidateStore = .init()) {
+        self.candidateStore = candidateStore
+    }
+
+    func dequeue(_ context: QueueContext, _ payload: Payload) async throws {
+        try await reconcile(context, payload, on: context.application.db)
+    }
+
+    func reconcile(
+        _ context: QueueContext,
+        _ payload: Payload,
+        on database: any Database
+    ) async throws {
+        try Task.checkCancellation()
+
+        let metadata = metadata(for: payload)
+        context.logger.info("Installation alert reconciliation started.", metadata: metadata)
+
+        let installation = try await DeviceInstallationModel.find(
+            payload.installationId,
+            on: database
+        )
+        let presence = try await DevicePresenceModel.find(
+            payload.installationId,
+            on: database
+        )
+        guard let currentState = PresenceReconciliationState(
+            installation: installation,
+            presence: presence
+        ) else {
+            context.logger.info(
+                "Installation alert reconciliation stopped because authoritative state is missing.",
+                metadata: metadata
+            )
+            return
+        }
+
+        let evaluatedAt = Date()
+        guard PresenceReconciliationTrigger.isUsable(currentState, now: evaluatedAt) else {
+            context.logger.info(
+                "Installation alert reconciliation stopped because authoritative state is unusable.",
+                metadata: metadata
+            )
+            return
+        }
+
+        var matchCount = 0
+        var dispatchedCount = 0
+        do {
+            let matches = try await candidateStore.loadMatchingActiveAlerts(
+                for: payload.installationId,
+                evaluatedAt: evaluatedAt,
+                on: database
+            )
+            matchCount = matches.count
+
+            let sendQueue = context.application.queues.queue(ArcusQueueLane.send.queueName)
+            for match in matches {
+                try Task.checkCancellation()
+                try await sendQueue.dispatch(
+                    NotificationSendJob.self,
+                    .init(
+                        seriesId: match.seriesId,
+                        revisionUrn: match.revisionUrn,
+                        mode: match.mode,
+                        reason: match.reason,
+                        installationId: payload.installationId
+                    )
+                )
+                dispatchedCount += 1
+            }
+
+            context.logger.info(
+                "Installation alert reconciliation completed.",
+                metadata: metadata.merging([
+                    "matchCount": .stringConvertible(matchCount),
+                    "dispatchCount": .stringConvertible(dispatchedCount)
+                ]) { _, new in new }
+            )
+        } catch {
+            context.logger.error(
+                "Installation alert reconciliation attempt failed.",
+                metadata: metadata.merging([
+                    "matchCount": .stringConvertible(matchCount),
+                    "dispatchCount": .stringConvertible(dispatchedCount),
+                    "errorType": .string(String(describing: type(of: error)))
+                ]) { _, new in new }
+            )
+            throw error
+        }
+    }
+
+    func error(_ context: QueueContext, _ error: any Error, _ payload: Payload) async throws {
+        context.logger.error(
+            "Installation alert reconciliation exhausted retries.",
+            metadata: metadata(for: payload).merging([
+                "maximumRetryCount": .stringConvertible(Self.maximumRetryCount),
+                "errorType": .string(String(describing: type(of: error)))
+            ]) { _, new in new }
+        )
+    }
+
+    func nextRetryIn(attempt: Int) -> Int {
+        Self.retryDelaysSeconds[min(max(0, attempt - 1), Self.retryDelaysSeconds.count - 1)]
+    }
+
+    private func metadata(for payload: Payload) -> Logger.Metadata {
+        [
+            "intentId": .string(payload.intentId.uuidString),
+            "installationId": .string(payload.installationId.uuidString),
+            "trigger": .string(payload.triggerCategory.rawValue)
+        ]
+    }
+}
+
+extension Application {
+    var presenceReconciliationHandoff: any PresenceReconciliationHandoffPerforming {
+        get { storage[PresenceReconciliationHandoffKey.self] ?? PresenceReconciliationHandoff() }
+        set { storage[PresenceReconciliationHandoffKey.self] = newValue }
+    }
+}
+
+private struct PresenceReconciliationHandoffKey: StorageKey {
+    typealias Value = any PresenceReconciliationHandoffPerforming
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -41,6 +41,7 @@ public func configure(_ app: Application, mode: AppRuntimeMode) async throws {
     app.nwsReplayFixtureLoader = LocalNWSReplayFixtureLoader()
     app.queues.add(IngestNWSAlertsJob())
     app.queues.add(TargetEventRevisionJob())
+    app.queues.add(ReconcileInstallationAlertsJob())
     app.queues.add(NotificationSendJob())
     app.queues.add(PressureArtifactWarmJob())
     app.queues.add(PressureArtifactFailureCompletionJob(
@@ -65,6 +66,8 @@ public func configure(_ app: Application, mode: AppRuntimeMode) async throws {
         configureWorkerRuntime(on: app)
         app.queues.schedule(DispatchIngestNWSAlertsScheduledJob()).minutely().at(0)
         app.recordWorkerScheduledJob("DispatchIngestNWSAlertsScheduledJob")
+        app.queues.schedule(DispatchPresenceReconciliationScheduledJob()).minutely().at(0)
+        app.recordWorkerScheduledJob("DispatchPresenceReconciliationScheduledJob")
         app.queues.schedule(ProbeHRRRPressureArtifactsScheduledJob()).every(seconds: Int(app.stormSetupConfiguration.pressureArtifactProbeIntervalSeconds))
         app.recordWorkerScheduledJob("ProbeHRRRPressureArtifactsScheduledJob")
         app.queues.schedule(CleanupPressureArtifactsScheduledJob()).every(seconds: Int(app.stormSetupConfiguration.pressureArtifactCleanupIntervalSeconds))

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -962,10 +962,18 @@ struct AppTests {
     func workerBootstrapRegistersPressureArtifactProbeSchedule() async throws {
         try await withApp(mode: .worker) { app in
             #expect(app.workerScheduledJobNames.contains("DispatchIngestNWSAlertsScheduledJob"))
+            #expect(app.workerScheduledJobNames.contains("DispatchPresenceReconciliationScheduledJob"))
             #expect(app.workerScheduledJobNames.contains("ProbeHRRRPressureArtifactsScheduledJob"))
             #expect(app.workerScheduledJobNames.contains("CleanupPressureArtifactsScheduledJob"))
             #expect(app.workerScheduledJobNames.contains("RefreshOperatorDashboardSnapshotScheduledJob"))
-            #expect(app.workerScheduledJobNames.count == 4)
+            #expect(app.workerScheduledJobNames.count == 5)
+        }
+    }
+
+    @Test("API bootstrap does not register worker schedules")
+    func apiBootstrapDoesNotRegisterWorkerSchedules() async throws {
+        try await withApp(mode: .api) { app in
+            #expect(app.workerScheduledJobNames.isEmpty)
         }
     }
 

--- a/Tests/AppTests/DeviceControllerTests.swift
+++ b/Tests/AppTests/DeviceControllerTests.swift
@@ -3,9 +3,11 @@ import ArcusCore
 import Fluent
 import FluentSQL
 import Foundation
+import Queues
 import Testing
 import Vapor
 import VaporTesting
+import XCTQueues
 
 @Suite("Device controller", .serialized)
 struct DeviceControllerTests {
@@ -14,6 +16,7 @@ struct DeviceControllerTests {
         do {
             try await configure(app, mode: .api)
             try await app.autoMigrate()
+            app.queues.use(.test)
             try await test(app)
         } catch {
             try? await app.asyncShutdown()
@@ -111,9 +114,11 @@ struct DeviceControllerTests {
         }
     }
 
-    @Test("first usable presence records a reconciliation intent")
-    func firstUsablePresenceRecordsIntent() async throws {
+    @Test("first usable presence immediately hands its reconciliation intent to the target lane")
+    func firstUsablePresenceDispatchesReconciliation() async throws {
         try await withApp { app in
+            let capture = DeviceReconciliationDispatchCapture()
+            app.queues.add(capture)
             let installationID = UUID()
             let capturedAt = Date()
 
@@ -122,6 +127,37 @@ struct DeviceControllerTests {
             let intent = try #require(try await intents(for: installationID, in: app).first)
             #expect(abs(intent.presenceCapturedAt.timeIntervalSince(capturedAt)) < 1)
             #expect(intent.triggerCategory == .firstUsablePresence)
+            #expect(intent.state == .done)
+            #expect(intent.attemptCount == 1)
+
+            let payload = try #require(app.queues.test.first(ReconcileInstallationAlertsJob.self))
+            #expect(payload.intentId == intent.id)
+            #expect(payload.installationId == installationID)
+            #expect(payload.triggerCategory == .firstUsablePresence)
+
+            let dispatch = try #require(
+                await capture.firstDispatch(jobName: ReconcileInstallationAlertsJob.name)
+            )
+            #expect(dispatch.queueName == ArcusQueueLane.target.rawValue)
+            #expect(dispatch.maxRetryCount == ReconcileInstallationAlertsJob.maximumRetryCount)
+        }
+    }
+
+    @Test("queue failure after commit keeps the accepted intent ready for worker drain")
+    func queueFailureKeepsAcceptedIntentReady() async throws {
+        try await withApp { app in
+            app.presenceReconciliationHandoff = PresenceReconciliationHandoff(
+                dispatcher: ThrowingReconciliationJobDispatcher()
+            )
+            let installationID = UUID()
+
+            try await submit(makePayload(installationId: installationID.uuidString), to: app)
+
+            let intent = try #require(try await intents(for: installationID, in: app).first)
+            #expect(intent.state == .ready)
+            #expect(intent.attemptCount == 1)
+            #expect(intent.lastError == String(describing: ReconciliationJobDispatchTestError.self))
+            #expect(intent.availableAt > Date())
         }
     }
 
@@ -342,5 +378,32 @@ struct DeviceControllerTests {
             #expect(abs(presence.capturedAt.timeIntervalSince(capturedAt)) < 1)
             #expect(presence.county == "COC031")
         }
+    }
+}
+
+private enum ReconciliationJobDispatchTestError: Error {
+    case unavailable
+}
+
+private struct ThrowingReconciliationJobDispatcher: ReconcileInstallationAlertsJobDispatching {
+    func dispatch(
+        _ payload: ReconcileInstallationAlertsJobPayload,
+        on application: Application
+    ) async throws {
+        _ = payload
+        _ = application
+        throw ReconciliationJobDispatchTestError.unavailable
+    }
+}
+
+private actor DeviceReconciliationDispatchCapture: AsyncJobEventDelegate {
+    private var dispatches: [JobEventData] = []
+
+    func dispatched(job: JobEventData) async throws {
+        dispatches.append(job)
+    }
+
+    func firstDispatch(jobName: String) -> JobEventData? {
+        dispatches.first { $0.jobName == jobName }
     }
 }

--- a/Tests/AppTests/InstallationAlertReconciliationJobTests.swift
+++ b/Tests/AppTests/InstallationAlertReconciliationJobTests.swift
@@ -1,0 +1,282 @@
+@testable import App
+import Fluent
+import Foundation
+import Queues
+import Testing
+import Vapor
+import XCTQueues
+
+@Suite("Installation alert reconciliation jobs", .serialized)
+struct InstallationAlertReconciliationJobTests {
+    private func withApp(test: (Application) async throws -> Void) async throws {
+        let app = try await Application.make(.testing)
+        do {
+            try await configure(app, mode: .api)
+            try await app.autoMigrate()
+            app.queues.use(.test)
+            try await test(app)
+        } catch {
+            try? await app.asyncShutdown()
+            throw error
+        }
+        try await app.asyncShutdown()
+    }
+
+    private func context(for app: Application) -> QueueContext {
+        QueueContext(
+            queueName: QueueName(string: "scheduled"),
+            configuration: app.queues.configuration,
+            application: app,
+            logger: app.logger,
+            on: app.eventLoopGroup.any()
+        )
+    }
+
+    private func seedInstallation(
+        id: UUID,
+        county: String,
+        isSubscribed: Bool = true,
+        on database: any Database
+    ) async throws {
+        try await DeviceInstallationModel(
+            installationId: id,
+            apnsDeviceToken: "test-token",
+            apnsEnvironment: .sandbox,
+            platform: .iOS,
+            osVersion: "26.0",
+            appVersion: "1.0.0",
+            buildNumber: "100",
+            locationAuth: .always,
+            lastSeenAt: .now,
+            isSubscribed: isSubscribed
+        ).create(on: database)
+
+        try await DevicePresenceModel(
+            installationId: id,
+            capturedAt: .now,
+            receivedAt: .now,
+            locationAgeSeconds: 0,
+            horizontalAccuracyMeters: 10,
+            cellScheme: .ugcOnly,
+            h3Cell: nil,
+            h3Resolution: nil,
+            county: county,
+            zone: nil,
+            fireZone: nil,
+            source: .foregroundPrime,
+            countyLabel: "Test County",
+            fireZoneLabel: nil
+        ).create(on: database)
+    }
+
+    private func seedActiveAlert(
+        county: String,
+        on database: any Database
+    ) async throws -> (seriesId: UUID, revisionUrn: String) {
+        let now = Date()
+        let seriesId = UUID()
+        let revisionUrn = "urn:oid:\(UUID().uuidString.lowercased())"
+        try await ArcusSeriesModel(
+            id: seriesId,
+            source: "nws",
+            event: "Tornado Warning",
+            sourceURL: "https://api.weather.gov/alerts/\(seriesId.uuidString.lowercased())",
+            currentRevisionUrn: revisionUrn,
+            currentRevisionSent: now,
+            messageType: "alert",
+            contentFingerprint: String(repeating: "a", count: 64),
+            state: EventState.active.rawValue,
+            expires: now.addingTimeInterval(600),
+            ends: now.addingTimeInterval(600),
+            lastSeenActive: now,
+            severity: "severe",
+            urgency: "immediate",
+            certainty: "observed",
+            ugcCodes: [county]
+        ).create(on: database)
+        try await ArcusEventRevisionModel(
+            seriesId: seriesId,
+            revisionUrn: revisionUrn,
+            messageType: "alert",
+            sent: now,
+            received: now,
+            referencedUrns: []
+        ).create(on: database)
+        try await ArcusNotificationOutboxModel(
+            series: seriesId,
+            revisionUrn: revisionUrn,
+            mode: NotificationTargetMode.ugc.rawValue,
+            reason: NotificationReason.new.rawValue,
+            state: "done",
+            attempts: 1,
+            availableAt: now
+        ).create(on: database)
+        return (seriesId, revisionUrn)
+    }
+
+    @Test("scheduled drain hands ready intents to the target lane with bounded job retries")
+    func scheduledDrainDispatchesReadyIntents() async throws {
+        try await withApp { app in
+            let capture = ReconciliationDispatchCapture()
+            app.queues.add(capture)
+
+            try await withRollbackTransaction(on: app) { database in
+                try await PresenceReconciliationOutboxModel.query(on: database)
+                    .filter(\.$stateRaw == PresenceReconciliationOutboxState.ready.rawValue)
+                    .set(\.$stateRaw, to: PresenceReconciliationOutboxState.done.rawValue)
+                    .update()
+                let installationId = UUID()
+                try await seedInstallation(id: installationId, county: "COC031", on: database)
+                let inserted = try await PresenceReconciliationOutboxStore().insert(
+                    installationID: installationId,
+                    presenceCapturedAt: .now,
+                    triggerCategory: .firstUsablePresence,
+                    targetingFingerprint: "opaque-fingerprint",
+                    availableAt: .distantPast,
+                    on: database
+                )
+                let intentId = try #require(inserted.id)
+
+                let scheduledJob = DispatchPresenceReconciliationScheduledJob()
+                try await scheduledJob.dispatchReady(context: context(for: app), on: database)
+                try await scheduledJob.dispatchReady(context: context(for: app), on: database)
+
+                let payloads = app.queues.test.all(ReconcileInstallationAlertsJob.self)
+                #expect(payloads.count == 1)
+                #expect(payloads.first?.intentId == intentId)
+                #expect(payloads.first?.installationId == installationId)
+                #expect(payloads.first?.triggerCategory == .firstUsablePresence)
+
+                let row = try #require(
+                    try await PresenceReconciliationOutboxModel.find(intentId, on: database)
+                )
+                #expect(row.state == .done)
+                #expect(row.attemptCount == 1)
+
+                let event = try #require(
+                    await capture.firstDispatch(jobName: ReconcileInstallationAlertsJob.name)
+                )
+                #expect(event.queueName == ArcusQueueLane.target.rawValue)
+                #expect(event.maxRetryCount == ReconcileInstallationAlertsJob.maximumRetryCount)
+            }
+        }
+    }
+
+    @Test("reconciliation dispatches installation-constrained send work on the send lane")
+    func reconciliationDispatchesConstrainedSendWork() async throws {
+        try await withApp { app in
+            let capture = ReconciliationDispatchCapture()
+            app.queues.add(capture)
+
+            try await withRollbackTransaction(on: app) { database in
+                let installationId = UUID()
+                let county = "county-\(UUID().uuidString.lowercased())"
+                try await seedInstallation(id: installationId, county: county, on: database)
+                let alert = try await seedActiveAlert(county: county, on: database)
+
+                try await ReconcileInstallationAlertsJob().reconcile(
+                    context(for: app),
+                    .init(
+                        intentId: UUID(),
+                        installationId: installationId,
+                        triggerCategory: .movedWhileUsable
+                    ),
+                    on: database
+                )
+
+                let payload = try #require(app.queues.test.first(NotificationSendJob.self))
+                #expect(payload.seriesId == alert.seriesId)
+                #expect(payload.revisionUrn == alert.revisionUrn)
+                #expect(payload.mode == .ugc)
+                #expect(payload.reason == .new)
+                #expect(payload.installationId == installationId)
+
+                let event = try #require(
+                    await capture.firstDispatch(jobName: NotificationSendJob.name)
+                )
+                #expect(event.queueName == ArcusQueueLane.send.rawValue)
+            }
+        }
+    }
+
+    @Test("delayed reconciliation uses latest presence and succeeds with zero current matches")
+    func delayedReconciliationUsesLatestPresence() async throws {
+        try await withApp { app in
+            try await withRollbackTransaction(on: app) { database in
+                let installationId = UUID()
+                let originalCounty = "county-\(UUID().uuidString.lowercased())"
+                try await seedInstallation(id: installationId, county: originalCounty, on: database)
+                _ = try await seedActiveAlert(county: originalCounty, on: database)
+
+                let presence = try #require(
+                    try await DevicePresenceModel.find(installationId, on: database)
+                )
+                presence.county = "county-\(UUID().uuidString.lowercased())"
+                presence.capturedAt = .now
+                try await presence.update(on: database)
+
+                try await ReconcileInstallationAlertsJob().reconcile(
+                    context(for: app),
+                    .init(
+                        intentId: UUID(),
+                        installationId: installationId,
+                        triggerCategory: .movedWhileUsable
+                    ),
+                    on: database
+                )
+
+                #expect(app.queues.test.contains(NotificationSendJob.self) == false)
+            }
+        }
+    }
+
+    @Test("unusable latest installation stops before constrained send dispatch")
+    func unusableInstallationStopsReconciliation() async throws {
+        try await withApp { app in
+            try await withRollbackTransaction(on: app) { database in
+                let installationId = UUID()
+                let county = "county-\(UUID().uuidString.lowercased())"
+                try await seedInstallation(
+                    id: installationId,
+                    county: county,
+                    isSubscribed: false,
+                    on: database
+                )
+                _ = try await seedActiveAlert(county: county, on: database)
+
+                try await ReconcileInstallationAlertsJob().reconcile(
+                    context(for: app),
+                    .init(
+                        intentId: UUID(),
+                        installationId: installationId,
+                        triggerCategory: .becameUsable
+                    ),
+                    on: database
+                )
+
+                #expect(app.queues.test.contains(NotificationSendJob.self) == false)
+            }
+        }
+    }
+
+    @Test("reconciliation retry delays are bounded")
+    func retryDelaysAreBounded() {
+        let job = ReconcileInstallationAlertsJob()
+        #expect(job.nextRetryIn(attempt: 1) == 15)
+        #expect(job.nextRetryIn(attempt: 2) == 60)
+        #expect(job.nextRetryIn(attempt: 3) == 300)
+        #expect(job.nextRetryIn(attempt: 99) == 300)
+    }
+}
+
+private actor ReconciliationDispatchCapture: AsyncJobEventDelegate {
+    private var dispatches: [JobEventData] = []
+
+    func dispatched(job: JobEventData) async throws {
+        dispatches.append(job)
+    }
+
+    func firstDispatch(jobName: String) -> JobEventData? {
+        dispatches.first { $0.jobName == jobName }
+    }
+}

--- a/Tests/AppTests/PresenceReconciliationOutboxTests.swift
+++ b/Tests/AppTests/PresenceReconciliationOutboxTests.swift
@@ -74,6 +74,9 @@ struct PresenceReconciliationOutboxTests {
     func insertParticipatesInCallerOwnedTransaction() async throws {
         try await withApp { app in
             let installationID = UUID()
+            let countBeforeTransaction = try await PresenceReconciliationOutboxModel
+                .query(on: app.db)
+                .count()
 
             try await withRollbackTransaction(on: app) { database in
                 try await createInstallation(id: installationID, on: database)
@@ -87,10 +90,17 @@ struct PresenceReconciliationOutboxTests {
 
                 #expect(result.inserted)
                 #expect(result.id != nil)
-                #expect(try await PresenceReconciliationOutboxModel.query(on: database).count() == 1)
+                #expect(
+                    try await PresenceReconciliationOutboxModel.query(on: database)
+                        .filter(\.$installation.$id == installationID)
+                        .count() == 1
+                )
             }
 
-            #expect(try await PresenceReconciliationOutboxModel.query(on: app.db).count() == 0)
+            #expect(
+                try await PresenceReconciliationOutboxModel.query(on: app.db).count()
+                    == countBeforeTransaction
+            )
         }
     }
 
@@ -119,7 +129,11 @@ struct PresenceReconciliationOutboxTests {
 
                 #expect(first.inserted)
                 #expect(!duplicate.inserted)
-                #expect(try await PresenceReconciliationOutboxModel.query(on: database).count() == 1)
+                #expect(
+                    try await PresenceReconciliationOutboxModel.query(on: database)
+                        .filter(\.$installation.$id == installationID)
+                        .count() == 1
+                )
             }
         }
     }

--- a/docs/plans/location-driven-alert-reconciliation-progress.md
+++ b/docs/plans/location-driven-alert-reconciliation-progress.md
@@ -262,7 +262,7 @@ Handoff:
 GitHub:
 - https://github.com/justinrooks/arcus-signal/issues/211
 
-Status: Implemented — Awaiting Human Review
+Status: Implemented — Ready for Commit
 
 Goal:
 - Add an installation-scoped active-current-revision lookup that preserves current H3 and UGC-fallback mode semantics.
@@ -325,7 +325,7 @@ Handoff:
 GitHub:
 - https://github.com/justinrooks/arcus-signal/issues/213
 
-Status: Pending
+Status: Implemented — Awaiting Human Review
 
 Goal:
 - Add best-effort API queue handoff, a worker scheduled outbox drain, and a bounded-retry target-lane job that dispatches installation-constrained send work for active matches.
@@ -345,6 +345,17 @@ Verification:
 
 Stop condition:
 - Durable intents reach the target lane and dispatch only installation-scoped send work; no end-to-end campaign expansion or client change.
+
+Evidence:
+- The location route now attempts target-lane handoff only after its persistence transaction commits; queue failure preserves the ready intent and records sanitized retry metadata without failing the accepted response.
+- A worker-only minute schedule drains ready intents, while `ReconcileInstallationAlertsJob` reloads authoritative installation/presence, applies bounded queue retries, rediscovers current active matches, and dispatches installation-constrained children on the send lane.
+- Focused tests cover immediate successful API handoff, target/send lane ownership, retry bounds, durable handoff failure, latest-presence movement, zero-match success, unusable state, and API/worker schedule isolation.
+- `swift test --filter InstallationAlertReconciliationJobTests`, `swift test --filter DeviceControllerTests`, and `swift test --filter AppTests.AppTests` passed on 2026-08-13.
+- Human review completed on 2026-08-13. Independent defect review found no actionable defects; the validation audit's two test-coverage findings were accepted, corrected, and confirmed closed.
+- `swift build` and the final full 552-test `swift test --no-parallel` pass completed successfully on 2026-08-13.
+
+Handoff:
+- After review and merge, issue #214 may add the final vertical race/idempotency matrix and align living architecture documentation. This slice does not change APNs retry/reclaim behavior or any client producer.
 
 ### Issue #214 - 07: Verify end-to-end races, retries, and rollout readiness
 


### PR DESCRIPTION
# Summary
Moves durable presence-reconciliation intents through queue handoff and worker processing into installation-constrained notification send work, with durable fallback when immediate enqueue fails. Closes #213.

# What Changed
- Handoff newly committed reconciliation intents to the target queue while preserving a ready durable intent when dispatch fails.
- Add a worker-only scheduled drain for ready reconciliation intents.
- Add a target-lane reconciliation job with bounded retries that reloads authoritative installation/presence state, stops for unusable or stale state, and rediscoveries matching active alerts.
- Dispatch constrained notification-send payloads on the send lane and register the job and worker schedule.
- Add structured reconciliation logging and focused coverage for handoff, draining, latest-presence behavior, no-op matching, unusable installations, and retry bounds.

# User Impact
No client or API contract changes. Devices can have active matching alert deliveries reconciled after an accepted presence update, including when the initial queue handoff is temporarily unavailable.

# Testing
- `swift build`
- Focused installation reconciliation, device controller, and app test suites passed.
- Final `swift test --no-parallel`: 552 tests passed.
- Issue-scoped `git diff --check` passed.

# Notes
- The API remains persistence/enqueue-only; APNs delivery remains worker-owned.
- The scheduled drain is registered only for worker runtime, with target-lane reconciliation jobs dispatching constrained send work on the send lane.
