### PR TITLE
Add canonical /v1 API routes while preserving /api compatibility

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "aa315d5dbc5ab681fe849bedd73f1275bfd5c635a9f82d03732c86407ee7e1dc",
+  "originHash" : "0c89b2040e2cc6f7b774a072eb5d884bdc1087f3511e082eb99c56c651e31dd7",
   "pins" : [
     {
       "identity" : "apns",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "4603a8036d921ea999fadb742931546c341f4bd7",
-        "version" : "1.35.0"
+        "revision" : "9544287b9416c0bc71e58b9f3aead8dd14b16103",
+        "version" : "1.36.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/console-kit.git",
       "state" : {
-        "revision" : "32ad16dfc7677b927b225595ed18f3debb32f577",
-        "version" : "4.16.0"
+        "revision" : "15121e1ec44a0a2064e43545d1390f02cc19b07d",
+        "version" : "4.16.1"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/postgres-kit.git",
       "state" : {
-        "revision" : "7c079553e9cda74811e627775bf22e40a9405ad9",
-        "version" : "2.15.1"
+        "revision" : "218aaf6810db9e61398f887aaaf26424142bdb53",
+        "version" : "2.16.1"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/postgres-nio.git",
       "state" : {
-        "revision" : "f2188e05ba3546a76e61a5193c071b82c4d69a45",
-        "version" : "1.33.0"
+        "revision" : "39ce38a93408937bcd27f521f3cdf88266136b80",
+        "version" : "1.33.1"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
-        "version" : "1.19.3"
+        "revision" : "449dbbecd0f31e82b510ada227ca152caa8b5e98",
+        "version" : "1.19.4"
       }
     },
     {
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
-        "version" : "4.5.0"
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
       }
     },
     {
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
-        "version" : "1.14.0"
+        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
+        "version" : "1.15.0"
       }
     },
     {
@@ -285,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "cd3e1152083706d77b223fb29110e590efcc70c0",
-        "version" : "2.101.2"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -303,8 +303,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
-        "version" : "1.44.0"
+        "revision" : "45bdf670248be5f16ec0340e125dca285536f0fb",
+        "version" : "1.45.0"
       }
     },
     {
@@ -312,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e",
-        "version" : "2.37.1"
+        "revision" : "d930168b86f46ca51a4bc09c5ca45c1833db8067",
+        "version" : "2.37.2"
       }
     },
     {
@@ -348,8 +348,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
       "state" : {
-        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
-        "version" : "2.11.0"
+        "revision" : "7f9326b0326ff86e3646295ea6e891f68c471c5e",
+        "version" : "2.12.0"
       }
     },
     {
@@ -357,8 +357,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "b5544ba79a70a0cb3563e75bf26dc198d6b40ed3",
-        "version" : "1.7.4"
+        "revision" : "869129b7bf4ecc57b97d0193ad29690ca2134750",
+        "version" : "1.8.1"
       }
     },
     {
@@ -366,8 +366,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pawelmajcher/SwiftyH3.git",
       "state" : {
-        "revision" : "6d9b5774cc7cc198597b14aaccf213587947678c",
-        "version" : "0.5.0"
+        "revision" : "d5091720769598f3747f0b86c597f3ff73c18e65",
+        "version" : "0.6.0"
       }
     },
     {
@@ -375,8 +375,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor.git",
       "state" : {
-        "revision" : "748ae8432a33e0965bbf0351fedd4e915e7f460c",
-        "version" : "4.122.0"
+        "revision" : "6f8091db7f159f966e028fbbc928cdcfa8597d59",
+        "version" : "4.122.1"
       }
     },
     {

--- a/Sources/App/Controllers/AirQualityController.swift
+++ b/Sources/App/Controllers/AirQualityController.swift
@@ -4,7 +4,9 @@ import Vapor
 
 struct AirQualityController: RouteCollection {
     func boot(routes: any RoutesBuilder) throws {
-        routes.grouped("api", "v1", "air-quality").get("current", use: current)
+        try registerOnAPIRoots(routes) { root in
+            root.grouped("v1", "air-quality").get("current", use: current)
+        }
     }
 
     func current(req: Request) async throws -> AirQualityCurrentResponse {

--- a/Sources/App/Controllers/AlertsController.swift
+++ b/Sources/App/Controllers/AlertsController.swift
@@ -32,8 +32,10 @@ private enum AlertLookupModeV2 {
 
 struct AlertsController: RouteCollection {
     func boot(routes: any RoutesBuilder) throws {
-        routes.grouped("api", "v1", "alerts").get(use: indexV1)
-        routes.grouped("api", "v2", "alerts").get(use: indexV2)
+        try registerOnAPIRoots(routes) { root in
+            root.grouped("v1", "alerts").get(use: indexV1)
+            root.grouped("v2", "alerts").get(use: indexV2)
+        }
     }
 
     func indexV1(req: Request) async throws -> Response {

--- a/Sources/App/Controllers/AnvilProfileAnalysisController.swift
+++ b/Sources/App/Controllers/AnvilProfileAnalysisController.swift
@@ -3,8 +3,9 @@ import Vapor
 
 struct AnvilProfileAnalysisController: RouteCollection {
     func boot(routes: any RoutesBuilder) throws {
-        let dev = routes.grouped("api", "v1", "dev", "anvil")
-        dev.get("profile-analysis", use: analyzeProfile)
+        try registerOnAPIRoots(routes) { root in
+            root.grouped("v1", "dev", "anvil").get("profile-analysis", use: analyzeProfile)
+        }
     }
 
     func analyzeProfile(req: Request) async throws -> Response {

--- a/Sources/App/Controllers/AnvilProfilePreviewController.swift
+++ b/Sources/App/Controllers/AnvilProfilePreviewController.swift
@@ -10,8 +10,9 @@ import Vapor
 
 struct AnvilProfilePreviewController: RouteCollection {
     func boot(routes: any RoutesBuilder) throws {
-        let dev = routes.grouped("api", "v1", "dev", "anvil")
-        dev.get("profile-preview", use: profilePreview)
+        try registerOnAPIRoots(routes) { root in
+            root.grouped("v1", "dev", "anvil").get("profile-preview", use: profilePreview)
+        }
     }
 
     func profilePreview(req: Request) async throws -> AnvilAnalyzeProfilePreviewResponse {

--- a/Sources/App/Controllers/DevController.swift
+++ b/Sources/App/Controllers/DevController.swift
@@ -10,8 +10,9 @@ import Vapor
 
 struct DevController: RouteCollection {
     func boot(routes: any RoutesBuilder) throws {
-        let dev = routes.grouped("api", "v1", "dev")
-        dev.post(use: index)
+        try registerOnAPIRoots(routes) { root in
+            root.grouped("v1", "dev").post(use: index)
+        }
     }
 
     func index(req: Request) async throws -> Response {

--- a/Sources/App/Controllers/DeviceController.swift
+++ b/Sources/App/Controllers/DeviceController.swift
@@ -22,10 +22,12 @@ private struct DevicePresenceCommitResult {
 
 struct DeviceController: RouteCollection {
     func boot(routes: any RoutesBuilder) throws {
-        let devices = routes.grouped("api", "v1", "devices")
-        devices.get(use: index)
-        devices.post("location-snapshots", use: create)
-        devices.post("preferences", use: createPreferences)
+        try registerOnAPIRoots(routes) { root in
+            let devices = root.grouped("v1", "devices")
+            devices.get(use: index)
+            devices.post("location-snapshots", use: create)
+            devices.post("preferences", use: createPreferences)
+        }
     }
     
     func create(req: Request) async throws -> LocationSnapshotAcceptedResponse {

--- a/Sources/App/Controllers/NotificationsController.swift
+++ b/Sources/App/Controllers/NotificationsController.swift
@@ -14,8 +14,9 @@ private struct NotificationLookupQuery: Content {
 
 struct NotificationsController: RouteCollection {
     func boot(routes: any RoutesBuilder) throws {
-        let notifications = routes.grouped("api", "v1", "notifications")
-        notifications.get(use: index)
+        try registerOnAPIRoots(routes) { root in
+            root.grouped("v1", "notifications").get(use: index)
+        }
     }
 
     func index(req: Request) async throws -> [NotificationLedgerModel] {

--- a/Sources/App/Controllers/StormSetupController.swift
+++ b/Sources/App/Controllers/StormSetupController.swift
@@ -11,8 +11,9 @@ import ArcusCore
 
 struct StormSetupController: RouteCollection {
     func boot(routes: any RoutesBuilder) throws {
-        let stormSetup = routes.grouped("api", "v1", "storm-setup")
-        stormSetup.get("current", use: current)
+        try registerOnAPIRoots(routes) { root in
+            root.grouped("v1", "storm-setup").get("current", use: current)
+        }
     }
 
     func current(req: Request) async throws -> StormSetupCurrentResponse {

--- a/Sources/App/apiRoutes.swift
+++ b/Sources/App/apiRoutes.swift
@@ -19,6 +19,16 @@ func configureAPIRoutes(_ app: Application) throws {
     try app.register(collection: AirQualityController())
 }
 
+/// Registers a route collection under both the canonical API root and the
+/// legacy `/api` root while clients migrate to the shorter URL scheme.
+func registerOnAPIRoots(
+    _ routes: any RoutesBuilder,
+    register: (any RoutesBuilder) throws -> Void
+) throws {
+    try register(routes)
+    try register(routes.grouped("api"))
+}
+
 public func normalizedOptional(_ value: String?) -> String? {
     guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
           !trimmed.isEmpty else {

--- a/Tests/AppTests/AlertsControllerTests.swift
+++ b/Tests/AppTests/AlertsControllerTests.swift
@@ -103,6 +103,22 @@ struct AlertsControllerTests {
         }
     }
 
+    @Test("GET /v2/alerts preserves the legacy response through the canonical route")
+    func canonicalTargetedLookupBySeriesUUID() async throws {
+        try await withApp { app in
+            let seriesID = UUID()
+            try await seedSeries(id: seriesID, on: app)
+
+            try await app.testing().test(.GET, "v2/alerts?id=\(seriesID.uuidString)", afterResponse: { res async throws in
+                #expect(res.status == .ok)
+
+                let payload = try res.content.decode([DecodedAlertPayload].self)
+                #expect(payload.count == 1)
+                #expect(payload.first?.id == seriesID)
+            })
+        }
+    }
+
     @Test("GET /api/v2/alerts rejects malformed targeted UUID")
     func targetedLookupRejectsMalformedUUID() async throws {
         try await withApp { app in

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -150,6 +150,32 @@ struct AppTests {
         }
     }
 
+    @Test("API route aliases register canonical and legacy paths exactly once")
+    func apiRouteAliasesRegisterCanonicalAndLegacyPaths() async throws {
+        try await withEnvironment(["ARCUS_DEBUG_ENDPOINTS_ENABLED": "true"]) {
+            try await withApp(mode: .api) { app in
+                let expectedRoutes = Set([
+                    "GET /v1/alerts", "GET /api/v1/alerts",
+                    "GET /v2/alerts", "GET /api/v2/alerts",
+                    "GET /v1/notifications", "GET /api/v1/notifications",
+                    "GET /v1/devices", "GET /api/v1/devices",
+                    "POST /v1/devices/location-snapshots", "POST /api/v1/devices/location-snapshots",
+                    "POST /v1/devices/preferences", "POST /api/v1/devices/preferences",
+                    "GET /v1/air-quality/current", "GET /api/v1/air-quality/current",
+                    "GET /v1/storm-setup/current", "GET /api/v1/storm-setup/current",
+                    "POST /v1/dev", "POST /api/v1/dev",
+                    "GET /v1/dev/anvil/profile-preview", "GET /api/v1/dev/anvil/profile-preview",
+                    "GET /v1/dev/anvil/profile-analysis", "GET /api/v1/dev/anvil/profile-analysis"
+                ])
+                let registeredRoutes = app.routes.all.map(\.description)
+                let matchingRoutes = registeredRoutes.filter(expectedRoutes.contains)
+
+                #expect(Set(matchingRoutes) == expectedRoutes)
+                #expect(matchingRoutes.count == expectedRoutes.count)
+            }
+        }
+    }
+
     private func productionBootstrapEnvironment(
         databaseURL: String? = "postgres://arcus:arcus@127.0.0.1:5432/arcus_signal?tlsmode=disable",
         redisURL: String? = "redis://127.0.0.1:6379"

--- a/docs/audits/weekly-bug-scan.md
+++ b/docs/audits/weekly-bug-scan.md
@@ -725,3 +725,73 @@
 - Implementation recommended: `yes`
 - GitHub issue creation: attempted but blocked by connector approval requirements; no issue created
 - Out-of-scope repositories intentionally not scanned: all sibling repositories
+
+## 2026-08-27
+
+### 1. Repository scanned
+- `arcus-signal`
+
+### 2. Commit window inspected
+- Reliable previous end marker: `563bdb0d3f63df49a67f7d8fb20bad287811288b` from the 2026-08-20 audit entry
+- Window used: commits after `563bdb0d3f63df49a67f7d8fb20bad287811288b` through `e957a454b2f1bcbd336abb66a162659cbc2a0a95`
+- Dates: `2026-08-26T12:08:09-06:00` through `2026-08-26T12:08:09-06:00`
+- Commit count: 1
+- Start and end commit: `e957a454b2f1bcbd336abb66a162659cbc2a0a95`
+- Fallback strategy: none; the bounded window contained one commit
+
+### 3. Files and high-risk areas inspected
+- Subprocess launch, output capture, timeout, cancellation, termination, and descriptor ownership (`Sources/App/StormSetup/GribAdapter.swift`, `Tests/AppTests/ProcessRunnerTests.swift`)
+- Stale notification-revision suppression at the final send boundary (`Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift`)
+- API collection scalar normalization (`arcus-signal.postman_collection/Arcus Signal API/.resources/definition.yaml`)
+- Living delivery and runtime contracts (`docs/architecture.md`)
+
+### 4. Findings
+- No new credible bug was found. New findings by confidence: `HIGH 0`, `MEDIUM 0`, `LOW 0`.
+
+### 5. Recurring, changed, and resolved findings
+- Recurring findings re-verified: none.
+- Changed findings: none.
+- The commit did not touch `BUG-SIGNAL-PRESSURE-PROBE-ENQUEUE-OVERWRITE` or `BUG-SIGNAL-PRESENCE-PREFERENCE-RECONCILIATION`; neither is repeated or reclassified.
+- The descriptor fix corresponds to earlier `BUG-SIGNAL-PROCESS-PIPE-FD-LEAK`, but its Linux-only runtime regression could not be independently executed here, so resolution is not newly asserted.
+
+### 6. Watchlist
+- None. No low-confidence concern had sufficient local evidence to retain.
+
+### 7. Top finding and best next fix
+- Top finding: none.
+- Best next fix: no fix recommended.
+- Implementation recommended: `no`; expected churn and regression risk are none.
+
+### 8. Validation
+- Static inspection covered the complete production diff and focused tests in commit `e957a454b2f1bcbd336abb66a162659cbc2a0a95`.
+- The commit records 10 passing `ProcessRunnerTests` and 9 passing `NotificationSendJobDeliveryBoundaryTests`.
+- A local `ProcessRunnerTests` attempt was blocked before manifest compilation because the managed sandbox denied SwiftPM's sandbox operation. No local pass is claimed.
+
+### 9. GitHub triage
+- GitHub issues created: none.
+- GitHub issues updated: none.
+- Existing issues referenced: none for a new finding.
+- No candidate met issue eligibility, so remote deduplication and mutation were unnecessary.
+
+### 10. Scope notes
+- Repository scanned: `arcus-signal` only.
+- Out-of-scope repositories: all sibling repositories and external clients were intentionally not scanned.
+- Skipped evidence: no cross-repository claims were evaluated or included.
+- Unrelated working-tree change preserved: `docs/Sql/Device.sql`.
+
+### 11. No fix recommended
+- The single bounded commit fixes subprocess descriptor ownership, adds focused regression coverage, and exposes no concrete correctness, reliability, privacy, notification, or severe-weather-awareness regression.
+
+### Audit entry (short)
+- Date: `2026-08-27`
+- Repository reviewed: `arcus-signal`
+- Workflow reviewed: weekly bug scan (audit-only, commits since the reliable previous end marker)
+- Commit window inspected: `e957a454b2f1bcbd336abb66a162659cbc2a0a95`; 1 commit
+- Files inspected: `Sources/App/StormSetup/GribAdapter.swift`, `Tests/AppTests/ProcessRunnerTests.swift`, `Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift`, `arcus-signal.postman_collection/Arcus Signal API/.resources/definition.yaml`, and `docs/architecture.md`
+- Top finding: no credible bug found
+- Best next fix: no fix recommended
+- Implementation recommended: `no`
+- GitHub issues created: none
+- GitHub issues updated: none
+- Existing issues referenced: none for a new finding
+- Out-of-scope repositories intentionally not scanned: all sibling repositories


### PR DESCRIPTION
# Summary

Adds the canonical API URL scheme without removing support for existing clients that use the legacy `/api` prefix.

# What Changed

- Added shared route registration for both canonical paths such as `/v1/...` and legacy `/api/v1/...` paths.
- Updated the air-quality, alerts, Anvil, development, device, notifications, and storm-setup controllers to register both route roots.
- Added coverage for canonical alert access and canonical/legacy route registration.
- Updated `Package.resolved` and recorded the weekly bug-scan audit changes.

# User Impact

Clients can use the shorter `/v1/...` API URLs while existing integrations using `/api/v1/...` continue to resolve.

# Testing

- The committed diff adds route-alias registration coverage and a canonical alerts-route test.
- No test execution evidence is recorded in the repository or in GitHub status checks for the head commit.

# Notes

- The branch contains the dependency lockfile refresh shown in the committed diff.
- Fixes #84