### PR TITLE
Fix subprocess pipe descriptor cleanup

### DIFF
--- a/Sources/App/StormSetup/GribAdapter.swift
+++ b/Sources/App/StormSetup/GribAdapter.swift
@@ -42,10 +42,10 @@ struct ProcessRunner: Sendable {
         process.executableURL = executableURL
         process.arguments = arguments
 
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
+        let pipes = ProcessPipeResources()
+        defer { pipes.closeAll() }
+        process.standardOutput = pipes.stdoutPipe
+        process.standardError = pipes.stderrPipe
 
         let exitObservation = ProcessExitObservation()
         process.terminationHandler = { _ in
@@ -60,12 +60,12 @@ struct ProcessRunner: Sendable {
                 "Failed to launch \(executableURL.path): \(error.localizedDescription)"
             )
         }
-
         return try await withTaskCancellationHandler {
-            let stdoutReader = ProcessPipeReader(fileHandle: stdoutPipe.fileHandleForReading)
-            let stderrReader = ProcessPipeReader(fileHandle: stderrPipe.fileHandleForReading)
+            let stdoutReader = ProcessPipeReader(fileHandle: pipes.stdoutReadingHandle)
+            let stderrReader = ProcessPipeReader(fileHandle: pipes.stderrReadingHandle)
             async let stdoutData = stdoutReader.readToEnd()
             async let stderrData = stderrReader.readToEnd()
+            pipes.closeWritingEnds()
 
             let waitOutcome: WaitOutcome
             do {
@@ -171,6 +171,72 @@ struct ProcessRunner: Sendable {
             ) {
                 continuation.resume()
             }
+        }
+    }
+}
+
+private final class ProcessPipeResources: Sendable {
+    private struct State: Sendable {
+        var stdoutReadClosed = false
+        var stdoutWriteClosed = false
+        var stderrReadClosed = false
+        var stderrWriteClosed = false
+    }
+
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+
+    var stdoutReadingHandle: FileHandle { stdoutPipe.fileHandleForReading }
+    var stderrReadingHandle: FileHandle { stderrPipe.fileHandleForReading }
+
+    private let state = NIOLockedValueBox(State())
+
+    func closeWritingEnds() {
+        let handles = state.withLockedValue { state -> [FileHandle] in
+            var handles: [FileHandle] = []
+
+            if !state.stdoutWriteClosed {
+                state.stdoutWriteClosed = true
+                handles.append(stdoutPipe.fileHandleForWriting)
+            }
+            if !state.stderrWriteClosed {
+                state.stderrWriteClosed = true
+                handles.append(stderrPipe.fileHandleForWriting)
+            }
+
+            return handles
+        }
+
+        handles.forEach { $0.closeFile() }
+    }
+
+    func closeAll() {
+        let handles = state.withLockedValue { state -> [FileHandle] in
+            var handles: [FileHandle] = []
+
+            if !state.stdoutReadClosed {
+                state.stdoutReadClosed = true
+                handles.append(stdoutPipe.fileHandleForReading)
+            }
+            if !state.stdoutWriteClosed {
+                state.stdoutWriteClosed = true
+                handles.append(stdoutPipe.fileHandleForWriting)
+            }
+            if !state.stderrReadClosed {
+                state.stderrReadClosed = true
+                handles.append(stderrPipe.fileHandleForReading)
+            }
+            if !state.stderrWriteClosed {
+                state.stderrWriteClosed = true
+                handles.append(stderrPipe.fileHandleForWriting)
+            }
+
+            return handles
+        }
+
+        handles.forEach {
+            $0.readabilityHandler = nil
+            $0.closeFile()
         }
     }
 }

--- a/Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift
+++ b/Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift
@@ -778,6 +778,55 @@ struct NotificationSendJobDeliveryBoundaryTests {
             #expect(await sender.sendCount == 0)
         }
     }
