### PR TITLE
Add installation growth metrics to the operator dashboard

### DIFF
--- a/Sources/App/Models/API/OperatorDashboardSnapshotResponse.swift
+++ b/Sources/App/Models/API/OperatorDashboardSnapshotResponse.swift
@@ -8,7 +8,7 @@ public enum PressureArtifactReadinessSelectionOutcome: String, Codable, Sendable
 }
 
 public struct OperatorDashboardStoredSnapshot: Codable, Sendable {
-    public static let currentSchemaVersion = 3
+    public static let currentSchemaVersion = 4
 
     public var schemaVersion: Int
     public var generatedAt: Date
@@ -25,6 +25,7 @@ public struct OperatorDashboardStoredSnapshot: Codable, Sendable {
     public var apnsDelivery: StoredAPNsDeliveryMetric
     public var sendNoOps: StoredSendNoOpsMetric
     public var zeroCandidateRate: StoredZeroCandidateRateMetric
+    public var installationGrowth: StoredInstallationGrowthMetric
     public var targetableCoverage: StoredTargetableCoverageMetric
     public var h3Derivation: StoredH3DerivationMetric
     public var modelArtifacts: StoredPressureArtifactDashboardMetric
@@ -45,6 +46,7 @@ public struct OperatorDashboardStoredSnapshot: Codable, Sendable {
         apnsDelivery: StoredAPNsDeliveryMetric = .init(),
         sendNoOps: StoredSendNoOpsMetric = .init(),
         zeroCandidateRate: StoredZeroCandidateRateMetric = .init(),
+        installationGrowth: StoredInstallationGrowthMetric = .init(),
         targetableCoverage: StoredTargetableCoverageMetric = .init(),
         h3Derivation: StoredH3DerivationMetric = .init(),
         modelArtifacts: StoredPressureArtifactDashboardMetric = .init(),
@@ -64,6 +66,7 @@ public struct OperatorDashboardStoredSnapshot: Codable, Sendable {
         self.apnsDelivery = apnsDelivery
         self.sendNoOps = sendNoOps
         self.zeroCandidateRate = zeroCandidateRate
+        self.installationGrowth = installationGrowth
         self.targetableCoverage = targetableCoverage
         self.h3Derivation = h3Derivation
         self.modelArtifacts = modelArtifacts
@@ -85,6 +88,7 @@ public struct OperatorDashboardStoredSnapshot: Codable, Sendable {
         case apnsDelivery
         case sendNoOps
         case zeroCandidateRate
+        case installationGrowth
         case targetableCoverage
         case h3Derivation
         case modelArtifacts
@@ -107,6 +111,7 @@ public struct OperatorDashboardStoredSnapshot: Codable, Sendable {
         self.apnsDelivery = try container.decode(StoredAPNsDeliveryMetric.self, forKey: .apnsDelivery)
         self.sendNoOps = try container.decode(StoredSendNoOpsMetric.self, forKey: .sendNoOps)
         self.zeroCandidateRate = try container.decode(StoredZeroCandidateRateMetric.self, forKey: .zeroCandidateRate)
+        self.installationGrowth = try container.decodeIfPresent(StoredInstallationGrowthMetric.self, forKey: .installationGrowth) ?? .init()
         self.targetableCoverage = try container.decode(StoredTargetableCoverageMetric.self, forKey: .targetableCoverage)
         self.h3Derivation = try container.decode(StoredH3DerivationMetric.self, forKey: .h3Derivation)
         self.modelArtifacts = try container.decodeIfPresent(StoredPressureArtifactDashboardMetric.self, forKey: .modelArtifacts) ?? .init()
@@ -274,6 +279,44 @@ public struct StoredZeroCandidateRateMetric: Codable, Sendable {
         self.windowHours = windowHours
         self.candidateResolutionAttemptCount = candidateResolutionAttemptCount
         self.zeroCandidateAttemptCount = zeroCandidateAttemptCount
+    }
+}
+
+public struct StoredMonthlyInstallationGrowth: Codable, Sendable {
+    public var monthStart: Date
+    public var newInstallationCount: Int
+    public var cumulativeInstallationCount: Int
+
+    public init(
+        monthStart: Date,
+        newInstallationCount: Int,
+        cumulativeInstallationCount: Int
+    ) {
+        self.monthStart = monthStart
+        self.newInstallationCount = newInstallationCount
+        self.cumulativeInstallationCount = cumulativeInstallationCount
+    }
+}
+
+public struct StoredInstallationGrowthMetric: Codable, Sendable {
+    public var knownInstallationCount: Int
+    public var newThisMonthCount: Int
+    public var currentlySubscribedCount: Int
+    public var seenLast24HoursCount: Int
+    public var monthlyGrowth: [StoredMonthlyInstallationGrowth]
+
+    public init(
+        knownInstallationCount: Int = 0,
+        newThisMonthCount: Int = 0,
+        currentlySubscribedCount: Int = 0,
+        seenLast24HoursCount: Int = 0,
+        monthlyGrowth: [StoredMonthlyInstallationGrowth] = []
+    ) {
+        self.knownInstallationCount = knownInstallationCount
+        self.newThisMonthCount = newThisMonthCount
+        self.currentlySubscribedCount = currentlySubscribedCount
+        self.seenLast24HoursCount = seenLast24HoursCount
+        self.monthlyGrowth = monthlyGrowth
     }
 }
 
@@ -668,6 +711,7 @@ public struct OperatorDashboardSnapshotResponse: Content, Sendable {
     public var generatedAt: Date
     public var redLights: OperatorDashboardRedLightsSectionResponse
     public var deliveryKPIs: OperatorDashboardDeliveryKPIsSectionResponse
+    public var growthUsage: OperatorDashboardGrowthUsageSectionResponse
     public var audienceTargeting: OperatorDashboardAudienceTargetingSectionResponse
     public var modelArtifacts: OperatorDashboardModelArtifactsSectionResponse
     public var operatorContext: OperatorDashboardOperatorContextSectionResponse
@@ -677,6 +721,7 @@ public struct OperatorDashboardSnapshotResponse: Content, Sendable {
         self.generatedAt = snapshot.generatedAt
         self.redLights = .init(snapshot: snapshot, renderedAt: renderedAt)
         self.deliveryKPIs = .init(snapshot: snapshot, renderedAt: renderedAt)
+        self.growthUsage = .init(snapshot: snapshot)
         self.audienceTargeting = .init(snapshot: snapshot, renderedAt: renderedAt)
         self.modelArtifacts = .init(snapshot: snapshot, renderedAt: renderedAt)
         self.operatorContext = .init(snapshot: snapshot)
@@ -708,6 +753,17 @@ public struct OperatorDashboardRedLightsSectionResponse: Content, Sendable {
         self.staleActiveSeriesCount = .init(
             refreshedAt: snapshot.standardRefreshedAt,
             metric: snapshot.staleActiveSeries
+        )
+    }
+}
+
+public struct OperatorDashboardGrowthUsageSectionResponse: Content, Sendable {
+    public var installationGrowth: InstallationGrowthMetricResponse
+
+    init(snapshot: OperatorDashboardStoredSnapshot) {
+        self.installationGrowth = .init(
+            refreshedAt: snapshot.slowRefreshedAt,
+            metric: snapshot.installationGrowth
         )
     }
 }
@@ -1085,6 +1141,41 @@ public struct TargetableCoverageBreakdownResponse: Content, Sendable {
     public var staleInstallationHeartbeatCount: Int
     public var stalePresenceCount: Int
     public var missingTargetingDataCount: Int
+}
+
+public struct MonthlyInstallationGrowthResponse: Content, Sendable {
+    public var monthStart: Date
+    public var newInstallationCount: Int
+    public var cumulativeInstallationCount: Int
+}
+
+public struct InstallationGrowthMetricResponse: Content, Sendable {
+    public var refreshedAt: Date?
+    public var knownInstallationCount: Int
+    public var newThisMonthCount: Int
+    public var currentlySubscribedCount: Int
+    public var seenLast24HoursCount: Int
+    public var seenLast24HoursRate: Double?
+    public var monthlyGrowth: [MonthlyInstallationGrowthResponse]
+
+    init(refreshedAt: Date?, metric: StoredInstallationGrowthMetric) {
+        self.refreshedAt = refreshedAt
+        self.knownInstallationCount = metric.knownInstallationCount
+        self.newThisMonthCount = metric.newThisMonthCount
+        self.currentlySubscribedCount = metric.currentlySubscribedCount
+        self.seenLast24HoursCount = metric.seenLast24HoursCount
+        self.seenLast24HoursRate = OperatorDashboardCalculations.rate(
+            numerator: metric.seenLast24HoursCount,
+            denominator: metric.knownInstallationCount
+        )
+        self.monthlyGrowth = metric.monthlyGrowth.map {
+            .init(
+                monthStart: $0.monthStart,
+                newInstallationCount: $0.newInstallationCount,
+                cumulativeInstallationCount: $0.cumulativeInstallationCount
+            )
+        }
+    }
 }
 
 public struct TargetableCoverageMetricResponse: Content, Sendable {

--- a/Sources/App/lib/OperatorDashboardPageRenderer.swift
+++ b/Sources/App/lib/OperatorDashboardPageRenderer.swift
@@ -412,6 +412,18 @@ enum OperatorDashboardPageRenderer {
             </section>
 
             <section class="section">
+              <h2>Growth / Usage</h2>
+              <div class="grid">
+                \(slot("known-installations-card", content: knownInstallationsCard(snapshot.growthUsage.installationGrowth)))
+                \(slot("new-installations-card", content: newInstallationsCard(snapshot.growthUsage.installationGrowth)))
+                \(slot("recent-server-activity-card", content: recentServerActivityCard(snapshot.growthUsage.installationGrowth)))
+              </div>
+              <div class="stack" style="margin-top: 16px;">
+                \(slot("installation-growth-table", content: installationGrowthTable(snapshot.growthUsage.installationGrowth)))
+              </div>
+            </section>
+
+            <section class="section">
               <h2>Model Artifacts</h2>
               <div class="grid">
                 \(slot("pressure-artifact-readiness-card", content: pressureArtifactReadinessCard(snapshot.modelArtifacts.pressureArtifactReadiness)))
@@ -595,6 +607,19 @@ enum OperatorDashboardPageRenderer {
             return `${dayDifference} days ago ${timeText}`;
           }
 
+          function formatMonth(value) {
+            const date = parseDateValue(value);
+            if (!date) {
+              return 'n/a';
+            }
+
+            return new Intl.DateTimeFormat('en-US', {
+              month: 'long',
+              year: 'numeric',
+              timeZone: 'UTC'
+            }).format(date);
+          }
+
           function formatDuration(value) {
             if (value === null || value === undefined || Number.isNaN(Number(value))) {
               return 'n/a';
@@ -709,6 +734,62 @@ enum OperatorDashboardPageRenderer {
             return renderCard('Stale active series', String(metric.count), metric.refreshedAt, [
               { label: 'Grace window', value: formatDuration(metric.graceSeconds) }
             ]);
+          }
+
+          function renderKnownInstallationsCard(metric) {
+            const previousMonth = metric.monthlyGrowth.length > 1
+              ? metric.monthlyGrowth[metric.monthlyGrowth.length - 2]
+              : null;
+            return renderCard('Known Installations', String(metric.knownInstallationCount), metric.refreshedAt, [
+              { label: 'Through last month', value: previousMonth ? String(previousMonth.cumulativeInstallationCount) : 'n/a' },
+              { label: 'Currently subscribed', value: String(metric.currentlySubscribedCount) }
+            ]);
+          }
+
+          function renderNewInstallationsCard(metric) {
+            const currentMonth = metric.monthlyGrowth.at(-1);
+            return renderCard('New This Month', String(metric.newThisMonthCount), metric.refreshedAt, [
+              { label: 'Month', value: formatMonth(currentMonth?.monthStart) }
+            ]);
+          }
+
+          function renderRecentServerActivityCard(metric) {
+            return renderCard('Seen Last 24h — Server Activity', String(metric.seenLast24HoursCount), metric.refreshedAt, [
+              { label: 'Share of known', value: formatPercent(metric.seenLast24HoursRate) },
+              { label: 'Interpretation', value: 'Operational activity, not DAU' }
+            ]);
+          }
+
+          function renderInstallationGrowthTable(metric) {
+            const rows = Array.isArray(metric.monthlyGrowth) ? metric.monthlyGrowth : [];
+            const body = rows.length === 0
+              ? '<div class="empty">No installation growth history.</div>'
+              : `
+                <div class="table-wrap">
+                  <table class="stream-table inline-mobile-table">
+                    <thead><tr><th>Month</th><th>New installations</th><th>Cumulative total</th></tr></thead>
+                    <tbody>
+                      ${rows.map((entry) => `
+                        <tr>
+                          <td data-label="Month">${escapeHtml(formatMonth(entry.monthStart))}</td>
+                          <td data-label="New installations">${escapeHtml(entry.newInstallationCount)}</td>
+                          <td data-label="Cumulative total">${escapeHtml(entry.cumulativeInstallationCount)}</td>
+                        </tr>
+                      `).join('')}
+                    </tbody>
+                  </table>
+                </div>
+              `;
+
+            return `
+              <div class="card table-card">
+                <div style="padding: 18px 18px 0;">
+                  <h3>Monthly Installation Growth</h3>
+                  <div class="subtle">Refreshed ${escapeHtml(formatDate(metric.refreshedAt))}</div>
+                </div>
+                ${body}
+              </div>
+            `;
           }
 
           function renderLatencyCard(metric) {
@@ -1064,6 +1145,15 @@ enum OperatorDashboardPageRenderer {
             updateSlot('pipeline-backlog-card', refreshKey(snapshot.redLights.pipelineBacklogAge.refreshedAt), renderPipelineBacklogCard(snapshot.redLights.pipelineBacklogAge));
             updateSlot('stuck-claimed-card', refreshKey(snapshot.redLights.stuckClaimedRows.refreshedAt), renderStuckClaimedCard(snapshot.redLights.stuckClaimedRows));
             updateSlot('stale-series-card', refreshKey(snapshot.redLights.staleActiveSeriesCount.refreshedAt), renderStaleSeriesCard(snapshot.redLights.staleActiveSeriesCount));
+            updateSlot('known-installations-card', refreshKey(snapshot.growthUsage.installationGrowth.refreshedAt), renderKnownInstallationsCard(snapshot.growthUsage.installationGrowth));
+            updateSlot('new-installations-card', refreshKey(snapshot.growthUsage.installationGrowth.refreshedAt), renderNewInstallationsCard(snapshot.growthUsage.installationGrowth));
+            updateSlot('recent-server-activity-card', refreshKey(snapshot.growthUsage.installationGrowth.refreshedAt), renderRecentServerActivityCard(snapshot.growthUsage.installationGrowth));
+            updateSlot(
+              'installation-growth-table',
+              refreshKey(snapshot.growthUsage.installationGrowth.refreshedAt),
+              renderInstallationGrowthTable(snapshot.growthUsage.installationGrowth),
+              { streamRows: true, streamDelayStepMs: 28 }
+            );
             updateSlot(
               'pressure-artifact-readiness-card',
               refreshKey(snapshot.modelArtifacts?.pressureArtifactReadiness?.refreshedAt),
@@ -1230,6 +1320,77 @@ enum OperatorDashboardPageRenderer {
             refreshedAt: metric.refreshedAt,
             lines: [("Grace window", maybeDuration(metric.graceSeconds))]
         )
+    }
+
+    private static func knownInstallationsCard(_ metric: InstallationGrowthMetricResponse) -> String {
+        let previousMonthTotal = metric.monthlyGrowth.dropLast().last?.cumulativeInstallationCount
+        return card(
+            title: "Known Installations",
+            primary: "\(metric.knownInstallationCount)",
+            refreshedAt: metric.refreshedAt,
+            lines: [
+                ("Through last month", previousMonthTotal.map(String.init) ?? "n/a"),
+                ("Currently subscribed", "\(metric.currentlySubscribedCount)")
+            ]
+        )
+    }
+
+    private static func newInstallationsCard(_ metric: InstallationGrowthMetricResponse) -> String {
+        card(
+            title: "New This Month",
+            primary: "\(metric.newThisMonthCount)",
+            refreshedAt: metric.refreshedAt,
+            lines: [
+                ("Month", metric.monthlyGrowth.last.map { formatMonth($0.monthStart) } ?? "n/a")
+            ]
+        )
+    }
+
+    private static func recentServerActivityCard(_ metric: InstallationGrowthMetricResponse) -> String {
+        card(
+            title: "Seen Last 24h — Server Activity",
+            primary: "\(metric.seenLast24HoursCount)",
+            refreshedAt: metric.refreshedAt,
+            lines: [
+                ("Share of known", maybePercent(metric.seenLast24HoursRate)),
+                ("Interpretation", "Operational activity, not DAU")
+            ]
+        )
+    }
+
+    private static func installationGrowthTable(_ metric: InstallationGrowthMetricResponse) -> String {
+        let body = metric.monthlyGrowth.isEmpty
+            ? #"<div class="empty">No installation growth history.</div>"#
+            : """
+              <div class="table-wrap">
+                <table class="stream-table inline-mobile-table">
+                  <thead><tr><th>Month</th><th>New installations</th><th>Cumulative total</th></tr></thead>
+                  <tbody>
+                    \(metric.monthlyGrowth.map(installationGrowthRow).joined())
+                  </tbody>
+                </table>
+              </div>
+            """
+
+        return """
+        <div class="card table-card">
+          <div style="padding: 18px 18px 0;">
+            <h3>Monthly Installation Growth</h3>
+            <div class="subtle">Refreshed \(escape(maybeDate(metric.refreshedAt)))</div>
+          </div>
+          \(body)
+        </div>
+        """
+    }
+
+    private static func installationGrowthRow(_ entry: MonthlyInstallationGrowthResponse) -> String {
+        """
+        <tr>
+          <td data-label="Month">\(escape(formatMonth(entry.monthStart)))</td>
+          <td data-label="New installations">\(entry.newInstallationCount)</td>
+          <td data-label="Cumulative total">\(entry.cumulativeInstallationCount)</td>
+        </tr>
+        """
     }
 
     private static func latencyCard(_ metric: EndToEndLatencyMetricResponse) -> String {
@@ -1634,6 +1795,10 @@ enum OperatorDashboardPageRenderer {
         return String(format: "%.1f%%", percent)
     }
 
+    private static func formatMonth(_ date: Date) -> String {
+        DateFormatter.dashboardMonthFormatter.string(from: date)
+    }
+
     private static func formatDuration(_ seconds: Int) -> String {
         if seconds < 60 {
             return "\(seconds)s"
@@ -1697,6 +1862,14 @@ enum OperatorDashboardPageRenderer {
 }
 
 private extension DateFormatter {
+    static let dashboardMonthFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "MMMM yyyy"
+        return formatter
+    }()
+
     static let dashboardTimeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")

--- a/Sources/App/lib/OperatorDashboardSnapshotRefresher.swift
+++ b/Sources/App/lib/OperatorDashboardSnapshotRefresher.swift
@@ -59,6 +59,7 @@ struct OperatorDashboardSnapshotRefresher {
         if slowDue {
             snapshot.endToEndLatency = try await loadEndToEndLatency(on: sql, now: now)
             snapshot.apnsDelivery = try await loadAPNsDelivery(on: sql, now: now)
+            snapshot.installationGrowth = try await loadInstallationGrowth(on: sql, now: now)
             snapshot.targetableCoverage = try await loadTargetableCoverage(on: sql, now: now)
             snapshot.slowRefreshedAt = now
         }
@@ -350,6 +351,82 @@ struct OperatorDashboardSnapshotRefresher {
                 stalePresenceCount: row.map { Int($0.stalePresenceCount) } ?? 0,
                 missingTargetingDataCount: row.map { Int($0.missingTargetingDataCount) } ?? 0
             )
+        )
+    }
+
+    func loadInstallationGrowth(on sql: any SQLDatabase, now: Date) async throws -> StoredInstallationGrowthMetric {
+        let rows = try await sql.raw("""
+            WITH bounds AS (
+                SELECT
+                    date_trunc('month', \(bind: now) AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' AS current_month_start,
+                    \(bind: now) AS observed_at
+            ),
+            months AS (
+                SELECT generate_series(
+                    current_month_start - INTERVAL '11 months',
+                    current_month_start,
+                    INTERVAL '1 month'
+                ) AS month_start
+                FROM bounds
+            ),
+            monthly_new AS (
+                SELECT
+                    months.month_start,
+                    COUNT(i.installation_id) AS new_installation_count
+                FROM months
+                LEFT JOIN device_installations i
+                  ON i.created_at >= months.month_start
+                 AND i.created_at < months.month_start + INTERVAL '1 month'
+                GROUP BY months.month_start
+            ),
+            prior_total AS (
+                SELECT COUNT(*) AS count
+                FROM device_installations, bounds
+                WHERE created_at < current_month_start - INTERVAL '11 months'
+            ),
+            current_state AS (
+                SELECT
+                    COUNT(*) AS known_installation_count,
+                    COUNT(*) FILTER (
+                        WHERE is_active = TRUE AND is_subscribed = TRUE
+                    ) AS currently_subscribed_count,
+                    COUNT(*) FILTER (
+                        WHERE last_seen_at >= observed_at - INTERVAL '24 hours'
+                    ) AS seen_last_24_hours_count
+                FROM device_installations, bounds
+            )
+            SELECT
+                monthly_new.month_start AS "monthStart",
+                monthly_new.new_installation_count AS "newInstallationCount",
+                (
+                    prior_total.count
+                        + SUM(monthly_new.new_installation_count) OVER (ORDER BY monthly_new.month_start)
+                )::BIGINT AS "cumulativeInstallationCount",
+                current_state.known_installation_count AS "knownInstallationCount",
+                current_state.currently_subscribed_count AS "currentlySubscribedCount",
+                current_state.seen_last_24_hours_count AS "seenLast24HoursCount"
+            FROM monthly_new
+            CROSS JOIN prior_total
+            CROSS JOIN current_state
+            ORDER BY monthly_new.month_start
+        """).all(decoding: InstallationGrowthRow.self)
+
+        guard let currentMonth = rows.last else {
+            return .init()
+        }
+
+        return .init(
+            knownInstallationCount: Int(currentMonth.knownInstallationCount),
+            newThisMonthCount: Int(currentMonth.newInstallationCount),
+            currentlySubscribedCount: Int(currentMonth.currentlySubscribedCount),
+            seenLast24HoursCount: Int(currentMonth.seenLast24HoursCount),
+            monthlyGrowth: rows.map {
+                .init(
+                    monthStart: $0.monthStart,
+                    newInstallationCount: Int($0.newInstallationCount),
+                    cumulativeInstallationCount: Int($0.cumulativeInstallationCount)
+                )
+            }
         )
     }
 
@@ -831,6 +908,15 @@ private struct TargetableCoverageRow: Decodable {
     let missingTargetingDataCount: Int64
     let candidateQueryEligibleInstallationCount: Int64
     let hardStalePresenceCount: Int64
+}
+
+private struct InstallationGrowthRow: Decodable {
+    let monthStart: Date
+    let newInstallationCount: Int64
+    let cumulativeInstallationCount: Int64
+    let knownInstallationCount: Int64
+    let currentlySubscribedCount: Int64
+    let seenLast24HoursCount: Int64
 }
 
 private struct H3AggregateRow: Decodable {

--- a/Tests/AppTests/OperatorDashboardInstallationGrowthTests.swift
+++ b/Tests/AppTests/OperatorDashboardInstallationGrowthTests.swift
@@ -1,0 +1,127 @@
+@testable import App
+import Fluent
+import FluentSQL
+import Foundation
+import Testing
+import Vapor
+
+@Suite("Operator dashboard installation growth", .serialized)
+struct OperatorDashboardInstallationGrowthTests {
+    private enum Rollback: Error {
+        case afterAssertions
+    }
+
+    private let now = Date(timeIntervalSince1970: 1_775_649_600) // 2026-04-08T12:00:00Z
+
+    private func withApp(test: @escaping @Sendable (any Database) async throws -> Void) async throws {
+        let app = try await Application.make(.testing)
+        do {
+            try await configure(app, mode: .api)
+            do {
+                try await app.db.transaction { database in
+                    guard let sql = database as? any SQLDatabase else {
+                        throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+                    }
+
+                    try await sql.raw("""
+                        CREATE TEMPORARY TABLE device_installations (
+                            installation_id UUID PRIMARY KEY,
+                            created_at TIMESTAMPTZ NOT NULL,
+                            last_seen_at TIMESTAMPTZ NOT NULL,
+                            is_active BOOLEAN NOT NULL,
+                            is_subscribed BOOLEAN NOT NULL
+                        ) ON COMMIT DROP
+                    """).run()
+                    try await test(database)
+                    throw Rollback.afterAssertions
+                }
+            } catch Rollback.afterAssertions {
+                // Expected: keep shared integration-test tables unchanged.
+            }
+        } catch {
+            try? await app.asyncShutdown()
+            throw error
+        }
+        try await app.asyncShutdown()
+    }
+
+    private func date(_ value: String) -> Date {
+        guard let date = ISO8601DateFormatter().date(from: value) else {
+            fatalError("Invalid date fixture: \(value)")
+        }
+        return date
+    }
+
+    private func seedInstallation(
+        createdAt: Date,
+        lastSeenAt: Date,
+        isActive: Bool = true,
+        isSubscribed: Bool = true,
+        on database: any Database
+    ) async throws {
+        guard let sql = database as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+        }
+
+        try await sql.raw("""
+            INSERT INTO device_installations
+                (installation_id, created_at, last_seen_at, is_active, is_subscribed)
+            VALUES
+                (\(bind: UUID()), \(bind: createdAt), \(bind: lastSeenAt),
+                 \(bind: isActive), \(bind: isSubscribed))
+        """).run()
+    }
+
+    @Test("growth aggregate respects UTC month boundaries and cumulative totals")
+    func growthAggregateRespectsMonthBoundariesAndCumulativeTotals() async throws {
+        try await withApp { database in
+            guard let sql = database as? any SQLDatabase else {
+                throw Abort(.internalServerError, reason: "Database is not SQLDatabase")
+            }
+            let activityCutoff = now.addingTimeInterval(-24 * 60 * 60)
+            try await seedInstallation(
+                createdAt: date("2025-04-30T23:59:59Z"),
+                lastSeenAt: activityCutoff.addingTimeInterval(-1),
+                on: database
+            )
+            try await seedInstallation(
+                createdAt: date("2025-05-01T00:00:00Z"),
+                lastSeenAt: activityCutoff,
+                on: database
+            )
+            try await seedInstallation(
+                createdAt: date("2026-03-31T23:59:59Z"),
+                lastSeenAt: activityCutoff.addingTimeInterval(-1),
+                isActive: false,
+                on: database
+            )
+            try await seedInstallation(
+                createdAt: date("2026-04-01T00:00:00Z"),
+                lastSeenAt: now,
+                isSubscribed: false,
+                on: database
+            )
+            try await seedInstallation(
+                createdAt: date("2026-04-08T11:59:59Z"),
+                lastSeenAt: now,
+                on: database
+            )
+
+            let metric = try await OperatorDashboardSnapshotRefresher()
+                .loadInstallationGrowth(on: sql, now: now)
+
+            #expect(metric.knownInstallationCount == 5)
+            #expect(metric.newThisMonthCount == 2)
+            #expect(metric.currentlySubscribedCount == 3)
+            #expect(metric.seenLast24HoursCount == 3)
+            #expect(metric.monthlyGrowth.count == 12)
+            #expect(metric.monthlyGrowth.first?.monthStart == date("2025-05-01T00:00:00Z"))
+            #expect(metric.monthlyGrowth.first?.newInstallationCount == 1)
+            #expect(metric.monthlyGrowth.first?.cumulativeInstallationCount == 2)
+            #expect(metric.monthlyGrowth[10].newInstallationCount == 1)
+            #expect(metric.monthlyGrowth[10].cumulativeInstallationCount == 3)
+            #expect(metric.monthlyGrowth.last?.newInstallationCount == 2)
+            #expect(metric.monthlyGrowth.last?.cumulativeInstallationCount == 5)
+        }
+    }
+}

--- a/Tests/AppTests/OperatorDashboardTests.swift
+++ b/Tests/AppTests/OperatorDashboardTests.swift
@@ -99,6 +99,24 @@ struct OperatorDashboardTests {
                 candidateResolutionAttemptCount: 24,
                 zeroCandidateAttemptCount: 6
             ),
+            installationGrowth: .init(
+                knownInstallationCount: 40,
+                newThisMonthCount: 4,
+                currentlySubscribedCount: 31,
+                seenLast24HoursCount: 27,
+                monthlyGrowth: [
+                    .init(
+                        monthStart: isoDate("2026-03-01T00:00:00Z"),
+                        newInstallationCount: 6,
+                        cumulativeInstallationCount: 36
+                    ),
+                    .init(
+                        monthStart: isoDate("2026-04-01T00:00:00Z"),
+                        newInstallationCount: 4,
+                        cumulativeInstallationCount: 40
+                    )
+                ]
+            ),
             targetableCoverage: .init(
                 installationFreshnessSeconds: 86_400,
                 presenceFreshnessSeconds: 21_600,
@@ -190,6 +208,7 @@ struct OperatorDashboardTests {
         #expect(abs((response.deliveryKPIs.apnsDeliverySuccessRate.successRate ?? 0) - 0.8) < 0.0001)
         #expect(abs((response.deliveryKPIs.sendNoOpRateByReason.noOpRate ?? 0) - 0.25) < 0.0001)
         #expect(abs((response.deliveryKPIs.zeroCandidateRevisionRate.zeroCandidateRate ?? 0) - 0.25) < 0.0001)
+        #expect(abs((response.growthUsage.installationGrowth.seenLast24HoursRate ?? 0) - 0.675) < 0.0001)
         #expect(abs((response.audienceTargeting.freshTargetableInstallationCoverage.targetableRate ?? 0) - 0.61) < 0.0001)
         #expect(abs((response.audienceTargeting.freshTargetableInstallationCoverage.candidateQueryEligibilityRate ?? 0) - 0.74) < 0.0001)
         #expect(abs((response.audienceTargeting.alertsWithGeographyAndH3Success.successRate ?? 0) - 0.8333333333) < 0.0001)
@@ -292,6 +311,8 @@ struct OperatorDashboardTests {
         #expect(snapshot.targetableCoverage.hardStalePresenceThresholdSeconds == Int(LocationFreshnessPolicy.hardStaleThreshold))
         #expect(snapshot.targetableCoverage.candidateQueryEligibleInstallationCount == 0)
         #expect(snapshot.targetableCoverage.hardStalePresenceCount == 0)
+        #expect(snapshot.installationGrowth.knownInstallationCount == 0)
+        #expect(snapshot.installationGrowth.monthlyGrowth.isEmpty)
     }
 
     @Test("legacy snapshot backfills touched-series fields")
@@ -334,6 +355,9 @@ struct OperatorDashboardTests {
                 #expect(payload.operatorContext.lastTouchedSeries.entries.first?.ugcCodes == ["COC005", "COC013"])
                 #expect(payload.operatorContext.lastTouchedSeries.entries.first?.tornadoDetection == "OBSERVED")
                 #expect(payload.operatorContext.lastTouchedSeries.entries.first?.tornadoDamageThreat == "CONSIDERABLE")
+                #expect(payload.growthUsage.installationGrowth.knownInstallationCount == 40)
+                #expect(payload.growthUsage.installationGrowth.currentlySubscribedCount == 31)
+                #expect(payload.growthUsage.installationGrowth.monthlyGrowth.last?.cumulativeInstallationCount == 40)
                 let coverage = payload.audienceTargeting.freshTargetableInstallationCoverage
                 #expect(coverage.hardStalePresenceThresholdSeconds == 86_400)
                 #expect(coverage.candidateQueryEligibleInstallationCount == 74)
@@ -353,6 +377,13 @@ struct OperatorDashboardTests {
                 #expect(res.headers.contentType == .html)
                 #expect(res.body.string.contains("Red Lights"))
                 #expect(res.body.string.contains("Delivery KPIs"))
+                #expect(res.body.string.contains("Growth / Usage"))
+                #expect(res.body.string.contains("Known Installations"))
+                #expect(res.body.string.contains("New This Month"))
+                #expect(res.body.string.contains("Seen Last 24h — Server Activity"))
+                #expect(res.body.string.contains("Operational activity, not DAU"))
+                #expect(res.body.string.contains("Monthly Installation Growth"))
+                #expect(res.body.string.contains("April 2026"))
                 #expect(res.body.string.contains("Audience / Targeting"))
                 #expect(res.body.string.contains("Operator Context"))
                 #expect(res.body.string.contains("Arcus Signal"))


### PR DESCRIPTION
# Summary
This branch adds installation growth metrics to the operator dashboard using the existing `device_installations` data. It stores the new aggregate in the dashboard snapshot, refreshes it on the slow path, and renders a new Growth / Usage section with the current counts and 12-month history.

# What Changed
- Added an installation-growth snapshot metric with known installations, new this month, currently subscribed, recent server activity, and monthly growth rows.
- Extended the slow dashboard refresh path to aggregate growth data from `device_installations`.
- Rendered a new Growth / Usage section with three summary cards and a monthly growth table on the operator dashboard.
- Added tests for month-boundary aggregation, response decoding, and dashboard rendering.
- Kept historical growth counts based on `created_at`, while treating recent activity as operational server activity rather than DAU.

# User Impact
Operators can now see installation growth and recent operational activity directly on the dashboard. This does not change app behavior for end users.

# Testing
- `swift test --filter OperatorDashboard` 19 tests in 4 suites passed.
- `swift build` passed.

# Notes
- The new recent-activity metric is labeled as operational server activity, not DAU/MAU.
- Historical install counts remain based on creation time rather than current subscription state.