+
+    @Test("dequeue persists stale revision mismatch without resolving candidates or sending")
+    func dequeuePersistsStaleRevisionMismatchWithoutResolvingCandidatesOrSending() async throws {
+        try await withIntegrationTestApplication(
+            setup: .directPostgres,
+            prepare: { app in try await bootstrapTables(on: app.db) }
+        ) { app in
+            let sender = RecordingNotificationSender()
+            let job = NotificationSendJob(sender: sender)
+            let context = makeQueueContext(app: app)
+            let seriesID = UUID()
+            let currentRevisionUrn = "urn:oid:current-dequeue-\(UUID().uuidString.lowercased())"
+            let staleRevisionUrn = "urn:oid:stale-dequeue-\(UUID().uuidString.lowercased())"
+            let payload = NotificationSendJobPayload(
+                seriesId: seriesID,
+                revisionUrn: staleRevisionUrn,
+                mode: .h3,
+                reason: .update
+            )
+
+            try await seedSeries(id: seriesID, revisionUrn: currentRevisionUrn, on: app.db)
+            try await seedRevision(seriesID: seriesID, revisionUrn: currentRevisionUrn, on: app.db)
+
+            try await job.dequeue(context, payload)
+
+            let attempts = try await NotificationSendAttemptModel.query(on: app.db)
+                .filter(\.$series.$id == seriesID)
+                .filter(\.$revisionUrn == staleRevisionUrn)
+                .all()
+            let ledgerCount = try await NotificationLedgerModel.query(on: app.db)
+                .filter(\.$series.$id == seriesID)
+                .filter(\.$revisionUrn == staleRevisionUrn)
+                .count()
+            #expect(attempts.count == 1)
+            #expect(ledgerCount == 0)
+
+            let attempt = try #require(attempts.first)
+            #expect(attempt.outcome == NotificationSendAttemptOutcome.noOp.rawValue)
+            #expect(attempt.noOpReason == NotificationSendNoOpReason.staleRevisionMismatch.rawValue)
+            #expect(attempt.mode == NotificationTargetMode.h3.rawValue)
+            #expect(attempt.reason == NotificationReason.update.rawValue)
+            #expect(attempt.candidateResolutionReached == false)
+            #expect(attempt.candidateCount == 0)
+            #expect(attempt.claimedCount == 0)
+            #expect(attempt.sentCount == 0)
+            #expect(attempt.failedCount == 0)
+            #expect(await sender.sendCount == 0)
+        }
+    }
 }
 
 private actor RecordingNotificationSender: NotificationSender {

--- a/Tests/AppTests/ProcessRunnerTests.swift
+++ b/Tests/AppTests/ProcessRunnerTests.swift
@@ -213,6 +213,43 @@ struct ProcessRunnerTests {
         }
     }
 
+    @Test("releases pipe descriptors after repeated success and timeout runs")
+    func releasesPipeDescriptorsAfterRepeatedRuns() async throws {
+        #if os(Linux)
+        let fixture = try makeFixture()
+        defer { fixture.remove() }
+
+        let baseline = try openFileDescriptorCount()
+
+        for _ in 0..<40 {
+            _ = try await ProcessRunner().run(
+                executableURL: fixture.executableURL,
+                arguments: ["success"],
+                timeoutSeconds: 1
+            )
+        }
+
+        for _ in 0..<20 {
+            do {
+                _ = try await ProcessRunner().run(
+                    executableURL: fixture.executableURL,
+                    arguments: fixture.waitingArguments(mode: "timeout"),
+                    timeoutSeconds: 0.1
+                )
+                Issue.record("Expected a timeout error.")
+            } catch let error as ProcessRunnerError {
+                guard case .timedOut = error else {
+                    Issue.record("Expected a timeout error, got \(error).")
+                    continue
+                }
+            }
+        }
+
+        let finalCount = try openFileDescriptorCount()
+        #expect(finalCount <= baseline + 12)
+        #endif
+    }
+
     private func makeFixture() throws -> FixtureContext {
         guard let bundledURL = Bundle.module.url(
             forResource: "ProcessRunnerFixture",
@@ -269,6 +306,10 @@ struct ProcessRunnerTests {
             return true
         }
         return errno == EPERM
+    }
+
+    private func openFileDescriptorCount() throws -> Int {
+        try FileManager.default.contentsOfDirectory(atPath: "/proc/self/fd").count
     }
 }
 

--- a/docs/audits/weekly-bug-scan.md
+++ b/docs/audits/weekly-bug-scan.md
@@ -617,3 +617,111 @@
 - Best next fix: constrain `markProbeFailure` to the probe-owned pending state and add deterministic ambiguous-dispatch regression tests
 - Implementation recommended: `yes`
 - Out-of-scope repositories intentionally not scanned: all sibling repositories
+
+## 2026-08-20
+
+### 1. Repository scanned
+- `arcus-signal`
+
+### 2. Commit window inspected
+- Reliable previous end marker: `8985a4d89e22b31bc6951acfbe3ba2886a973991` from the 2026-08-13 audit entry
+- Window used: commits after `8985a4d89e22b31bc6951acfbe3ba2886a973991` through `563bdb0d3f63df49a67f7d8fb20bad287811288b`
+- Dates: `2026-08-13T11:54:39-06:00` through `2026-08-13T16:46:49-06:00`
+- Commit count: 8
+- Start commit: `b5e08e633529b8028c49d344e5e42465debd38f2`
+- End commit: `563bdb0d3f63df49a67f7d8fb20bad287811288b`
+- Fallback strategy: none; the bounded window contained commits
+
+### 3. High-risk areas inspected
+- Authoritative installation/presence transition detection and transactional outbox creation (`Sources/App/Controllers/DeviceController.swift`, `Sources/App/Infrastructure/Notifications/PresenceReconciliationTrigger.swift`)
+- Durable reconciliation handoff, scheduled drain, and retry/idempotency behavior (`Sources/App/Models/Notification/PresenceReconciliationOutboxStore.swift`, `Sources/App/Jobs/DispatchPresenceReconciliationScheduledJob.swift`, `Sources/App/Jobs/ReconcileInstallationAlertsJob.swift`)
+- Active-alert H3/UGC matching and installation-constrained notification delivery (`Sources/App/Models/Notification/NotificationCandidateStore.swift`, `Sources/App/Jobs/NotificationSendJob.swift`)
+- Installation-growth dashboard aggregation and rendering (`Sources/App/lib/OperatorDashboardSnapshotRefresher.swift`, `Sources/App/lib/OperatorDashboardPageRenderer.swift`)
+
+### 4. Findings
+
+#### BUG-SIGNAL-PRESENCE-PREFERENCE-RECONCILIATION
+
+- Finding ID: `BUG-SIGNAL-PRESENCE-PREFERENCE-RECONCILIATION`
+- Fingerprint: `weekly-bug-scan|arcus-signal|DeviceController.createPreferences|usable-installation-transition-without-reconciliation-intent`
+- Repository: `arcus-signal`
+- Audit type: Weekly Bug Scan
+- Title: Preference sync can restore delivery eligibility without reconciling active alerts
+- Status: `NEW`
+- Severity: `MEDIUM`
+- Confidence: `MEDIUM`
+- First observed: `2026-08-20`
+- Last verified: `2026-08-20`
+- Affected files and symbols: `Sources/App/Controllers/DeviceController.swift` (`createPreferences`, `create`), `Sources/App/Infrastructure/Notifications/PresenceReconciliationTrigger.swift` (`decide`, `isUsable`)
+- Failure mode: The location-snapshot route captures previous installation/presence state, persists both, evaluates whether the installation became usable, transactionally inserts a reconciliation intent, and performs post-commit queue handoff. The preferences route can independently change `isSubscribed`, APNs token, or location authorization while fresh targetable presence already exists, but it only upserts `device_installations`. An unusable-to-usable preference transition therefore creates no reconciliation intent and does not rediscover matching active alerts until a later qualifying location snapshot.
+- Evidence: Commit `31651e819170697dc4f88374c38c3301c0315d1a` added transition evaluation to `DeviceController.create`. Current `DeviceController.swift` lines 108-186 contain previous/current state evaluation, transactional intent creation, and handoff for location snapshots; lines 267-281 show `createPreferences` only updating the installation. `PresenceReconciliationTrigger.swift` lines 65-99 explicitly treats subscription, activity, APNs token, and location authorization as usability gates and returns `becameUsable` for recovery. Existing controller tests exercise a subscription recovery only through the location-snapshot route; no preference-sync test covers existing fresh presence.
+- Blast radius: Users who restore notification eligibility through preference sync can miss already-active severe-weather alerts matching their stored location. Future alert revisions still use the alert-driven path, and a later qualifying location heartbeat can recover the gap.
+- Minimal fix strategy: Apply the existing previous/current state evaluation and transactional outbox insertion to the preferences route when fresh targetable presence exists, then use the existing post-commit handoff. Keep the slice controller-local and avoid worker or notification-pipeline changes.
+- Required validation: Route-level tests for unsubscribed-to-subscribed recovery with existing fresh presence, unchanged/no-op preference updates, unusable states, transaction rollback on intent failure, and queue-handoff failure retention; run `DeviceControllerTests` and `LocationDrivenAlertReconciliationFlowTests` with PostgreSQL available.
+- Related GitHub issue: creation attempted on `2026-08-20` but blocked because the GitHub connector required approval while the automation approval policy was `never`; no issue was created and no prohibited fallback was used.
+- Triage: `ACTIONABLE`
+
+### 5. Recurring findings
+- `BUG-SIGNAL-PRESSURE-PROBE-ENQUEUE-OVERWRITE` remains represented by open GitHub issue [#198](https://github.com/justinrooks/arcus-signal/issues/198). The bounded commit window did not touch its failure mechanism, so the normalized finding is not repeated.
+
+### 6. Watchlist
+- None. No additional candidate met the evidence threshold.
+
+### 7. Resolved findings
+- None re-verified in this bounded window.
+
+### 8. Top finding and best next fix
+- Top finding: `BUG-SIGNAL-PRESENCE-PREFERENCE-RECONCILIATION`.
+- Best next fix: make preference-sync usability recovery create and hand off the existing durable reconciliation intent.
+- Expected files: `Sources/App/Controllers/DeviceController.swift` and `Tests/AppTests/DeviceControllerTests.swift`.
+- Estimated churn: small, approximately 40-90 LOC.
+- Regression risk: low to medium; preserve transactional intent insertion and avoid duplicate intents for unchanged preferences.
+- Implementation recommended: `yes`
+
+### 9. Validation
+- Static execution-path inspection completed for all eight commits and the focused production/test files listed below.
+- `swift test --filter DeviceControllerTests` attempted; build passed, but all 12 selected tests were blocked by unavailable PostgreSQL at `127.0.0.1:5432` (`connection refused`).
+- Later focused suites in the chained command did not run after the first suite failed.
+
+### 10. GitHub triage
+- Deduplication searches by finding mechanism, route symbol, and impact found no equivalent issue.
+- GitHub issues created: none; the authorized creation attempt failed because the GitHub connector required approval under an approval policy of `never`.
+- GitHub issues updated: none.
+- Existing issues referenced: [#198](https://github.com/justinrooks/arcus-signal/issues/198).
+
+### 11. Files inspected
+- `Sources/App/Controllers/DeviceController.swift`
+- `Sources/App/Infrastructure/Notifications/PresenceReconciliationTrigger.swift`
+- `Sources/App/Jobs/DispatchPresenceReconciliationScheduledJob.swift`
+- `Sources/App/Jobs/NotificationSendJob.swift`
+- `Sources/App/Jobs/ReconcileInstallationAlertsJob.swift`
+- `Sources/App/Migrations/CreatePresenceReconciliationOutbox.swift`
+- `Sources/App/Models/Notification/NotificationCandidateStore.swift`
+- `Sources/App/Models/Notification/PresenceReconciliationOutboxStore.swift`
+- `Sources/App/configure.swift`
+- `Sources/App/lib/OperatorDashboardPageRenderer.swift`
+- `Sources/App/lib/OperatorDashboardSnapshotRefresher.swift`
+- `Tests/AppTests/DeviceControllerTests.swift`
+- `Tests/AppTests/InstallationAlertReconciliationJobTests.swift`
+- `Tests/AppTests/LocationDrivenAlertReconciliationFlowTests.swift`
+- `Tests/AppTests/NotificationActiveAlertQueryTests.swift`
+- `Tests/AppTests/PresenceReconciliationOutboxTests.swift`
+- `Tests/AppTests/PresenceReconciliationTriggerTests.swift`
+- `docs/architecture.md`
+
+### 12. Scope notes
+- Repository scanned: `arcus-signal` only.
+- Out-of-scope repositories: all sibling repositories and external clients were intentionally not scanned.
+- Skipped evidence: no cross-repository claims were evaluated or included.
+
+### Audit entry (short)
+- Date: `2026-08-20`
+- Repository reviewed: `arcus-signal`
+- Workflow reviewed: weekly bug scan (audit-only, commits since the reliable previous end marker)
+- Commit window inspected: `b5e08e633529b8028c49d344e5e42465debd38f2` through `563bdb0d3f63df49a67f7d8fb20bad287811288b`; 8 commits
+- Files inspected: presence transition policy, API persistence/intent boundary, reconciliation handoff and worker, active-alert matching, constrained notification delivery, installation-growth dashboard, and focused tests listed above
+- Top finding: preference sync can restore delivery eligibility without reconciling already-active alerts
+- Best next fix: apply the existing transactional transition/intent pattern to `createPreferences` and add route-level regression coverage
+- Implementation recommended: `yes`
+- GitHub issue creation: attempted but blocked by connector approval requirements; no issue created
+- Out-of-scope repositories intentionally not scanned: all sibling repositories

--- a/docs/audits/weekly-test-gap-audit.md
+++ b/docs/audits/weekly-test-gap-audit.md
@@ -278,3 +278,47 @@
   - the delayed-startup-grace recovery-failure branch asynchronously shuts down the worker and lacks a direct lifecycle test; promote only if that branch changes or a deterministic shutdown harness becomes available, because the same recovery-before-consumer and failure-stop invariants are already covered through the zero-grace path
 - Implementation recommended: no
 - Out-of-scope repositories intentionally not scanned: all sibling repositories and external HRRR, Redis, PostgreSQL, and Vapor Queues implementations
+
+## 2026-08-25
+- Repository reviewed: `arcus-signal`
+- Commit window inspected: no commits after the last automation run (`2026-08-18T15:00:27.570Z` through `2026-08-25`); `HEAD` remains `563bdb0d3f63df49a67f7d8fb20bad287811288b` from 2026-08-13, so the audit used current-state inspection of three high-risk areas
+- High-risk areas inspected:
+  - installation/presence reconciliation intent durability, latest-presence lookup, active-alert matching, constrained send dispatch, retries, and alert/location discovery races
+  - notification send-boundary revision and lifecycle suppression, installation constraints, freshness gating, ledger claims, APNs completion, and attempt telemetry
+  - NWS lifecycle derivation and transactional event/revision persistence, deterministic lineage merging, dispatch-intent creation, and rollback
+- Files inspected:
+  - `Sources/App/Jobs/ReconcileInstallationAlertsJob.swift`
+  - `Sources/App/Models/Notification/PresenceReconciliationOutboxStore.swift`
+  - `Sources/App/Models/Notification/NotificationCandidateStore.swift`
+  - `Sources/App/Jobs/NotificationSendJob.swift`
+  - `Sources/App/Services/NWSIngestPersistence.swift`
+  - `Tests/AppTests/LocationDrivenAlertReconciliationFlowTests.swift`
+  - `Tests/AppTests/InstallationAlertReconciliationJobTests.swift`
+  - `Tests/AppTests/PresenceReconciliationOutboxTests.swift`
+  - `Tests/AppTests/NotificationActiveAlertQueryTests.swift`
+  - `Tests/AppTests/NotificationSendJobCandidateQueryTests.swift`
+  - `Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift`
+  - `Tests/AppTests/NWSIngestPersistenceFlowTests.swift`
+  - `Tests/AppTests/NWSAlertLifecycleTests.swift`
+- Existing relevant tests found:
+  - reconciliation coverage exercises meaningful entry/re-entry transitions, latest authoritative presence, H3/UGC matches, inactive/stale exclusion, duplicate drains, bounded retries, and alert/location discovery races converging on the ledger identity
+  - notification delivery-boundary coverage exercises stale/degraded/fresh candidates, duplicate claims, constrained/unconstrained races, sender failure persistence, inactive-series suppression, and legacy payload decoding
+  - NWS persistence coverage exercises exact geometry-specific intents, duplicate and out-of-order revisions, deterministic lineage merging, lifecycle expiry, and full transaction rollback
+- Recommended test gap:
+  - Behavior: `NotificationSendJob.dequeue` should suppress a queued payload when `payload.revisionUrn` no longer equals the series' current revision, avoid candidate resolution and APNs delivery, and persist exactly one send-attempt row with `noOpReason == staleRevisionMismatch`
+  - Repository: `arcus-signal`
+  - Evidence: the early-return branch in `Sources/App/Jobs/NotificationSendJob.swift`; adjacent `Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift` covers inactive-series suppression but contains no assertion for `staleRevisionMismatch`
+  - Risk reduced: prevents regressions that deliver superseded severe-weather copy and verifies the telemetry needed to distinguish safe queue staleness from a lost send
+  - Test type: integration
+  - Suggested test name: `dequeuePersistsStaleRevisionMismatchWithoutResolvingCandidatesOrSending`
+  - Minimal setup: seed a series and current revision, invoke `dequeue` with an older revision URN and a recording sender, then query send-attempt rows
+  - Expected assertion: sender count remains zero, no ledger row is claimed, candidate resolution remains false, counts remain zero, and exactly one attempt records `staleRevisionMismatch`
+  - Size: XS
+  - Confidence: Medium
+- Top recommended test: add the stale-revision mismatch dequeue test to `Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift`; expected churn is roughly 25-45 lines in one test file with low regression risk
+- Watchlist items:
+  - `NotificationSendJob.dequeue` also records `missingGeolocation` for H3 work without usable geometry. Promote only if that branch changes or operational evidence shows unexplained H3 no-op attempts; current repository evidence does not establish comparable product risk.
+- Implementation recommended: no — implemented on 2026-08-26 by `Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift`
+- Implementation status: `dequeuePersistsStaleRevisionMismatchWithoutResolvingCandidatesOrSending` now verifies stale-revision suppression, zero candidate resolution, zero ledger claims and sends, and persisted `staleRevisionMismatch` attempt telemetry
+- Validation: `swift test --filter NotificationSendJobDeliveryBoundaryTests` (9 executed, 9 passed, 0 failed, 0 skipped)
+- Out-of-scope repositories intentionally not scanned: all sibling repositories and external NWS, APNs, Redis, and PostgreSQL implementations

--- a/postman/collections/Arcus Signal API/.resources/definition.yaml
+++ b/postman/collections/Arcus Signal API/.resources/definition.yaml
@@ -2,15 +2,15 @@ $kind: collection
 name: Arcus Signal API
 description: Comprehensive endpoint coverage for Arcus Signal API and worker health routes.
 variables:
-  apiBaseUrl: "http://localhost:8080"
-  workerBaseUrl: "http://localhost:8081"
+  apiBaseUrl: http://localhost:8080
+  workerBaseUrl: http://localhost:8081
   installationId: ""
-  apnsDeviceToken: "test-token-1234567890abcdef"
+  apnsDeviceToken: test-token-1234567890abcdef
   validH3Cell: "622236750694711295"
   validH3Resolution: "9"
-  sampleCounty: "COC001"
-  sampleForecast: "COZ041"
-  sampleFire: "COC001"
+  sampleCounty: COC001
+  sampleForecast: COZ041
+  sampleFire: COC001
   sampleArcusSeriesId: ""
   capturedAtNow: ""
   capturedAtFuture10m: ""


### PR DESCRIPTION
# Summary
Fixes subprocess pipe descriptor retention in Storm Setup, adds stale-revision send-boundary coverage, and records the related audit/test-gap evidence.

# What Changed
- Explicitly own and close stdout/stderr pipe endpoints for launched subprocesses, including launch failure, timeout, cancellation, successful exit, and non-zero exit paths.
- Add a Linux regression test that repeatedly exercises successful and timed-out subprocesses while asserting bounded descriptor usage.
- Add integration coverage that suppresses stale notification revisions before candidate resolution, ledger claims, or APNs delivery.
- Update weekly audit records and normalize Postman collection scalar formatting.

# User Impact
Storm Setup subprocesses no longer accumulate pipe descriptors until API or worker availability is affected. Superseded notification revisions remain suppressed and are recorded as safe no-op attempts.

# Testing
- `swift test --filter ProcessRunnerTests` — 10 tests passed.
- `swift test --filter NotificationSendJobDeliveryBoundaryTests` — 9 tests passed (recorded in the committed audit).
- Full `swift test` was attempted locally but database-backed tests could not connect to the intentionally unavailable local PostgreSQL instance.

# Notes
- The descriptor-count regression is Linux-only because it reads `/proc/self/fd`.